### PR TITLE
support global variable g:vimwiki_nested_syntaxes

### DIFF
--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -588,6 +588,9 @@ let b:current_syntax="vimwiki"
 
 " EMBEDDED syntax setup "{{{
 let s:nested = VimwikiGet('nested_syntaxes')
+if empty(s:nested) && exists('g:vimwiki_nested_syntaxes')
+  let s:nested = g:vimwiki_nested_syntaxes
+endif
 if !empty(s:nested)
   for [s:hl_syntax, s:vim_syntax] in items(s:nested)
     call vimwiki#base#nested_syntax(s:vim_syntax,


### PR DESCRIPTION
vimwiki is perfect and I prefer to use it with all markdown files.
I'd like to add a global nested syntaxes setting for markdown files outside the wiki path. 
or is there any solution already?

thanks.