### PR TITLE
Fix markdown-style link detection

### DIFF
--- a/syntax/omnipresent_syntax.vim
+++ b/syntax/omnipresent_syntax.vim
@@ -20,7 +20,7 @@ let g:vimwiki_markdown_header_search = '^\s*\(#\{1,6}\)\([^#].*\)$'
 let g:vimwiki_markdown_header_match = '^\s*\(#\{1,6}\)#\@!\s*__Header__\s*$'
 let g:vimwiki_markdown_bold_search = '\%(^\|\s\|[[:punct:]]\)\@<=\*\zs\%([^*`[:space:]][^*`]*[^*`[:space:]]\|[^*`[:space:]]\)\ze\*\%([[:punct:]]\|\s\|$\)\@='
 let g:vimwiki_markdown_bold_match = '\%(^\|\s\|[[:punct:]]\)\@<=\*__Text__\*\%([[:punct:]]\|\s\|$\)\@='
-let g:vimwiki_markdown_wikilink = '\[\%([^\\\]|]\+\)\?\](\zs[^\\\]]\+\ze)'
+let g:vimwiki_markdown_wikilink = '\[\%([^\\\]|]\+\)\?\](\zs[^\\)]\+\ze)'
 let g:vimwiki_markdown_tag_search = g:vimwiki_default_tag_search
 let g:vimwiki_markdown_tag_match = g:vimwiki_default_tag_match
 

--- a/syntax/omnipresent_syntax.vim
+++ b/syntax/omnipresent_syntax.vim
@@ -20,7 +20,7 @@ let g:vimwiki_markdown_header_search = '^\s*\(#\{1,6}\)\([^#].*\)$'
 let g:vimwiki_markdown_header_match = '^\s*\(#\{1,6}\)#\@!\s*__Header__\s*$'
 let g:vimwiki_markdown_bold_search = '\%(^\|\s\|[[:punct:]]\)\@<=\*\zs\%([^*`[:space:]][^*`]*[^*`[:space:]]\|[^*`[:space:]]\)\ze\*\%([[:punct:]]\|\s\|$\)\@='
 let g:vimwiki_markdown_bold_match = '\%(^\|\s\|[[:punct:]]\)\@<=\*__Text__\*\%([[:punct:]]\|\s\|$\)\@='
-let g:vimwiki_markdown_wikilink = g:vimwiki_default_wikilink "XXX plus markdown-style links
+let g:vimwiki_markdown_wikilink = '\[\%([^\\\]|]\+\)\?\](\zs[^\\\]]\+\ze)'
 let g:vimwiki_markdown_tag_search = g:vimwiki_default_tag_search
 let g:vimwiki_markdown_tag_match = g:vimwiki_default_tag_match
 


### PR DESCRIPTION
Hello,

I recently installed the plugin, set up Markdown as the default syntax (as described in `:h vimwiki-option-syntax`):

    let g:vimwiki_list = [{ 'path'   : '~/vimwiki/',
                          \ 'syntax' : 'markdown',
                          \ 'ext'    : '.md'}]

… opened the index, hitting `Leader w w`, wrote `foo`, hit Enter to convert the word into a link, hit Enter a second time to open the link, and finally executed the command `:VWB` (short version of `:VimwikiBacklinks`). The output was:

    Vimwiki: No other file links to this file

I expected to see the index file to be shown in the location list, since `index.md` has a direct link to the file `foo.md`.

The command `:VWB` is defined [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/ftplugin/vimwiki.vim#L278):

    command! -buffer -nargs=0 VimwikiBacklinks call vimwiki#base#backlinks()

It calls the `vimwiki#base#backlinks()` function, which is defined [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/autoload/vimwiki/base.vim#L489-L513).
The problem seems to come from [this line](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/autoload/vimwiki/base.vim#L496):

     let links = s:get_links(source_file, idx)

On my system, the function `s:get_links()` doesn't seem to return anything for markdown files.
`s:get_links()` is defined [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/autoload/vimwiki/base.vim#L702-L732), and seems to fail on [this line](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/autoload/vimwiki/base.vim#L718):

     let link_text = matchstr(line, rx_link, 0, link_count)

I could be wrong, but I think this assignment should give us the link. It probably fails because of the pattern `rx_link` which is defined [a bit earlier](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/autoload/vimwiki/base.vim#L707-L708):

     let syntax = VimwikiGet('syntax', a:idx)
     let rx_link = g:vimwiki_{syntax}_wikilink

In my case, the value of `syntax` is `markdown`, so I think `g:vimwiki_{syntax}_wikilink` is expanded into `g:vimwiki_markdown_wikilink` (as described in `:h curly-braces-names`), and its value is assigned to `rx_link`.

`g:vimwiki_markdown_wikilink` is assigned [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/syntax/omnipresent_syntax.vim#L23):

    let g:vimwiki_markdown_wikilink = g:vimwiki_default_wikilink "XXX plus markdown-style links

It receives the same value as `g:vimwiki_default_wikilink`, which is defined [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/syntax/omnipresent_syntax.vim#L15):

    let g:vimwiki_default_wikilink = '\[\[\zs[^\\\]|]\+\ze\%(|[^\\\]]\+\)\?\]\]'

The pattern is a bit hard to read, but it seems to try to match a link like this:

    [[link|description]]

It could be broken down into 4 simple parts:

 - `\[\[` describes the first 2 open square brackets
 - `[^\\\]|]\+` describes the link, which is a sequence of characters different than a backslash, a closing square bracket, and a pipe
 - `\%(|[^\\\]]\+\)\?` describes an optional description
 -  `\]\]` describes the last 2 closing square brackets

It works great for the vimwiki syntax, but it doesn't for markdown.
It can be checked by executing the following commands:

    :let g:vimwiki_default_wikilink = '\[\[\zs[^\\\]|]\+\ze\%(|[^\\\]]\+\)\?\]\]'
    :echo matchstr('[[link|description]]', g:vimwiki_default_wikilink)
    :echo matchstr('[description](link)', g:vimwiki_default_wikilink)

The first `:echo` works, but the second fails.

I think a markdown link looks something like this:

    [description](link)

So, in a markdown file, maybe this regex would be better to match `link`:

    \[\%([^\\\]|]\+\)\?\](\zs[^\\\]]\+\ze)

I tried this regex on my system, and it seemed to work, as the `:VWB` correctly detects backlinks in a markdown file.

Thank you very much for your plugin, and for reading my PR.