### PR TITLE
Bugfix/cursor moves on toc update

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1175,6 +1175,8 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
     let whitespaces_in_first_line = ''
   endif
 
+  let start_of_listing = start_lnum
+
   " write new listing
   let new_header = whitespaces_in_first_line
         \ . substitute(g:vimwiki_rxH1_Template,
@@ -1193,9 +1195,9 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
   endif
 
   " Open fold, if needed
-  if !is_fold_closed
-    exe start_lnum
-    norm zo
+  if !is_fold_closed && foldclosed(start_of_listing)
+    exe start_of_listing
+    norm! zo
   endif
 
   if is_cursor_after_listing

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1147,9 +1147,12 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
   let cursor_line = old_cursor_pos[1]
   let is_cursor_after_listing = 0
 
+  let is_fold_closed = 1
+
   let lines_diff = 0
 
   if already_there
+    let is_fold_closed = ( foldclosed(start_lnum) > 1 )
     " delete the old listing
     let whitespaces_in_first_line = matchstr(getline(start_lnum), '\m^\s*')
     let end_lnum = start_lnum + 1
@@ -1187,6 +1190,12 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
   if start_lnum <= line('$') && getline(start_lnum) !~# '\m^\s*$'
     call append(start_lnum - 1, '')
     let lines_diff += 1
+  endif
+
+  " Open fold, if needed
+  if !is_fold_closed
+    exe start_lnum
+    norm zo
   endif
 
   if is_cursor_after_listing

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1152,7 +1152,7 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
   let lines_diff = 0
 
   if already_there
-    let is_fold_closed = ( foldclosed(start_lnum) > 1 )
+    let is_fold_closed = ( foldclosed(start_lnum) > -1 )
     " delete the old listing
     let whitespaces_in_first_line = matchstr(getline(start_lnum), '\m^\s*')
     let end_lnum = start_lnum + 1
@@ -1195,7 +1195,7 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
   endif
 
   " Open fold, if needed
-  if !is_fold_closed && foldclosed(start_of_listing)
+  if !is_fold_closed && ( foldclosed(start_of_listing) > -1 )
     exe start_of_listing
     norm! zo
   endif

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1143,8 +1143,8 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
     return
   endif
 
-  let old_cursor_pos = getpos('.')
-  let cursor_line = old_cursor_pos[1]
+  let winview_save = winsaveview()
+  let cursor_line = winview_save.lnum
   let is_cursor_after_listing = 0
 
   let is_fold_closed = 1
@@ -1199,9 +1199,9 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
   endif
 
   if is_cursor_after_listing
-    let old_cursor_pos[1] += lines_diff
+    let winview_save.lnum += lines_diff
   endif
-  call setpos('.', old_cursor_pos)
+  call winrestview(winview_save)
 endfunction "}}}
 
 " WIKI link following functions {{{


### PR DESCRIPTION
I'm frequently using pages with TOC, and I have folds enabled.

With this environment, I've noticed the following:
* cursor moves when you save page right after you add/remove headers (which changes size of TOC section)
* TOC section fold is always closed after save -- even if it was open right before
* screen sometimes scrolls (esp. if you sit within large fold when you save)

This pull request will fix these three issues.