### PR TITLE
Workaround for slow folding methods (issue #225)

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2288,6 +2288,8 @@ Limitations:
   - 'list' is intended to work with lists nicely indented with 'shiftwidth'.
   - 'syntax' is only available for the default syntax so far.
 
+The options above can be suffixed with ':quick' (e.g.: 'expr:quick') in order
+to use some workarounds to make folds work faster.
 
 ------------------------------------------------------------------------------
 *g:vimwiki_list_ignore_newline*

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -156,15 +156,15 @@ function! s:setup_buffer_enter() "{{{
   " Settings foldmethod, foldexpr and foldtext are local to window. Thus in a
   " new tab with the same buffer folding is reset to vim defaults. So we
   " insist vimwiki folding here.
-  if g:vimwiki_folding ==? 'expr'
+  if g:vimwiki_folding =~? '^expr.*'
     setlocal fdm=expr
     setlocal foldexpr=VimwikiFoldLevel(v:lnum)
     setlocal foldtext=VimwikiFoldText()
-  elseif g:vimwiki_folding ==? 'list' || g:vimwiki_folding ==? 'lists'
+  elseif g:vimwiki_folding =~? '^list.*' || g:vimwiki_folding ==? '^lists.*'
     setlocal fdm=expr
     setlocal foldexpr=VimwikiFoldListLevel(v:lnum)
     setlocal foldtext=VimwikiFoldText()
-  elseif g:vimwiki_folding ==? 'syntax'
+  elseif g:vimwiki_folding =~? '^syntax.*'
     setlocal fdm=syntax
     setlocal foldtext=VimwikiFoldText()
   else
@@ -445,6 +445,14 @@ augroup vimwiki
     if g:vimwiki_table_auto_fmt
       exe 'autocmd InsertLeave *'.s:ext.' call vimwiki#tbl#format(line("."))'
       exe 'autocmd InsertEnter *'.s:ext.' call vimwiki#tbl#reset_tw(line("."))'
+    endif
+    if g:vimwiki_folding =~? ':quick$'
+      " from http://vim.wikia.com/wiki/Keep_folds_closed_while_inserting_text
+      " Don't screw up folds when inserting text that might affect them, until
+      " leaving insert mode. Foldmethod is local to the window. Protect against
+      " screwing up folding when switching between windows.
+      exe 'autocmd InsertEnter *'.s:ext.' if !exists("w:last_fdm") | let w:last_fdm=&foldmethod | setlocal foldmethod=manual | endif'
+      exe 'autocmd InsertLeave,WinLeave *'.s:ext.' if exists("w:last_fdm") | let &l:foldmethod=w:last_fdm | unlet w:last_fdm | endif'
     endif
   endfor
 augroup END


### PR DESCRIPTION
It seems that Vim has a limitation when folding by expression and syntax. The Vim FAQ 29.7 mentions a [workaround on the wiki ](http://vim.wikia.com/wiki/Keep_folds_closed_while_inserting_text) which seems to work fine. 

The creation of the new lists still has a (smaller) delay, probably because the `<CR>` mapping leaves insert mode.
