### PR TITLE
Add command for opening yesterday's diary

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -198,6 +198,24 @@ See also |:VimwikiMakeDiaryNote|
 See also |:VimwikiTabMakeDiaryNote|
 
 
+[count]<Leader>w<Leader>y or <Plug>VimwikiMakeYesterdayDiaryNote
+        Open diary wiki-file for yesterday of the [count]'s wiki.
+
+        <Leader>w<Leader>y opens diary wiki-file for yesterday in the first
+        wiki from |g:vimwiki_list|.
+        1<Leader>w<Leader>y as above opens diary wiki-file for yesterday in
+        the first wiki from |g:vimwiki_list|.
+        2<Leader>w<Leader>y opens diary wiki-file for yesterday in the second
+        wiki from |g:vimwiki_list|.
+        3<Leader>w<Leader>y opens diary wiki-file for yesterday in the third
+        wiki from |g:vimwiki_list|.
+        etc.
+        To remap: >
+        :nmap <Leader>dy <Plug>VimwikiMakeYesterdayDiaryNote
+<
+See also |:VimwikiMakeYesterdayDiaryNote|
+
+
 ------------------------------------------------------------------------------
 3.2. Local mappings
 
@@ -566,6 +584,9 @@ il                      A single list item.
 
 *:VimwikiTabMakeDiaryNote*
     Open diary wiki-file for today of the current wiki in a new tab.
+
+*:VimwikiMakeYesterdayDiaryNote*
+    Open diary wiki-file for yesterday of the current wiki.
 
 
 ------------------------------------------------------------------------------

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -523,6 +523,8 @@ command! -count=1 VimwikiMakeDiaryNote
       \ call vimwiki#diary#make_note(v:count1)
 command! -count=1 VimwikiTabMakeDiaryNote
       \ call vimwiki#diary#make_note(v:count1, 1)
+command! -count=1 VimwikiMakeYesterdayDiaryNote
+      \ call vimwiki#diary#make_note(v:count1, 0, strftime(VimwikiGet('diary_link_fmt', v:count1 - 1), localtime() - 60*60*24))
 
 command! VimwikiDiaryGenerateLinks
       \ call vimwiki#diary#generate_diary_section()
@@ -564,6 +566,12 @@ if !hasmapto('<Plug>VimwikiTabMakeDiaryNote')
 endif
 nnoremap <unique><script> <Plug>VimwikiTabMakeDiaryNote
       \ :VimwikiTabMakeDiaryNote<CR>
+
+if !hasmapto('<Plug>VimwikiMakeYesterdayDiaryNote')
+  exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'<Leader>y <Plug>VimwikiMakeYesterdayDiaryNote'
+endif
+nnoremap <unique><script> <Plug>VimwikiMakeYesterdayDiaryNote
+      \ :VimwikiMakeYesterdayDiaryNote<CR>
 
 "}}}
 


### PR DESCRIPTION
I frequently stay up past midnight, and so when I bother to mark down today's
progress, the date I need to write in diary on is technically yesterday.
There was no quick way to open yesterday's page (VimwikiDiaryPrevDay doesn't
work if yesterday's entry was never created), so I've patched a command.

I think it might prove useful for anyone in the same situation.