### PR TITLE
Add support for logical_newlines option to translate \n to <br> on HTML ...

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -976,7 +976,11 @@ function! s:process_tag_para(line, para) "{{{
       let para = 1
     endif
     let processed = 1
-    call add(lines, a:line)
+    if g:vimwiki_logical_newlines == 1
+      call add(lines, a:line."<br />")
+    else
+      call add(lines, a:line)
+    endif
   elseif para && a:line =~ '^\s*$'
     call add(lines, "</p>")
     let para = 0

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -399,6 +399,7 @@ call s:default('dir_link', '')
 call s:default('valid_html_tags', 'b,i,s,u,sub,sup,kbd,br,hr,div,center,strong,em')
 call s:default('user_htmls', '')
 call s:default('autowriteall', 1)
+call s:default('logical_newlines', 1)
 
 call s:default('html_header_numbering', 0)
 call s:default('html_header_numbering_sym', '')


### PR DESCRIPTION
This branch allows users to set a config option to translate newlines in wikis to newlines in the HTML output. The current version only implements the feature, it remains undocumented. I need to document it.
