### PR TITLE
html export: Let the user know where to find the output

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1561,6 +1561,7 @@ function! vimwiki#html#WikiAll2HTML(path_html) "{{{
   call VimwikiSet('invsubdir', current_invsubdir)
 
   call s:create_default_CSS(path_html)
+  echomsg 'HTML exported to '.path_html
   echomsg 'Done!'
 
   let &more = setting_more

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -255,9 +255,9 @@ command! -buffer Vimwiki2HTML
       \ let res = vimwiki#html#Wiki2HTML(expand(VimwikiGet('path_html')),
       \                             expand('%'))
       \<bar>
-      \ if res != '' | echo 'Vimwiki: HTML conversion is done.' | endif
+      \ if res != '' | echo 'Vimwiki: HTML conversion is done, output: '.expand(VimwikiGet('path_html')) | endif
 command! -buffer Vimwiki2HTMLBrowse
-      \ silent w <bar> 
+      \ silent w <bar>
       \ call vimwiki#base#system_open_link(vimwiki#html#Wiki2HTML(
       \         expand(VimwikiGet('path_html')),
       \         expand('%')))


### PR DESCRIPTION
This works both for :Vimwiki2HTML and :VimwikiAll2HTML.

Signed-off-by: Carl Helmertz chelmertz@op5.com
