### PR TITLE
Allow users to override <Leader>w prefix via config option

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2537,6 +2537,16 @@ mother tongue like this: >
 
 The default is 'Contents'.
 
+------------------------------------------------------------------------------
+*g:vimwiki_map_prefix*
+
+A string which specifies the prefix for all global mappings (and some local).
+Use it to avoid conflicts with other plugins.  Note that it must be defined
+before the plugin loads.  >
+  let g:vimwiki_map_prefix = '<Leader>e'
+
+The default is '<Leader>w'.
+
 
 ==============================================================================
 13. Miscellaneous                                               *vimwiki-misc*

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -324,13 +324,13 @@ endif
 
 
 if !hasmapto('<Plug>Vimwiki2HTML')
-  nmap <buffer> <Leader>wh <Plug>Vimwiki2HTML
+  exe 'nmap <buffer> '.g:vimwiki_map_prefix.'h <Plug>Vimwiki2HTML'
 endif
 nnoremap <script><buffer>
       \ <Plug>Vimwiki2HTML :Vimwiki2HTML<CR>
 
 if !hasmapto('<Plug>Vimwiki2HTMLBrowse')
-  nmap <buffer> <Leader>whh <Plug>Vimwiki2HTMLBrowse
+  exe 'nmap <buffer> '.g:vimwiki_map_prefix.'hh <Plug>Vimwiki2HTMLBrowse'
 endif
 nnoremap <script><buffer>
       \ <Plug>Vimwiki2HTMLBrowse :Vimwiki2HTMLBrowse<CR>
@@ -397,13 +397,13 @@ nnoremap <silent><script><buffer>
       \ <Plug>VimwikiPrevLink :VimwikiPrevLink<CR>
 
 if !hasmapto('<Plug>VimwikiDeleteLink')
-  nmap <silent><buffer> <Leader>wd <Plug>VimwikiDeleteLink
+  exe 'nmap <silent><buffer> '.g:vimwiki_map_prefix.'d <Plug>VimwikiDeleteLink'
 endif
 nnoremap <silent><script><buffer>
       \ <Plug>VimwikiDeleteLink :VimwikiDeleteLink<CR>
 
 if !hasmapto('<Plug>VimwikiRenameLink')
-  nmap <silent><buffer> <Leader>wr <Plug>VimwikiRenameLink
+  exe 'nmap <silent><buffer> '.g:vimwiki_map_prefix.'r <Plug>VimwikiRenameLink'
 endif
 nnoremap <silent><script><buffer>
       \ <Plug>VimwikiRenameLink :VimwikiRenameLink<CR>

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -418,6 +418,7 @@ call s:default('diary_months',
       \ 10: 'October', 11: 'November', 12: 'December'
       \ })
 
+call s:default('map_prefix', '<Leader>w')
 
 call s:default('current_idx', 0)
 
@@ -489,37 +490,37 @@ command! VimwikiDiaryGenerateLinks
 
 " MAPPINGS {{{
 if !hasmapto('<Plug>VimwikiIndex')
-  nmap <silent><unique> <Leader>ww <Plug>VimwikiIndex
+  exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'w <Plug>VimwikiIndex'
 endif
 nnoremap <unique><script> <Plug>VimwikiIndex :VimwikiIndex<CR>
 
 if !hasmapto('<Plug>VimwikiTabIndex')
-  nmap <silent><unique> <Leader>wt <Plug>VimwikiTabIndex
+  exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'t <Plug>VimwikiTabIndex'
 endif
 nnoremap <unique><script> <Plug>VimwikiTabIndex :VimwikiTabIndex<CR>
 
 if !hasmapto('<Plug>VimwikiUISelect')
-  nmap <silent><unique> <Leader>ws <Plug>VimwikiUISelect
+  exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'s <Plug>VimwikiUISelect'
 endif
 nnoremap <unique><script> <Plug>VimwikiUISelect :VimwikiUISelect<CR>
 
 if !hasmapto('<Plug>VimwikiDiaryIndex')
-  nmap <silent><unique> <Leader>wi <Plug>VimwikiDiaryIndex
+  exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'i <Plug>VimwikiDiaryIndex'
 endif
 nnoremap <unique><script> <Plug>VimwikiDiaryIndex :VimwikiDiaryIndex<CR>
 
 if !hasmapto('<Plug>VimwikiDiaryGenerateLinks')
-  nmap <silent><unique> <Leader>w<Leader>i <Plug>VimwikiDiaryGenerateLinks
+  exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'<Leader>i <Plug>VimwikiDiaryGenerateLinks'
 endif
 nnoremap <unique><script> <Plug>VimwikiDiaryGenerateLinks :VimwikiDiaryGenerateLinks<CR>
 
 if !hasmapto('<Plug>VimwikiMakeDiaryNote')
-  nmap <silent><unique> <Leader>w<Leader>w <Plug>VimwikiMakeDiaryNote
+  exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'<Leader>w <Plug>VimwikiMakeDiaryNote'
 endif
 nnoremap <unique><script> <Plug>VimwikiMakeDiaryNote :VimwikiMakeDiaryNote<CR>
 
 if !hasmapto('<Plug>VimwikiTabMakeDiaryNote')
-  nmap <silent><unique> <Leader>w<Leader>t <Plug>VimwikiTabMakeDiaryNote
+  exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'<Leader>t <Plug>VimwikiTabMakeDiaryNote'
 endif
 nnoremap <unique><script> <Plug>VimwikiTabMakeDiaryNote
       \ :VimwikiTabMakeDiaryNote<CR>


### PR DESCRIPTION
I have a lot of other stuff mapped with `<Leader>w` prefix, so I thought this might be helpful to allow a global config option to override this with one line (instead of re-mapping all mappings explicitly in my vimrc).
