### PR TITLE
Fix creation of a link in markdown file from visual mode

### DIFF
--- a/autoload/vimwiki/markdown_base.vim
+++ b/autoload/vimwiki/markdown_base.vim
@@ -200,7 +200,7 @@ function! s:normalize_link_syntax_v() " {{{
     call setreg('"', link, 'v')
 
     " paste result
-    norm! `>pgvd
+    norm! `>""pgvd
 
   finally
     call setreg('"', rv, rt)


### PR DESCRIPTION
Hello,

It seems the creation of a link in a markdown file, from visual mode, fails if you prepend the value `unnamedplus` in the option `'clipboard'`:

    set clipboard^=unnamedplus

The buffer-local mapping for `CR` in visual mode is defined [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/ftplugin/vimwiki.vim#L379-L383) and executes the command `:VimwikiNormalizeLink 1`, which in turn is defined [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/ftplugin/vimwiki.vim#L272) and calls the function `vimwiki#base#normalize_link()`.

The latter is defined [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/autoload/vimwiki/base.vim#L1980-L1992), and calls the function `vimwiki#markdown_base#normalize_link()`:

    call vimwiki#{VimwikiGet('syntax')}_base#normalize_link(a:is_visual_mode)

It calls `vimwiki#markdown_base#normalize_link()` which is defined [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/autoload/vimwiki/markdown_base.vim#L213-L224):

    call vimwiki#{VimwikiGet('syntax')}_base#normalize_link(a:is_visual_mode)

In turn it calls `s:normalize_link_syntax_v()` defined [here](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/autoload/vimwiki/markdown_base.vim#L186-L210).
And the problem seems to come from this [line](https://github.com/vimwiki/vimwiki/blob/2c9df656441eed66f868483bfdba20f661f92362/autoload/vimwiki/markdown_base.vim#L203):

    norm! `>pgvd

It works if you didn't change the value of `'clipboard'`, but in my case it fails, because by default Vim paste from the `+` register, but the plugin only changed the value of the unnamed register using `setreg()`. The solution would be very simple, we just need to explicitly tell the paste command to paste the unnamed register, by prepending `""` in front of it:

    norm! `>""pgvd

It seems to work, as now, the creation of a link in a markdown file works no matter the value of `'clipboard'`.

Thank you for your plugin, and for reading my PR.