### PR TITLE
Open wiki in a split pane

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1301,8 +1301,12 @@ function! vimwiki#base#goto_index(wnum, ...) "{{{
     let idx = 0
   endif
 
-  if a:0
+  if a:0 == 1
     let cmd = 'tabedit'
+  elseif a:0 == 2
+    let cmd = 'sp'
+  elseif a:0 == 3
+    let cmd = 'vsp'
   else
     let cmd = 'edit'
   endif

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1301,12 +1301,14 @@ function! vimwiki#base#goto_index(wnum, ...) "{{{
     let idx = 0
   endif
 
-  if a:1 == 1
-    let cmd = 'tabedit'
-  elseif a:1 == 2
-    let cmd = 'split'
-  elseif a:1 == 3
-    let cmd = 'vsplit'
+  if a:0
+    if a:1 == 1
+      let cmd = 'tabedit'
+    elseif a:1 == 2
+      let cmd = 'split'
+    elseif a:1 == 3
+      let cmd = 'vsplit'
+    endif
   else
     let cmd = 'edit'
   endif

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1311,8 +1311,6 @@ function! vimwiki#base#goto_index(wnum, ...) "{{{
     let cmd = 'edit'
   endif
 
-  echomsg 'Passed argument '.a:0.'. Using cmd '.cmd
-
   call Validate_wiki_options(idx)
   call vimwiki#base#edit_file(cmd,
         \ VimwikiGet('path', idx).VimwikiGet('index', idx).

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1301,15 +1301,17 @@ function! vimwiki#base#goto_index(wnum, ...) "{{{
     let idx = 0
   endif
 
-  if a:0 == 1
+  if a:1 == 1
     let cmd = 'tabedit'
-  elseif a:0 == 2
-    let cmd = 'sp'
-  elseif a:0 == 3
-    let cmd = 'vsp'
+  elseif a:1 == 2
+    let cmd = 'split'
+  elseif a:1 == 3
+    let cmd = 'vsplit'
   else
     let cmd = 'edit'
   endif
+
+  echomsg 'Passed argument '.a:0.'. Using cmd '.cmd
 
   call Validate_wiki_options(idx)
   call vimwiki#base#edit_file(cmd,

--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -174,8 +174,14 @@ function! vimwiki#diary#make_note(wnum, ...) "{{{
 
   call vimwiki#path#mkdir(VimwikiGet('path', idx).VimwikiGet('diary_rel_path', idx))
 
-  if a:0 && a:1 == 1
-    let cmd = 'tabedit'
+  if a:0
+    if a:1 == 1
+      let cmd = 'tabedit'
+    elseif a:2 == 2
+      let cmd = 'split'
+    elseif a:3 == 3
+      let cmd = 'vsplit'
+    endif
   else
     let cmd = 'edit'
   endif


### PR DESCRIPTION
Opening a wiki in a split pane added to function base#goto_index() through the 'tabedit' argument.
The function can now take the following:
```
vimwiki#base#goto_index(..., [1, 2, 3])
1       tabedit
2       split
3       vsplit
```

The change does not affect any other function calls because all the other function calls assumed '1' to be 'tabedit'.