### PR TITLE
Bold anchors were duplicated in get_anchors() results

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -651,7 +651,7 @@ function! vimwiki#base#get_anchors(filename, syntax) "{{{
     endif
 
     " collect bold text (there can be several in one line)
-    let bold_count = 0
+    let bold_count = 1
     while 1
       let bold_text = matchstr(line, rxbold, 0, bold_count)
       if bold_text == ''


### PR DESCRIPTION
Open new wiki page, add bold text in (e.g. `*bold*`), and issue:
```
:echo vimwiki#base#get_anchors(@%, 'default')
```

You'll see that `bold` is returned twice.  Apparently it's because `matchstr()` expects that `{count}` argument starts numbering at 1 not at 0 (vim docs say nothing about this, but experiments kind of proved it).

So I've fixed the `vimwiki#base#get_anchors()` to account for it.

(PS: Ubuntu, Vim 7.4)