### PR TITLE
Allow to use includes in templates

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -111,6 +111,7 @@ function! s:get_html_template(template) "{{{
     let template_name = s:template_full_name(a:template)
     try
       let lines = readfile(template_name)
+      let lines = s:get_html_template_include(lines)
       return lines
     catch /E484/
       echomsg 'Vimwiki: HTML template '.template_name.
@@ -125,7 +126,23 @@ function! s:get_html_template(template) "{{{
   endif
 
   let lines = readfile(default_tpl)
+  let lines = s:get_html_template_include(lines)
   return lines
+endfunction "}}}
+
+function! s:get_html_template_include(lines) "{{{
+  let html_lines=[]
+  for line in a:lines
+    if line =~# '%include'
+      let template = []
+      let template = split(line)
+      let include_lines = s:get_html_template(template[-1])
+      call extend(html_lines, include_lines)
+    else
+      call add(html_lines, line)
+    endif
+  endfor
+  return html_lines
 endfunction "}}}
 
 function! s:safe_html_preformatted(line) "{{{

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1916,6 +1916,11 @@ where
 
   %content% is replaced by a wiki file content.
 
+It is possible to include a template in another template.
+Consider you have a template named 'head.html' that you'd like to have
+in the template 'person.html' then add >
+    %include head.html
+to that template.
 
 The default template will be applied to all wiki pages unless a page specifies
 a template. Consider you have wiki page named 'Maxim.wiki' and you want apply


### PR DESCRIPTION
This adds the possibility to use includes in the templates by using
```
%include other_template
```

It can be used to share a common head or other common parts among templates.