### PR TITLE
Automatic detection of nested syntaxes in markdown

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1994,7 +1994,7 @@ endfunction "}}}
 " vimwiki#base#detect_nested_syntax
 function! vimwiki#base#detect_nested_syntax() "{{{
   let last_word = '\v.*<(\w+)\s*$'
-  let lines = map(filter(getline(1, "$"), 'v:val =~ "{{{" && v:val =~ last_word'), 
+  let lines = map(filter(getline(1, "$"), 'v:val =~ "\\%({{{\\|```\\)" && v:val =~ last_word'),
         \ 'substitute(v:val, last_word, "\\=submatch(1)", "")')
   let dict = {}
   for elem in lines


### PR DESCRIPTION
Adds support for nested syntax detection on markdown preformat blocks.  Fixes #244.  Wasn't sure how to test the currently applied vimwiki syntax setting, so this simply updates to test for either {{{ or ``` without regard to whether we're in wimwiki or markdown mode.
