### PR TITLE
Fix for visual mode link creation

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1547,14 +1547,14 @@ function! s:normalize_link_syntax_v() " {{{
   let done = 0
 
   try
-    norm! gvy
+    norm! gv""y
     let visual_selection = @"
     let visual_selection = substitute(g:vimwiki_WikiLinkTemplate1, '__LinkUrl__', '\='."'".visual_selection."'", '')
 
     call setreg('"', visual_selection, 'v')
 
     " paste result
-    norm! `>pgvd
+    norm! `>""pgvd
 
   finally
     call setreg('"', rv, rt)


### PR DESCRIPTION
There's an open issue at https://github.com/vimwiki/vimwiki/issues/27 about not being able to create new links in visual mode, this I found happens when clipboard-unnamed and clipboard-unnamedplus options are set. 

The following patch fixes it.
