### PR TITLE
Possibility to increase/decrease checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ A Personal Wiki For Vim
 ==============================================================================
 
 ![screenshot1](doc/screenshot_1.png)
-![screenshot2](doc/screenshot_2.png)
+![screenshot2](doc/screenshot_2.png) *
 
 Intro
 ------------------------------------------------------------------------------
@@ -145,3 +145,7 @@ Add `Plugin 'vimwiki/vimwiki'` to your vimrc file and run
 Or download the [zip archive](https://github.com/vimwiki/vimwiki/archive/master.zip) and extract it in `~/.vim/bundle/`
 
 Then launch Vim, run `:Helptags` and then `:help vimwiki` to verify it was installed.
+
+----
+\* Screenshots made with the [solarized colorscheme](https://github.com/altercation/vim-colors-solarized)
+and [lightline](https://github.com/itchyny/lightline.vim)

--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -43,7 +43,7 @@ function! s:get_position_links(link) "{{{
   let idx = -1
   let links = []
   if a:link =~# '^\d\{4}-\d\d-\d\d'
-    let links = keys(s:get_diary_links())
+    let links = map(s:get_diary_files(), 'fnamemodify(v:val, ":t:r")')
     " include 'today' into links
     if index(links, s:diary_date_link()) == -1
       call add(links, s:diary_date_link())
@@ -83,7 +83,7 @@ fun! s:read_captions(files) "{{{
   return result
 endfun "}}}
 
-fun! s:get_diary_links() "{{{
+fun! s:get_diary_files() "{{{
   let rx = '^\d\{4}-\d\d-\d\d'
   let s_files = glob(VimwikiGet('path').VimwikiGet('diary_rel_path').'*'.VimwikiGet('ext'))
   let files = split(s_files, '\n')
@@ -92,9 +92,7 @@ fun! s:get_diary_links() "{{{
   " remove backup files (.wiki~)
   call filter(files, 'v:val !~# ''.*\~$''')
 
-  let links_with_captions = s:read_captions(files)
-
-  return links_with_captions
+  return files
 endfun "}}}
 
 fun! s:group_links(links) "{{{
@@ -129,7 +127,9 @@ endfunction "}}}
 function! s:format_diary() "{{{
   let result = []
 
-  let g_files = s:group_links(s:get_diary_links())
+
+  let links_with_captions = s:read_captions(s:get_diary_files())
+  let g_files = s:group_links(links_with_captions)
 
   for year in s:sort(keys(g_files))
     call add(result, '')

--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1203,7 +1203,7 @@ function! s:parse_line(line, state) " {{{
 
   " nohtml -- placeholder
   if !processed
-    if line =~# '^\s*%nohtml'
+    if line =~# '\m^\s*%nohtml\s*$'
       let processed = 1
       let state.placeholder = ['nohtml']
     endif
@@ -1211,27 +1211,27 @@ function! s:parse_line(line, state) " {{{
 
   " title -- placeholder
   if !processed
-    if line =~# '^\s*%title'
+    if line =~# '\m^\s*%title\%(\s.*\)\?$'
       let processed = 1
-      let param = matchstr(line, '^\s*%title\s\zs.*')
+      let param = matchstr(line, '\m^\s*%title\s\+\zs.*')
       let state.placeholder = ['title', param]
     endif
   endif
 
   " date -- placeholder
   if !processed
-    if line =~# '^\s*%date'
+    if line =~# '\m^\s*%date\%(\s.*\)\?$'
       let processed = 1
-      let param = matchstr(line, '^\s*%date\s\zs.*')
+      let param = matchstr(line, '\m^\s*%date\s\+\zs.*')
       let state.placeholder = ['date', param]
     endif
   endif
 
   " html template -- placeholder "{{{
   if !processed
-    if line =~# '^\s*%template'
+    if line =~# '\m^\s*%template\%(\s.*\)\?$'
       let processed = 1
-      let param = matchstr(line, '^\s*%template\s\zs.*')
+      let param = matchstr(line, '\m^\s*%template\s\+\zs.*')
       let state.placeholder = ['template', param]
     endif
   endif

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -808,6 +808,78 @@ function! s:remove_cb(item) "{{{
   return item
 endfunction "}}}
 
+
+"Increment checkbox between [ ] and [X]
+"in the lines of the given range
+function! vimwiki#lst#decrement_cb(from_line, to_line) "{{{
+  let from_item = s:get_corresponding_item(a:from_line)
+  if from_item.type == 0
+    return
+  endif
+
+  let parent_items_of_lines = []
+
+  if from_item.cb != ''
+
+    "if from_line has CB, toggle it and set all siblings to the same new state
+    let rate_first_line = s:get_rate(from_item)
+    let n=len(g:vimwiki_listsyms_list)
+    let new_rate = max([rate_first_line - 100/(n-1)-1, 0])
+
+    for cur_ln in range(from_item.lnum, a:to_line)
+      let cur_item = s:get_item(cur_ln)
+      if cur_item.type != 0 && cur_item.cb != ''
+        call s:set_state_plus_children(cur_item, new_rate)
+        let cur_parent_item = s:get_parent(cur_item)
+        if index(parent_items_of_lines, cur_parent_item) == -1
+          call insert(parent_items_of_lines, cur_parent_item)
+        endif
+      endif
+    endfor
+
+  endif
+
+  for parent_item in parent_items_of_lines
+    call s:update_state(parent_item)
+  endfor
+
+endfunction "}}}
+"Increment checkbox between [ ] and [X]
+"in the lines of the given range
+function! vimwiki#lst#increment_cb(from_line, to_line) "{{{
+  let from_item = s:get_corresponding_item(a:from_line)
+  if from_item.type == 0
+    return
+  endif
+
+  let parent_items_of_lines = []
+
+  if from_item.cb != ''
+
+    "if from_line has CB, toggle it and set all siblings to the same new state
+    let rate_first_line = s:get_rate(from_item)
+    let n=len(g:vimwiki_listsyms_list)
+    let new_rate = min([rate_first_line + 100/(n-1)+1, 100])
+
+    for cur_ln in range(from_item.lnum, a:to_line)
+      let cur_item = s:get_item(cur_ln)
+      if cur_item.type != 0 && cur_item.cb != ''
+        call s:set_state_plus_children(cur_item, new_rate)
+        let cur_parent_item = s:get_parent(cur_item)
+        if index(parent_items_of_lines, cur_parent_item) == -1
+          call insert(parent_items_of_lines, cur_parent_item)
+        endif
+      endif
+    endfor
+
+  endif
+
+  for parent_item in parent_items_of_lines
+    call s:update_state(parent_item)
+  endfor
+
+endfunction "}}}
+
 "Toggles checkbox between [ ] and [X] or creates one
 "in the lines of the given range
 function! vimwiki#lst#toggle_cb(from_line, to_line) "{{{

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -808,10 +808,9 @@ function! s:remove_cb(item) "{{{
   return item
 endfunction "}}}
 
-
-"Increment checkbox between [ ] and [X]
+"Change state of checkbox
 "in the lines of the given range
-function! vimwiki#lst#decrement_cb(from_line, to_line) "{{{
+function! s:change_cb(from_line, to_line, new_rate) "{{{
   let from_item = s:get_corresponding_item(a:from_line)
   if from_item.type == 0
     return
@@ -819,31 +818,40 @@ function! vimwiki#lst#decrement_cb(from_line, to_line) "{{{
 
   let parent_items_of_lines = []
 
-  if from_item.cb != ''
-
-    "if from_line has CB, toggle it and set all siblings to the same new state
-    let rate_first_line = s:get_rate(from_item)
-    let n=len(g:vimwiki_listsyms_list)
-    let new_rate = max([rate_first_line - 100/(n-1)-1, 0])
-
-    for cur_ln in range(from_item.lnum, a:to_line)
-      let cur_item = s:get_item(cur_ln)
-      if cur_item.type != 0 && cur_item.cb != ''
-        call s:set_state_plus_children(cur_item, new_rate)
-        let cur_parent_item = s:get_parent(cur_item)
-        if index(parent_items_of_lines, cur_parent_item) == -1
-          call insert(parent_items_of_lines, cur_parent_item)
-        endif
+  for cur_ln in range(from_item.lnum, a:to_line)
+    let cur_item = s:get_item(cur_ln)
+    if cur_item.type != 0 && cur_item.cb != ''
+      call s:set_state_plus_children(cur_item, a:new_rate)
+      let cur_parent_item = s:get_parent(cur_item)
+      if index(parent_items_of_lines, cur_parent_item) == -1
+        call insert(parent_items_of_lines, cur_parent_item)
       endif
-    endfor
-
-  endif
+    endif
+  endfor
 
   for parent_item in parent_items_of_lines
     call s:update_state(parent_item)
   endfor
 
 endfunction "}}}
+
+"Decrement checkbox between [ ] and [X]
+"in the lines of the given range
+function! vimwiki#lst#decrement_cb(from_line, to_line) "{{{
+  let from_item = s:get_corresponding_item(a:from_line)
+  if from_item.type == 0
+    return
+  endif
+
+  "if from_line has CB, decrement it and set all siblings to the same new state
+  let rate_first_line = s:get_rate(from_item)
+  let n=len(g:vimwiki_listsyms_list)
+  let new_rate = max([rate_first_line - 100/(n-1)-1, 0])
+
+  call s:change_cb(a:from_line, a:to_line, new_rate)
+
+endfunction "}}}
+
 "Increment checkbox between [ ] and [X]
 "in the lines of the given range
 function! vimwiki#lst#increment_cb(from_line, to_line) "{{{
@@ -852,31 +860,12 @@ function! vimwiki#lst#increment_cb(from_line, to_line) "{{{
     return
   endif
 
-  let parent_items_of_lines = []
+  "if from_line has CB, increment it and set all siblings to the same new state
+  let rate_first_line = s:get_rate(from_item)
+  let n=len(g:vimwiki_listsyms_list)
+  let new_rate = min([rate_first_line + 100/(n-1)+1, 100])
 
-  if from_item.cb != ''
-
-    "if from_line has CB, toggle it and set all siblings to the same new state
-    let rate_first_line = s:get_rate(from_item)
-    let n=len(g:vimwiki_listsyms_list)
-    let new_rate = min([rate_first_line + 100/(n-1)+1, 100])
-
-    for cur_ln in range(from_item.lnum, a:to_line)
-      let cur_item = s:get_item(cur_ln)
-      if cur_item.type != 0 && cur_item.cb != ''
-        call s:set_state_plus_children(cur_item, new_rate)
-        let cur_parent_item = s:get_parent(cur_item)
-        if index(parent_items_of_lines, cur_parent_item) == -1
-          call insert(parent_items_of_lines, cur_parent_item)
-        endif
-      endif
-    endfor
-
-  endif
-
-  for parent_item in parent_items_of_lines
-    call s:update_state(parent_item)
-  endfor
+  call s:change_cb(a:from_line, a:to_line, new_rate)
 
 endfunction "}}}
 
@@ -887,8 +876,6 @@ function! vimwiki#lst#toggle_cb(from_line, to_line) "{{{
   if from_item.type == 0
     return
   endif
-
-  let parent_items_of_lines = []
 
   if from_item.cb == ''
 
@@ -906,28 +893,19 @@ function! vimwiki#lst#toggle_cb(from_line, to_line) "{{{
       endif
     endfor
 
+    for parent_item in parent_items_of_lines
+      call s:update_state(parent_item)
+    endfor
+
   else
 
     "if from_line has CB, toggle it and set all siblings to the same new state
     let rate_first_line = s:get_rate(from_item)
     let new_rate = rate_first_line == 100 ? 0 : 100
 
-    for cur_ln in range(from_item.lnum, a:to_line)
-      let cur_item = s:get_item(cur_ln)
-      if cur_item.type != 0 && cur_item.cb != ''
-        call s:set_state_plus_children(cur_item, new_rate)
-        let cur_parent_item = s:get_parent(cur_item)
-        if index(parent_items_of_lines, cur_parent_item) == -1
-          call insert(parent_items_of_lines, cur_parent_item)
-        endif
-      endif
-    endfor
+    call s:change_cb(a:from_line, a:to_line, new_rate)
 
   endif
-
-  for parent_item in parent_items_of_lines
-    call s:update_state(parent_item)
-  endfor
 
 endfunction "}}}
 

--- a/autoload/vimwiki/markdown_base.vim
+++ b/autoload/vimwiki/markdown_base.vim
@@ -70,61 +70,6 @@ endfunction " }}}
 
 " WIKI link following functions {{{
 
-" vimwiki#markdown_base#follow_link
-function! vimwiki#markdown_base#follow_link(split, ...) "{{{ Parse link at cursor and pass 
-  " to VimwikiLinkHandler, or failing that, the default open_link handler
-  " echom "markdown_base#follow_link"
-
-  if 0
-    " Syntax-specific links
-    " XXX: @Stuart: do we still need it?
-    " XXX: @Maxim: most likely!  I am still working on a seemless way to
-    " integrate regexp's without complicating syntax/vimwiki.vim
-  else
-    if a:split ==# "split"
-      let cmd = ":split "
-    elseif a:split ==# "vsplit"
-      let cmd = ":vsplit "
-    elseif a:split ==# "tabnew"
-      let cmd = ":tabnew "
-    else
-      let cmd = ":e "
-    endif
-
-    " try WikiLink
-    let lnk = matchstr(vimwiki#base#matchstr_at_cursor(g:vimwiki_rxWikiLink),
-          \ g:vimwiki_rxWikiLinkMatchUrl)
-    " try WikiIncl
-    if lnk == ""
-      let lnk = matchstr(vimwiki#base#matchstr_at_cursor(g:vimwiki_rxWikiIncl),
-          \ g:vimwiki_rxWikiInclMatchUrl)
-    endif
-    " try Weblink
-    if lnk == ""
-      let lnk = matchstr(vimwiki#base#matchstr_at_cursor(g:vimwiki_rxWeblink),
-            \ g:vimwiki_rxWeblinkMatchUrl)
-    endif
-
-    if lnk != ""
-      if !VimwikiLinkHandler(lnk)
-        if !vimwiki#markdown_base#open_reflink(lnk)
-          " remove the extension from the filename if exists
-          let lnk = substitute(lnk, VimwikiGet('ext').'$', '', '')
-          call vimwiki#base#open_link(cmd, lnk)
-        endif
-      endif
-      return
-    endif
-
-    if a:0 > 0
-      execute "normal! ".a:1
-    else		
-      call vimwiki#base#normalize_link(0)
-    endif
-  endif
-
-endfunction " }}}
-
 " LINK functions {{{
 
 " s:normalize_link_syntax_n

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1177,7 +1177,8 @@ This might be useful for coloring program code with external JS tools
 such as Google's syntax highlighter.
 
 You can setup Vimwiki to highlight code snippets in preformatted text.
-See |vimwiki-option-nested_syntaxes|
+See |vimwiki-option-nested_syntaxes| and
+|vimwiki-option-automatic_nested_syntaxes|.
 
 
 ------------------------------------------------------------------------------
@@ -2074,7 +2075,9 @@ Just write your preformatted text in your file like this >
  my preformatted text
  }}}
 
-where xxx is a Vim filetype.
+where xxx is a filetype which is known to Vim. For example, for C++
+highlighting, use "cpp" (not "c++"). For a list of known filetypes, type
+":setf " and hit Ctrl+d.
 
 Note that you may have to reload the file (|:edit|) to see the highlight.
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -742,8 +742,9 @@ Vimwiki file.
 
 *:VimwikiGenerateTags* tagname1 tagname2 ...
     Creates or updates an overview on all tags of the wiki with links to all
-    their instances.  Supports |cmdline-completion|.  If
-    no arguments (tags) are specified, outputs all tags.
+    their instances.  Supports |cmdline-completion|.  If no arguments (tags)
+    are specified, outputs all tags.  To make this command work properly, make
+    sure the tags have been built (see |vimwiki-build-tags|).
 
 ------------------------------------------------------------------------------
 4.3. Functions                                              *vimwiki-functions*
@@ -1296,8 +1297,9 @@ which opens up a popup menu with all tags defined in the wiki starting with
 
 Tags are also treated as |vimwiki-anchors| (similar to bold text).
 
-Note that tag search/jump/completion commands need certain metadata saved in
-the wiki folder.  This metadata file can be manually updated by running
+                                                          *vimwiki-build-tags*
+Note that the tag search/jump/completion commands need certain metadata saved
+in the wiki folder.  This metadata file can be manually updated by running
 |:VimwikiRebuildTags|.  When the option |vimwiki-option-auto_tags| is enabled,
 the tags metadata will be auto-updated on each page save.
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -755,9 +755,10 @@ Warning: this is currently unstable and likely to change.
 
 To map them to a key, use >
  nnoremap <C-K> :call vimwiki#base#function_name(arg1, arg2)<CR>
+<
 
-
-vimwiki#base#follow_link({split}, {reuse}, {move_cursor})         *follow_link*
+                                                          *vimwiki-follow_link*
+vimwiki#base#follow_link({split}, {reuse}, {move_cursor})
     Open the link under the cursor. {split} can have the following values:
         'nosplit'       open the link in the current window
         'vsplit'        open in a vertically split window

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2321,6 +2321,8 @@ Value           Description~
 'expr'          Folding based on expression (folds sections and code blocks)
 'syntax'        Folding based on syntax (folds sections; slower than 'expr')
 'list'          Folding based on expression (folds list subitems; much slower)
+'custom'        Leave the folding settings as they are (e.g. set by another
+                plugin)
 
 Default: ''
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -594,6 +594,9 @@ il                      A single list item.
 ------------------------------------------------------------------------------
 4.2. Local commands                                   *vimwiki-local-commands*
 
+These commands are only available (and meaningful) when you are currently in a
+Vimwiki file.
+
 *:VimwikiFollowLink*
     Follow wiki link (or create target wiki page if needed).
 
@@ -741,6 +744,34 @@ il                      A single list item.
     Creates or updates an overview on all tags of the wiki with links to all
     their instances.  Supports |cmdline-completion|.  If
     no arguments (tags) are specified, outputs all tags.
+
+------------------------------------------------------------------------------
+4.3. Functions                                              *vimwiki-functions*
+
+Functions to interact with Vimwiki. (It's intended that most commands will be
+replaced with corresponding function calls in the future.)
+Warning: this is currently unstable and likely to change.
+
+
+To map them to a key, use >
+ nnoremap <C-K> :call vimwiki#base#function_name(arg1, arg2)<CR>
+
+
+vimwiki#base#follow_link({split}, {reuse}, {move_cursor})         *follow_link*
+    Open the link under the cursor. {split} can have the following values:
+        'nosplit'       open the link in the current window
+        'vsplit'        open in a vertically split window
+        'hsplit'        open in a horizontally split window
+        'tab'           open in a new tab
+
+    If {reuse} is 1 and {split} one of 'vsplit' or 'hsplit', open the link in
+    a possibly existing split window instead of making a new split.
+
+    If {move_cursor} is 1 the cursor moves to the window or tab with the
+    opened link, otherwise, it stays in the window or tab with the link.
+
+    For example, <CR> is per default mapped to
+    vimwiki#base#follow_link('nosplit', 0, 1)
 
 
 ==============================================================================

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1399,6 +1399,18 @@ into it.
 
 See |vimwiki-option-template_path| for details.
 
+------------------------------------------------------------------------------
+%date                                                           *vimwiki-date*
+
+The date of the wiki page. The value can be used in the HTML template, see
+|vimwiki-option-template_path| for details.
+
+%date 2017-07-08
+%date
+
+If you omit the date after the placeholder, the date of the HTML conversion is
+used.
+
 
 ==============================================================================
 8. Lists                                                       *vimwiki-lists*
@@ -1950,11 +1962,13 @@ Each template could look like: >
         <div class="content">
         %content%
         </div>
+        <p><small>Page created on %date%</small></p>
     </body>
     </html>
 
 where
   %title% is replaced by a wiki page name or by a |vimwiki-title|
+  %date% is replaced with the current date or by |vimwiki-date|
   %root_path% is replaced by a count of ../ for pages buried in subdirs:
     if you have wikilink [[dir1/dir2/dir3/my page in a subdir]] then
     %root_path% is replaced by '../../../'.

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -295,6 +295,8 @@ command! -buffer -range -nargs=1 VimwikiChangeSymbolTo call vimwiki#lst#change_m
 command! -buffer -range -nargs=1 VimwikiListChangeSymbolI call vimwiki#lst#change_marker(<line1>, <line2>, <f-args>, 'i')
 command! -buffer -nargs=1 VimwikiChangeSymbolInListTo call vimwiki#lst#change_marker_in_list(<f-args>)
 command! -buffer -range VimwikiToggleListItem call vimwiki#lst#toggle_cb(<line1>, <line2>)
+command! -buffer -range VimwikiIncrementListItem call vimwiki#lst#increment_cb(<line1>, <line2>)
+command! -buffer -range VimwikiDecrementListItem call vimwiki#lst#decrement_cb(<line1>, <line2>)
 command! -buffer -range -nargs=+ VimwikiListChangeLvl call vimwiki#lst#change_level(<line1>, <line2>, <f-args>)
 command! -buffer -range VimwikiRemoveSingleCB call vimwiki#lst#remove_cb(<line1>, <line2>)
 command! -buffer VimwikiRemoveCBInList call vimwiki#lst#remove_cb_in_list()
@@ -444,6 +446,23 @@ nnoremap <silent><script><buffer>
       \ <Plug>VimwikiToggleListItem :VimwikiToggleListItem<CR>
 vnoremap <silent><script><buffer>
       \ <Plug>VimwikiToggleListItem :VimwikiToggleListItem<CR>
+
+if !hasmapto('<Plug>VimwikiIncrementListItem')
+  nmap <silent><buffer> <M-+> <Plug>VimwikiIncrementListItem
+  vmap <silent><buffer> <M-+> <Plug>VimwikiIncrementListItem
+endif
+if !hasmapto('<Plug>VimwikiDecrementListItem')
+  nmap <silent><buffer> <M--> <Plug>VimwikiDecrementListItem
+  vmap <silent><buffer> <M--> <Plug>VimwikiDecrementListItem
+endif
+nnoremap <silent><script><buffer>
+      \ <Plug>VimwikiIncrementListItem :VimwikiIncrementListItem<CR>
+vnoremap <silent><script><buffer>
+      \ <Plug>VimwikiIncrementListItem :VimwikiIncrementListItem<CR>
+nnoremap <silent><script><buffer>
+      \ <Plug>VimwikiDecrementListItem :VimwikiDecrementListItem<CR>
+vnoremap <silent><script><buffer>
+      \ <Plug>VimwikiDecrementListItem :VimwikiDecrementListItem<CR>
 
 if !hasmapto('<Plug>VimwikiDecreaseLvlSingleItem', 'i')
   imap <silent><buffer> <C-D>

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -264,14 +264,14 @@ command! -buffer VimwikiNextLink call vimwiki#base#find_next_link()
 command! -buffer VimwikiPrevLink call vimwiki#base#find_prev_link()
 command! -buffer VimwikiDeleteLink call vimwiki#base#delete_link()
 command! -buffer VimwikiRenameLink call vimwiki#base#rename_link()
-command! -buffer VimwikiFollowLink call vimwiki#base#follow_link('nosplit')
+command! -buffer VimwikiFollowLink call vimwiki#base#follow_link('nosplit', 0, 1)
 command! -buffer VimwikiGoBackLink call vimwiki#base#go_back_link()
-command! -buffer VimwikiSplitLink call vimwiki#base#follow_link('split')
-command! -buffer VimwikiVSplitLink call vimwiki#base#follow_link('vsplit')
+command! -buffer VimwikiSplitLink call vimwiki#base#follow_link('hsplit', 0, 1)
+command! -buffer VimwikiVSplitLink call vimwiki#base#follow_link('vsplit', 0, 1)
 
 command! -buffer -nargs=? VimwikiNormalizeLink call vimwiki#base#normalize_link(<f-args>)
 
-command! -buffer VimwikiTabnewLink call vimwiki#base#follow_link('tabnew')
+command! -buffer VimwikiTabnewLink call vimwiki#base#follow_link('tab', 0, 1)
 
 command! -buffer VimwikiGenerateLinks call vimwiki#base#generate_links()
 
@@ -327,7 +327,7 @@ command! -buffer -nargs=* -complete=custom,vimwiki#tags#complete_tags
 if g:vimwiki_use_mouse
   nmap <buffer> <S-LeftMouse> <NOP>
   nmap <buffer> <C-LeftMouse> <NOP>
-  nnoremap <silent><buffer> <2-LeftMouse> :call vimwiki#base#follow_link("nosplit", "\<lt>2-LeftMouse>")<CR>
+  nnoremap <silent><buffer> <2-LeftMouse> :call vimwiki#base#follow_link('nosplit', 0, 1, "\<lt>2-LeftMouse>")<CR>
   nnoremap <silent><buffer> <S-2-LeftMouse> <LeftMouse>:VimwikiSplitLink<CR>
   nnoremap <silent><buffer> <C-2-LeftMouse> <LeftMouse>:VimwikiVSplitLink<CR>
   nnoremap <silent><buffer> <RightMouse><LeftMouse> :VimwikiGoBackLink<CR>

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -448,12 +448,12 @@ vnoremap <silent><script><buffer>
       \ <Plug>VimwikiToggleListItem :VimwikiToggleListItem<CR>
 
 if !hasmapto('<Plug>VimwikiIncrementListItem')
-  nmap <silent><buffer> <M-+> <Plug>VimwikiIncrementListItem
-  vmap <silent><buffer> <M-+> <Plug>VimwikiIncrementListItem
+  nmap <silent><buffer> gl+ <Plug>VimwikiIncrementListItem
+  vmap <silent><buffer> gl+ <Plug>VimwikiIncrementListItem
 endif
 if !hasmapto('<Plug>VimwikiDecrementListItem')
-  nmap <silent><buffer> <M--> <Plug>VimwikiDecrementListItem
-  vmap <silent><buffer> <M--> <Plug>VimwikiDecrementListItem
+  nmap <silent><buffer> gl- <Plug>VimwikiDecrementListItem
+  vmap <silent><buffer> gl- <Plug>VimwikiDecrementListItem
 endif
 nnoremap <silent><script><buffer>
       \ <Plug>VimwikiIncrementListItem :VimwikiIncrementListItem<CR>

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -478,8 +478,8 @@ if !hasmapto('<Plug>VimwikiListToggle', 'i')
 endif
 inoremap <silent><script><buffer> <Plug>VimwikiListToggle <Esc>:VimwikiListToggle<CR>
 
-nnoremap <silent> <buffer> o :call vimwiki#lst#kbd_o()<CR>
-nnoremap <silent> <buffer> O :call vimwiki#lst#kbd_O()<CR>
+nnoremap <silent> <buffer> o :<C-U>call vimwiki#lst#kbd_o()<CR>
+nnoremap <silent> <buffer> O :<C-U>call vimwiki#lst#kbd_O()<CR>
 
 if !hasmapto('<Plug>VimwikiRenumberList')
   nmap <silent><buffer> glr <Plug>VimwikiRenumberList

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -167,6 +167,8 @@ function! s:setup_buffer_enter() "{{{
   elseif g:vimwiki_folding ==? 'syntax'
     setlocal fdm=syntax
     setlocal foldtext=VimwikiFoldText()
+  elseif g:vimwiki_folding ==? 'custom'
+    " do nothing
   else
     setlocal fdm=manual
     normal! zE

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -459,10 +459,10 @@ execute 'syntax region VimwikiMath start=/'.g:vimwiki_rxMathStart.
 
 " placeholders
 syntax match VimwikiPlaceholder /^\s*%nohtml\s*$/
-syntax match VimwikiPlaceholder /^\s*%title\%(\s.*\)\?$/ contains=VimwikiPlaceholderParam
-syntax match VimwikiPlaceholder /^\s*%date\%(\s.*\)\?$/ contains=VimwikiPlaceholderParam
-syntax match VimwikiPlaceholder /^\s*%template\%(\s.*\)\?$/ contains=VimwikiPlaceholderParam
-syntax match VimwikiPlaceholderParam /\s.*/ contained
+syntax match VimwikiPlaceholder /^\s*%title\ze\%(\s.*\)\?$/ nextgroup=VimwikiPlaceholderParam skipwhite
+syntax match VimwikiPlaceholder /^\s*%date\ze\%(\s.*\)\?$/ nextgroup=VimwikiPlaceholderParam skipwhite
+syntax match VimwikiPlaceholder /^\s*%template\ze\%(\s.*\)\?$/ nextgroup=VimwikiPlaceholderParam skipwhite
+syntax match VimwikiPlaceholderParam /.*/ contained
 
 " html tags
 if g:vimwiki_valid_html_tags != ''

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -460,6 +460,7 @@ execute 'syntax region VimwikiMath start=/'.g:vimwiki_rxMathStart.
 " placeholders
 syntax match VimwikiPlaceholder /^\s*%nohtml\s*$/
 syntax match VimwikiPlaceholder /^\s*%title\%(\s.*\)\?$/ contains=VimwikiPlaceholderParam
+syntax match VimwikiPlaceholder /^\s*%date\%(\s.*\)\?$/ contains=VimwikiPlaceholderParam
 syntax match VimwikiPlaceholder /^\s*%template\%(\s.*\)\?$/ contains=VimwikiPlaceholderParam
 syntax match VimwikiPlaceholderParam /\s.*/ contained
 


### PR DESCRIPTION
This implements Issue #308:
With :VimwikiToggleListItem we can change the status of a listitem between 0% and 100% – but we also include sub states configured in g:vimwiki_listsyms – for now we use them mostly to indicate the status of a item with subitems but it can already be nested, so it is possible to use the inbetween-states also for items without subitems.
This would become easier and more obvious if there are functions and keybindings to increment and decrement the state.

Adds new functions: `vimwiki#lst#increment_cb` & `vimwiki#lst#decrement_cb`
Adds keybinding for them: `<ctrl>-<alt>-<+>` &  `<ctrl>-<alt>-<->`