### PR TITLE
Support escaped `> table cell values (selectively avoid spanning)

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1035,6 +1035,10 @@ function! s:process_tag_table(line, table, header_ids) "{{{
       let cell.body    = ''
       let cell.rowspan = 1
       let cell.colspan = 0
+    elseif a:value =~ '^\s*`&gt;\s*$'
+      let cell.body    = '&gt;'
+      let cell.rowspan = 1
+      let cell.colspan = 1
     elseif a:value =~ '^\s*$'
       let cell.body    = '&nbsp;'
       let cell.rowspan = 1


### PR DESCRIPTION
It should be possible to create table cells with `>` as their sole content, e.g.:

| VIM Shortcut | Description |
| --- | --- |
| > | Indent |

Currenty, `>` always leads to column spanning. With this patch, the spanning can be suppressed by escaping the value with a backtick:  <tt>`></tt>
