### PR TITLE
fix #64: markdown style link support

### DIFF
--- a/autoload/vimwiki/markdown_base.vim
+++ b/autoload/vimwiki/markdown_base.vim
@@ -108,6 +108,8 @@ function! vimwiki#markdown_base#follow_link(split, ...) "{{{ Parse link at curso
     if lnk != ""
       if !VimwikiLinkHandler(lnk)
         if !vimwiki#markdown_base#open_reflink(lnk)
+          " remove the extension from the filename if exists
+          let lnk = substitute(lnk, VimwikiGet('ext').'$', '', '')
           call vimwiki#base#open_link(cmd, lnk)
         endif
       endif
@@ -173,7 +175,7 @@ function! s:normalize_link_syntax_n() " {{{
   if !empty(lnk)
     let sub = vimwiki#base#normalize_link_helper(lnk,
           \ g:vimwiki_rxWord, '',
-          \ g:vimwiki_WikiLinkTemplate1)
+          \ g:vimwiki_Weblink1Template)
     call vimwiki#base#replacestr_at_cursor('\V'.lnk, sub)
     return
   endif
@@ -192,9 +194,10 @@ function! s:normalize_link_syntax_v() " {{{
   try
     norm! gvy
     let visual_selection = @"
-    let visual_selection = substitute(g:vimwiki_WikiLinkTemplate1, '__LinkUrl__', '\='."'".visual_selection."'", '')
+    let link = substitute(g:vimwiki_Weblink1Template, '__LinkUrl__', '\='."'".visual_selection."'", '')
+    let link = substitute(link, '__LinkDescription__', '\='."''", '')
 
-    call setreg('"', visual_selection, 'v')
+    call setreg('"', link, 'v')
 
     " paste result
     norm! `>pgvd

--- a/autoload/vimwiki/markdown_base.vim
+++ b/autoload/vimwiki/markdown_base.vim
@@ -195,7 +195,7 @@ function! s:normalize_link_syntax_v() " {{{
     norm! gvy
     let visual_selection = @"
     let link = substitute(g:vimwiki_Weblink1Template, '__LinkUrl__', '\='."'".visual_selection."'", '')
-    let link = substitute(link, '__LinkDescription__', '\='."''", '')
+    let link = substitute(link, '__LinkDescription__', '\='."'".visual_selection."'", '')
 
     call setreg('"', link, 'v')
 


### PR DESCRIPTION
Now, when normalize a link in markdown syntax, it will get:

```
[some link text](some link text)
[](visual selection text)
```

And the following three links will work( `.md` is the extension specified by `wiki.ext` in the configuration.

```
[[link]]
[link](link)
[link](link.md)
```