### PR TITLE
Use shiftwidth() instead of &shiftwidth

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1725,7 +1725,7 @@ function! vimwiki#base#table_of_contents(create)
         \ '__Header__', '\='."'".g:vimwiki_toc_header."'", ''))
 
   let startindent = repeat(' ', vimwiki#lst#get_list_margin())
-  let indentstring = repeat(' ', shiftwidth())
+  let indentstring = repeat(' ', vimwiki#u#sw())
   for [lvl, link, desc] in headers
     let esc_link = substitute(link, "'", "''", 'g')
     let esc_desc = substitute(desc, "'", "''", 'g')

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1725,7 +1725,7 @@ function! vimwiki#base#table_of_contents(create)
         \ '__Header__', '\='."'".g:vimwiki_toc_header."'", ''))
 
   let startindent = repeat(' ', vimwiki#lst#get_list_margin())
-  let indentstring = repeat(' ', &shiftwidth)
+  let indentstring = repeat(' ', shiftwidth())
   for [lvl, link, desc] in headers
     let esc_link = substitute(link, "'", "''", 'g')
     let esc_desc = substitute(desc, "'", "''", 'g')

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -932,9 +932,9 @@ function! s:decrease_level(item) "{{{
   else
     let old_indent = indent(a:item.lnum)
     if &shiftround
-      let new_indent = (old_indent - 1) / shiftwidth() * shiftwidth()
+      let new_indent = (old_indent - 1) / vimwiki#u#sw() * vimwiki#u#sw()
     else
-      let new_indent = old_indent - shiftwidth()
+      let new_indent = old_indent - vimwiki#u#sw()
     endif
     call s:set_indent(a:item.lnum, new_indent)
     let removed_indent = new_indent - old_indent
@@ -952,9 +952,9 @@ function! s:increase_level(item) "{{{
   else
     let old_indent = indent(a:item.lnum)
     if &shiftround
-      let new_indent = (old_indent / shiftwidth() + 1) * shiftwidth()
+      let new_indent = (old_indent / vimwiki#u#sw() + 1) * vimwiki#u#sw()
     else
-      let new_indent = old_indent + shiftwidth()
+      let new_indent = old_indent + vimwiki#u#sw()
     endif
     call s:set_indent(a:item.lnum, new_indent)
     let additional_indent = new_indent - old_indent

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -932,9 +932,9 @@ function! s:decrease_level(item) "{{{
   else
     let old_indent = indent(a:item.lnum)
     if &shiftround
-      let new_indent = (old_indent - 1) / &shiftwidth * &shiftwidth
+      let new_indent = (old_indent - 1) / shiftwidth() * shiftwidth()
     else
-      let new_indent = old_indent - &shiftwidth
+      let new_indent = old_indent - shiftwidth()
     endif
     call s:set_indent(a:item.lnum, new_indent)
     let removed_indent = new_indent - old_indent
@@ -952,9 +952,9 @@ function! s:increase_level(item) "{{{
   else
     let old_indent = indent(a:item.lnum)
     if &shiftround
-      let new_indent = (old_indent / &shiftwidth + 1) * &shiftwidth
+      let new_indent = (old_indent / shiftwidth() + 1) * shiftwidth()
     else
-      let new_indent = old_indent + &shiftwidth
+      let new_indent = old_indent + shiftwidth()
     endif
     call s:set_indent(a:item.lnum, new_indent)
     let additional_indent = new_indent - old_indent

--- a/autoload/vimwiki/u.vim
+++ b/autoload/vimwiki/u.vim
@@ -52,3 +52,14 @@ endfunction "}}}
 function vimwiki#u#reload_regexes_custom() "{{{
   execute 'runtime! syntax/vimwiki_'.VimwikiGet('syntax').'_custom.vim'
 endfunction "}}}
+
+" Backward compatible version of the built-in function shiftwidth()
+if exists('*shiftwidth') "{{{
+  func vimwiki#u#sw()
+    return shiftwidth()
+  endfunc
+else
+  func vimwiki#u#sw()
+    return &sw
+  endfunc
+endif "}}}


### PR DESCRIPTION
Using &shiftwidth makes VimwikiListChangeLvl misbehave when this option is set
to 0, which is a default configuration of [DetectIndent](https://github.com/roryokane/detectindent).