### PR TITLE
escape paths with spaces when adding to tags

### DIFF
--- a/autoload/vimwiki/tags.vim
+++ b/autoload/vimwiki/tags.vim
@@ -139,7 +139,7 @@ endfunction " }}}
 " vimwiki#tags#metadata_file_path
 "   Returns tags metadata file path
 function! vimwiki#tags#metadata_file_path() abort "{{{
-  return fnamemodify(VimwikiGet('path') . '/' . s:TAGS_METADATA_FILE_NAME, ':p')
+  return fnameescape(fnamemodify(VimwikiGet('path') . '/' . s:TAGS_METADATA_FILE_NAME, ':p'))
 endfunction " }}}
 
 " s:load_tags_metadata


### PR DESCRIPTION
The `fnameescape()` method escapes special characters that may be found in a file path. This is needed for file paths containing spaces.

See the [vimdocs](http://vimdoc.sourceforge.net/htmldoc/eval.html#fnameescape()) for more information.