### PR TITLE
Add option for enabling local folding settings

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2321,6 +2321,7 @@ Value           Description~
 'expr'          Folding based on expression (folds sections and code blocks)
 'syntax'        Folding based on syntax (folds sections; slower than 'expr')
 'list'          Folding based on expression (folds list subitems; much slower)
+'local'		Enable use of local folding settings
 
 Default: ''
 

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -167,6 +167,8 @@ function! s:setup_buffer_enter() "{{{
   elseif g:vimwiki_folding ==? 'syntax'
     setlocal fdm=syntax
     setlocal foldtext=VimwikiFoldText()
+  elseif g:vimwiki_folding ==? 'local'
+    ;
   else
     setlocal fdm=manual
     normal! zE


### PR DESCRIPTION
Because the default folding setting set 'foldmethod=manual' it
makes it difficult to use local folding settings defined in the
after-directory. This code adds a 'local' option to g:vimwiki_folding
that makes this easier.