### PR TITLE
Allow g:vimwiki_listsyms be larger than 5 elements (Issue #275)

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -861,11 +861,11 @@ function! s:process_tag_list(line, lists) "{{{
     if !empty(chk) && len(chk[1]) > 0
       let completion = index(g:vimwiki_listsyms_list, chk[1])
       let n = len(g:vimwiki_listsyms_list)
-      if completion >= 0 && completion < n-1
-        let completion = float2nr(ceil(completion * 4.0 / (n-1) ))
+      if completion == 0
+        let st_tag = '<li class="done0">'
+      elseif completion > 0 && completion < n
+        let completion = float2nr(round(completion / (n-1.0) * 3.0 + 0.5 ))
         let st_tag = '<li class="done'.completion.'">'
-      elseif completion == n-1
-        let st_tag = '<li class="done4">'
       endif
     endif
     return [st_tag, '']

--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -860,8 +860,12 @@ function! s:process_tag_list(line, lists) "{{{
     let chk = matchlist(a:line, a:rx_list)
     if !empty(chk) && len(chk[1]) > 0
       let completion = index(g:vimwiki_listsyms_list, chk[1])
-      if completion >= 0 && completion <=4
+      let n = len(g:vimwiki_listsyms_list)
+      if completion >= 0 && completion < n-1
+        let completion = float2nr(ceil(completion * 4.0 / (n-1) ))
         let st_tag = '<li class="done'.completion.'">'
+      elseif completion == n-1
+        let st_tag = '<li class="done4">'
       endif
     endif
     return [st_tag, '']

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -693,7 +693,8 @@ function! s:get_rate(item) "{{{
     return -1
   endif
   let state = a:item.cb
-  return index(g:vimwiki_listsyms_list, state) * 25
+  let n=len(g:vimwiki_listsyms_list)
+  return index(g:vimwiki_listsyms_list, state) * 100/(n-1)
 endfunction "}}}
 
 "Set state of the list item to [ ] or [o] or whatever
@@ -729,16 +730,14 @@ endfunction "}}}
 "Returns: the appropriate symbol for a given percent rate
 function! s:rate_to_state(rate) "{{{
   let state = ''
+  let n=len(g:vimwiki_listsyms_list)
   if a:rate == 100
-    let state = g:vimwiki_listsyms_list[4]
+    let state = g:vimwiki_listsyms_list[n-1]
   elseif a:rate == 0
     let state = g:vimwiki_listsyms_list[0]
-  elseif a:rate >= 67
-    let state = g:vimwiki_listsyms_list[3]
-  elseif a:rate >= 34
-    let state = g:vimwiki_listsyms_list[2]
   else
-    let state = g:vimwiki_listsyms_list[1]
+    let index = float2nr(ceil(a:rate/100.0*(n-2)))
+    let state = g:vimwiki_listsyms_list[index]
   endif
   return state
 endfunction "}}}

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2245,11 +2245,11 @@ Default: 'Vimwiki'
 ------------------------------------------------------------------------------
 *g:vimwiki_listsyms*
 
-String of 5 symbols to show the progression of todo list items.
+String of at least two symbols to show the progression of todo list items.
 Default value is ' .oOX'.
 
 The first char is for 0% done items.
-The fifth is for 100% done items.
+The last is for 100% done items.
 
 You can set it to some more fancy symbols like this:
 >

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -413,7 +413,7 @@ execute 'syntax match VimwikiList /'.g:vimwiki_rxListDefine.'/'
 execute 'syntax match VimwikiListTodo /'.g:vimwiki_rxListItem.'/'
 
 if g:vimwiki_hl_cb_checked == 1
-  execute 'syntax match VimwikiCheckBoxDone /'.g:vimwiki_rxListItemWithoutCB.'\s*\['.g:vimwiki_listsyms_list[4].'\]\s.*$/ '.
+  execute 'syntax match VimwikiCheckBoxDone /'.g:vimwiki_rxListItemWithoutCB.'\s*\['.g:vimwiki_listsyms_list[-1].'\]\s.*$/ '.
         \ 'contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
 elseif g:vimwiki_hl_cb_checked == 2
   execute 'syntax match VimwikiCheckBoxDone /'.g:vimwiki_rxListItemAndChildren.'/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'

--- a/syntax/vimwiki_default.vim
+++ b/syntax/vimwiki_default.vim
@@ -80,7 +80,7 @@ call vimwiki#lst#setup_marker_infos()
 
 let g:vimwiki_rxListItemWithoutCB = '^\s*\%(\('.g:vimwiki_rxListBullet.'\)\|\('.g:vimwiki_rxListNumber.'\)\)\s'
 let g:vimwiki_rxListItem = g:vimwiki_rxListItemWithoutCB . '\+\%(\[\(['.g:vimwiki_listsyms.']\)\]\s\)\?'
-let g:vimwiki_rxListItemAndChildren = '^\(\s*\)\%('.g:vimwiki_rxListBullet.'\|'.g:vimwiki_rxListNumber.'\)\s\+\['.g:vimwiki_listsyms_list[4].'\]\s.*\%(\n\%(\1\s.*\|^$\)\)*'
+let g:vimwiki_rxListItemAndChildren = '^\(\s*\)\%('.g:vimwiki_rxListBullet.'\|'.g:vimwiki_rxListNumber.'\)\s\+\['.g:vimwiki_listsyms_list[-1].'\]\s.*\%(\n\%(\1\s.*\|^$\)\)*'
 
 " Preformatted text
 let g:vimwiki_rxPreStart = '{{{'

--- a/syntax/vimwiki_markdown.vim
+++ b/syntax/vimwiki_markdown.vim
@@ -77,7 +77,7 @@ call vimwiki#lst#setup_marker_infos()
 
 let g:vimwiki_rxListItemWithoutCB = '^\s*\%(\('.g:vimwiki_rxListBullet.'\)\|\('.g:vimwiki_rxListNumber.'\)\)\s'
 let g:vimwiki_rxListItem = g:vimwiki_rxListItemWithoutCB . '\+\%(\[\(['.g:vimwiki_listsyms.']\)\]\s\)\?'
-let g:vimwiki_rxListItemAndChildren = '^\(\s*\)\%('.g:vimwiki_rxListBullet.'\|'.g:vimwiki_rxListNumber.'\)\s\+\['.g:vimwiki_listsyms_list[4].'\]\s.*\%(\n\%(\1\s.*\|^$\)\)*'
+let g:vimwiki_rxListItemAndChildren = '^\(\s*\)\%('.g:vimwiki_rxListBullet.'\|'.g:vimwiki_rxListNumber.'\)\s\+\['.g:vimwiki_listsyms_list[-1].'\]\s.*\%(\n\%(\1\s.*\|^$\)\)*'
 
 " Preformatted text
 let g:vimwiki_rxPreStart = '```'

--- a/syntax/vimwiki_media.vim
+++ b/syntax/vimwiki_media.vim
@@ -58,7 +58,7 @@ call vimwiki#lst#setup_marker_infos()
 
 let g:vimwiki_rxListItemWithoutCB = '^\s*\%(\('.g:vimwiki_rxListBullet.'\)\|\('.g:vimwiki_rxListNumber.'\)\)\s'
 let g:vimwiki_rxListItem = g:vimwiki_rxListItemWithoutCB . '\+\%(\[\(['.g:vimwiki_listsyms.']\)\]\s\)\?'
-let g:vimwiki_rxListItemAndChildren = '^\('.g:vimwiki_rxListBullet.'\)\s\+\['.g:vimwiki_listsyms_list[4].'\]\s.*\%(\n\%(\1\%('.g:vimwiki_rxListBullet.'\).*\|^$\|\s.*\)\)*'
+let g:vimwiki_rxListItemAndChildren = '^\('.g:vimwiki_rxListBullet.'\)\s\+\['.g:vimwiki_listsyms_list[-1].'\]\s.*\%(\n\%(\1\%('.g:vimwiki_rxListBullet.'\).*\|^$\|\s.*\)\)*'
 
 " Preformatted text
 let g:vimwiki_rxPreStart = '<pre>'


### PR DESCRIPTION
Allows g:vimwiki_listsyms to be of arbitrary size, so that smoother transitions like '▁▂▃▄▅▆▇▉' or '○◔◑◕●✓' are possible.