### PR TITLE
autoload/vimwiki/base.vim was sourced at vim startup

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -8,6 +8,23 @@ if exists("g:loaded_vimwiki_auto") || &cp
 endif
 let g:loaded_vimwiki_auto = 1
 
+" s:vimwiki_get_known_syntaxes
+function! s:vimwiki_get_known_syntaxes() " {{{
+  " Getting all syntaxes that different wikis could have
+  let syntaxes = {}
+  let syntaxes['default'] = 1
+  for wiki in g:vimwiki_list
+    if has_key(wiki, 'syntax')
+      let syntaxes[wiki.syntax] = 1
+    endif
+  endfor
+  " append map g:vimwiki_ext2syntax
+  for syn in values(g:vimwiki_ext2syntax)
+    let syntaxes[syn] = 1
+  endfor
+  return keys(syntaxes)
+endfunction " }}}
+
 " vimwiki#base#apply_wiki_options
 function! vimwiki#base#apply_wiki_options(options) " {{{ Update the current
   " wiki using the options dictionary
@@ -1905,7 +1922,7 @@ endfunction " }}}
 
 " -------------------------------------------------------------------------
 " Load syntax-specific Wiki functionality
-for s:syn in VimwikiGetKnownSyntaxes()
+for s:syn in s:vimwiki_get_known_syntaxes()
   execute 'runtime! autoload/vimwiki/'.s:syn.'_base.vim'
 endfor 
 " -------------------------------------------------------------------------

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -8,42 +8,6 @@ if exists("g:loaded_vimwiki_auto") || &cp
 endif
 let g:loaded_vimwiki_auto = 1
 
-" MISC helper functions {{{
-
-function! vimwiki#base#get_known_extensions() " {{{
-  " Getting all extensions that different wikis could have
-  let extensions = {}
-  for wiki in g:vimwiki_list
-    if has_key(wiki, 'ext')
-      let extensions[wiki.ext] = 1
-    else
-      let extensions['.wiki'] = 1
-    endif
-  endfor
-  " append map g:vimwiki_ext2syntax
-  for ext in keys(g:vimwiki_ext2syntax)
-    let extensions[ext] = 1
-  endfor
-  return keys(extensions)
-endfunction " }}}
-
-function! vimwiki#base#get_known_syntaxes() " {{{
-  " Getting all syntaxes that different wikis could have
-  let syntaxes = {}
-  let syntaxes['default'] = 1
-  for wiki in g:vimwiki_list
-    if has_key(wiki, 'syntax')
-      let syntaxes[wiki.syntax] = 1
-    endif
-  endfor
-  " append map g:vimwiki_ext2syntax
-  for syn in values(g:vimwiki_ext2syntax)
-    let syntaxes[syn] = 1
-  endfor
-  return keys(syntaxes)
-endfunction " }}}
-" }}}
-
 " vimwiki#base#apply_wiki_options
 function! vimwiki#base#apply_wiki_options(options) " {{{ Update the current
   " wiki using the options dictionary
@@ -1941,7 +1905,7 @@ endfunction " }}}
 
 " -------------------------------------------------------------------------
 " Load syntax-specific Wiki functionality
-for s:syn in vimwiki#base#get_known_syntaxes()
+for s:syn in VimwikiGetKnownSyntaxes()
   execute 'runtime! autoload/vimwiki/'.s:syn.'_base.vim'
 endfor 
 " -------------------------------------------------------------------------

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -374,22 +374,6 @@ function! VimwikiGetKnownExtensions() " {{{
   return keys(extensions)
 endfunction " }}}
 
-function! VimwikiGetKnownSyntaxes() " {{{
-  " Getting all syntaxes that different wikis could have
-  let syntaxes = {}
-  let syntaxes['default'] = 1
-  for wiki in g:vimwiki_list
-    if has_key(wiki, 'syntax')
-      let syntaxes[wiki.syntax] = 1
-    endif
-  endfor
-  " append map g:vimwiki_ext2syntax
-  for syn in values(g:vimwiki_ext2syntax)
-    let syntaxes[syn] = 1
-  endfor
-  return keys(syntaxes)
-endfunction " }}}
-
 " }}}
 
 " CALLBACK functions "{{{

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -357,6 +357,39 @@ function! VimwikiClear(option, ...) "{{{
 endfunction "}}}
 " }}}
 
+function! VimwikiGetKnownExtensions() " {{{
+  " Getting all extensions that different wikis could have
+  let extensions = {}
+  for wiki in g:vimwiki_list
+    if has_key(wiki, 'ext')
+      let extensions[wiki.ext] = 1
+    else
+      let extensions['.wiki'] = 1
+    endif
+  endfor
+  " append map g:vimwiki_ext2syntax
+  for ext in keys(g:vimwiki_ext2syntax)
+    let extensions[ext] = 1
+  endfor
+  return keys(extensions)
+endfunction " }}}
+
+function! VimwikiGetKnownSyntaxes() " {{{
+  " Getting all syntaxes that different wikis could have
+  let syntaxes = {}
+  let syntaxes['default'] = 1
+  for wiki in g:vimwiki_list
+    if has_key(wiki, 'syntax')
+      let syntaxes[wiki.syntax] = 1
+    endif
+  endfor
+  " append map g:vimwiki_ext2syntax
+  for syn in values(g:vimwiki_ext2syntax)
+    let syntaxes[syn] = 1
+  endfor
+  return keys(syntaxes)
+endfunction " }}}
+
 " }}}
 
 " CALLBACK functions "{{{
@@ -486,7 +519,7 @@ augroup end
 
 augroup vimwiki
   autocmd!
-  for s:ext in vimwiki#base#get_known_extensions()
+  for s:ext in VimwikiGetKnownExtensions()
     exe 'autocmd BufEnter *'.s:ext.' call s:setup_buffer_reenter()'
     exe 'autocmd BufWinEnter *'.s:ext.' call s:setup_buffer_enter()'
     exe 'autocmd BufLeave,BufHidden *'.s:ext.' call s:setup_buffer_leave()'

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -357,7 +357,7 @@ function! VimwikiClear(option, ...) "{{{
 endfunction "}}}
 " }}}
 
-function! VimwikiGetKnownExtensions() " {{{
+function! s:vimwiki_get_known_extensions() " {{{
   " Getting all extensions that different wikis could have
   let extensions = {}
   for wiki in g:vimwiki_list
@@ -503,7 +503,7 @@ augroup end
 
 augroup vimwiki
   autocmd!
-  for s:ext in VimwikiGetKnownExtensions()
+  for s:ext in s:vimwiki_get_known_extensions()
     exe 'autocmd BufEnter *'.s:ext.' call s:setup_buffer_reenter()'
     exe 'autocmd BufWinEnter *'.s:ext.' call s:setup_buffer_enter()'
     exe 'autocmd BufLeave,BufHidden *'.s:ext.' call s:setup_buffer_leave()'


### PR DESCRIPTION
`plugin/vimwiki.vim` was calling a function from `autoload/../base.vim`.  Thus causing the autoload file be loaded at each and every startup, thus defeating the entire idea of that file ("if it's always loaded, why do we need it anyway").