### PR TITLE
Checks if custom_wiki2html is executable on PATH

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1344,7 +1344,7 @@ endfunction " }}}
 
 function! s:use_custom_wiki2html() "{{{
   let custom_wiki2html = VimwikiGet('custom_wiki2html')
-  return !empty(custom_wiki2html) && s:file_exists(custom_wiki2html)
+  return !empty(custom_wiki2html) && (s:file_exists(custom_wiki2html) || s:binary_exists(custom_wiki2html))
 endfunction " }}}
 
 function! vimwiki#html#CustomWiki2HTML(path, wikifile, force) "{{{
@@ -1568,6 +1568,10 @@ endfunction "}}}
 
 function! s:file_exists(fname) "{{{
   return !empty(getftype(expand(a:fname)))
+endfunction "}}}
+
+function! s:binary_exists(fname) "{{{
+  return executable(expand(a:fname))
 endfunction "}}}
 
 " uses VimwikiGet('path')


### PR DESCRIPTION
Would it be possible to add this patch.  It checks if the custom_wiki2html is an executable on the system path (rather than just a script which exists on the filesystem).

The reason I ask is that I am in the process of creating a ruby gem which handles the conversion of vimwiki markdown (github flavoured) including syntax highlighting etc to HTML.  It's all working locally so I'll be pushing it to rubygems shortly.  Anyway, I couldn't call out to the binary until I had made the attached change.

Thanks for the great work - I love vimwikiw :+1: 
