### PR TITLE
Escape tilde (~) in path names otherwise regex comparison gets upset

### DIFF
--- a/autoload/vimwiki/u.vim
+++ b/autoload/vimwiki/u.vim
@@ -38,7 +38,7 @@ function! vimwiki#u#count_first_sym(line) "{{{
 endfunction "}}}
 
 function! vimwiki#u#escape(string) "{{{
-  return escape(a:string, '.*[]\^$')
+  return escape(a:string, '~.*[]\^$')
 endfunction "}}}
 
 " Load concrete Wiki syntax: sets regexes and templates for headers and links


### PR DESCRIPTION
I was running into errors in vimwiki#base#is_diary_file() when comparing file paths with the diary path.  The regex comparison was bombing with error:

> Error detected while processing function vimwiki#base#normalize_link.. \<SNR\>90_normalize_link_syntax_v..\<SNR\>90_is_diary_file:
> line 4:
> E33: No previous substitute regular expression
> E33: No previous substitute regular expression
> Error detected while processing function vimwiki#base#normalize_link: 
> line 9:
> E171: Missing :endif

I checked the rel_path, file_path and diary_path variables.  I noticed that the diary_path was using ~/vimwiki/diary and traced it back to vimwiki#u#escape().  Including ~ in the character set gets the comparison to work but probably the better solution would be to store a fully qualified diary_path instead of relying on tilde expansion.