### PR TITLE
follow url silently in mac

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -380,7 +380,7 @@ function! vimwiki#base#system_open_link(url) "{{{
     execute 'silent ! start "Title" /B ' . url
   endfunction
   function! s:macunix_handler(url)
-    execute '!open ' . shellescape(a:url, 1)
+    call system('open ' . shellescape(a:url).' &')
   endfunction
   function! s:linux_handler(url)
     call system('xdg-open ' . shellescape(a:url).' &')


### PR DESCRIPTION
Every time follow a link in browser will print `Press ENTER or type command to continue`, this PR will avoid this.