### PR TITLE
change option 'toc_header' from global to local wiki setting

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1613,7 +1613,7 @@ function! vimwiki#base#table_of_contents(create)
 
   " look for existing TOC
   let toc_header = '^\s*'.substitute(g:vimwiki_rxH1_Template, '__Header__',
-        \ '\='."'".g:vimwiki_toc_header."'", '').'\s*$'
+        \ '\='."'".VimwikiGet('toc_header')."'", '').'\s*$'
   let toc_line = 0
   let lnum = 1
   while lnum <= &modelines + 2 && lnum <= line('$')
@@ -1678,7 +1678,7 @@ function! vimwiki#base#table_of_contents(create)
 
   " write new TOC
   call append(toc_line-1, whitespaces . substitute(g:vimwiki_rxH1_Template,
-        \ '__Header__', '\='."'".g:vimwiki_toc_header."'", ''))
+        \ '__Header__', '\='."'".VimwikiGet('toc_header')."'", ''))
 
   let startindent = repeat(' ', vimwiki#lst#get_list_margin())
   let indentstring = repeat(' ', vimwiki#u#sw())

--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -993,7 +993,7 @@ function! s:process_tag_h(line, id) "{{{
     let h_id = s:safe_html_anchor(h_text)
     let centered = (a:line =~# '^\s')
 
-    if h_text !=# g:vimwiki_toc_header
+    if h_text !=# VimwikiGet('toc_header')
 
       let a:id[h_level-1] = [h_text, a:id[h_level-1][1]+1]
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1629,8 +1629,8 @@ If you don't want the TOC to sit in the very first line, e.g. because you have
 a modeline there, put the magic header in the second or third line and run
 :VimwikiTOC to update the TOC.
 
-If your language is not english, set the option |g:vimwiki_toc_header| to your
-favorite translation.
+If your language is not english, set the option |vimwiki-option-toc_header| to
+your favorite translation.
 
 If you want to keep the TOC up to date automatically, use the option
 |vimwiki-option-auto_toc|.
@@ -1773,6 +1773,17 @@ Description~
 Set this option to 1 to automatically update the table of contents when the
 current wiki page is saved: >
   let g:vimwiki_list = [{'path': '~/my_site/', 'auto_toc': 1}]
+
+
+*vimwiki-option-toc_header*
+------------------------------------------------------------------------------
+
+A string with the magic header that tells vimwiki where the Table of Contents
+is located in the file. You can change it to the appropriate word in your
+mother tongue like this: >
+  let g:vimwiki_list = [{'path': '~/my_site/', 'toc_header': 'Index'}]
+
+The default is 'Contents'.
 
 
 *vimwiki-option-index*
@@ -2573,16 +2584,6 @@ let g:vimwiki_diary_months = {
       \ }
 
 ------------------------------------------------------------------------------
-*g:vimwiki_toc_header*
-
-A string with the magic header that tells vimwiki where the Table of Contents
-is located in the file. You can change it to the appropriate word in your
-mother tongue like this: >
-  let g:vimwiki_toc_header = 'Inhalt'
-
-The default is 'Contents'.
-
-------------------------------------------------------------------------------
 *g:vimwiki_map_prefix*
 
 A string which specifies the prefix for all global mappings (and some local).
@@ -2657,7 +2658,7 @@ Vim plugins: http://www.vim.org/scripts/script.php?script_id=2226
         * the function base#resolve_scheme() now also returns the anchor
           (important for custom VimwikiLinkHandlers)
         * new local option |vimwiki-option-auto_toc|
-        * new global option |g:vimwiki_toc_header|
+        * new local option |vimwiki-option-toc_header|
     * List editing capabilities, see |vimwiki-lists|:
         * support for auto incrementing numbered lists
         * more key maps for list manipulation, see |vimwiki-list-manipulation|

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -388,6 +388,7 @@ let s:vimwiki_defaults.index = 'index'
 let s:vimwiki_defaults.ext = '.wiki'
 let s:vimwiki_defaults.maxhi = 0
 let s:vimwiki_defaults.syntax = 'default'
+let s:vimwiki_defaults.toc_header = 'Contents'
 
 let s:vimwiki_defaults.template_path = '~/vimwiki/templates/'
 let s:vimwiki_defaults.template_default = 'default'
@@ -436,7 +437,6 @@ call s:default('dir_link', '')
 call s:default('valid_html_tags', 'b,i,s,u,sub,sup,kbd,br,hr,div,center,strong,em')
 call s:default('user_htmls', '')
 call s:default('autowriteall', 1)
-call s:default('toc_header', 'Contents')
 
 call s:default('html_header_numbering', 0)
 call s:default('html_header_numbering_sym', '')


### PR DESCRIPTION
Hi there,

I just made some small modifications to change option 'toc_header' from global to local wiki setting.
I requested this in issue #127.