### PR TITLE
Dynamically detect nested syntaxes (fix #128)

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1926,6 +1926,18 @@ function! vimwiki#base#normalize_link(is_visual_mode) "{{{
   endif
 endfunction "}}}
 
+" vimwiki#base#detect_nested_syntax
+function! vimwiki#base#detect_nested_syntax() "{{{
+  let last_word = '\v.*<(\w+)\s*$'
+  let lines = map(filter(getline(1, "$"), 'v:val =~ "{{{" && v:val =~ last_word'), 
+        \ 'substitute(v:val, last_word, "\\=submatch(1)", "")')
+  let dict = {}
+  for elem in lines
+    exe "let dict.".elem." = elem"
+  endfor
+  return dict
+endfunction "}}}
+
 " }}}
 
 " Command completion functions {{{

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1940,6 +1940,20 @@ or in: >
  }}}
 
 
+*vimwiki-option-automatic_nested_syntaxes*
+------------------------------------------------------------------------------
+Key                       Default value~
+automatic_nested_syntaxes 1            
+
+Description~
+Allows for smaller |vimwiki-option-nested_syntaxes| dictionaries, by turning
+entry for python on the previous example unnecessary: >
+  let wiki.nested_syntaxes = {'python': 'python', 'c++': 'cpp'}
+
+It requires that the file is reloaded (|:edit|) after new |filetype| is
+included in a file.
+
+
 *vimwiki-option-diary_rel_path*
 ------------------------------------------------------------------------------
 Key             Default value~

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -390,6 +390,7 @@ let s:vimwiki_defaults.template_default = ''
 let s:vimwiki_defaults.template_ext = ''
 
 let s:vimwiki_defaults.nested_syntaxes = {}
+let s:vimwiki_defaults.automatic_nested_syntaxes = 1
 let s:vimwiki_defaults.auto_export = 0
 let s:vimwiki_defaults.auto_toc = 0
 " is wiki temporary -- was added to g:vimwiki_list by opening arbitrary wiki

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -600,7 +600,7 @@ call vimwiki#u#reload_regexes_custom()
 let b:current_syntax="vimwiki"
 
 " EMBEDDED syntax setup "{{{
-let s:nested = VimwikiGet('nested_syntaxes')
+let s:nested = extend(VimwikiGet('nested_syntaxes'), vimwiki#base#detect_nested_syntax())
 if !empty(s:nested)
   for [s:hl_syntax, s:vim_syntax] in items(s:nested)
     call vimwiki#base#nested_syntax(s:vim_syntax,

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -600,7 +600,10 @@ call vimwiki#u#reload_regexes_custom()
 let b:current_syntax="vimwiki"
 
 " EMBEDDED syntax setup "{{{
-let s:nested = extend(VimwikiGet('nested_syntaxes'), vimwiki#base#detect_nested_syntax())
+let s:nested = VimwikiGet('nested_syntaxes')
+if VimwikiGet('automatic_nested_syntaxes')
+  let s:nested = extend(s:nested, vimwiki#base#detect_nested_syntax())
+endif
 if !empty(s:nested)
   for [s:hl_syntax, s:vim_syntax] in items(s:nested)
     call vimwiki#base#nested_syntax(s:vim_syntax,


### PR DESCRIPTION
I'm probably missing something on the discussion for #128, but this change doesn't seems inefficient. Maybe it could be disabled for files beyond a certain size, but I think it can be very useful (reducing 80% of my `wiki.nested_syntaxes` entries).