### PR TITLE
add option to convert multiple rows in table to single HTML table row

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -7,6 +7,8 @@ if exists("g:loaded_vimwiki_auto") || &cp
   finish
 endif
 let g:loaded_vimwiki_auto = 1
+" by default, one column has multiple rows
+let g:vimwiki_one_column_one_row = 0 
 
 " s:vimwiki_get_known_syntaxes
 function! s:vimwiki_get_known_syntaxes() " {{{
@@ -1361,6 +1363,15 @@ function! vimwiki#base#delete_link() "{{{
   " reread buffer => deleted wiki link should appear as non-existent
   if expand('%:p') != ""
     execute "e"
+  endif
+endfunction "}}}
+
+" vimwiki#base#one_column_one_row_toggle
+function! vimwiki#base#one_column_one_row_toggle() "{{{
+  if g:vimwiki_one_column_one_row
+      let g:vimwiki_one_column_one_row = 0
+  else
+      let g:vimwiki_one_column_one_row = 1
   endif
 endfunction "}}}
 

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -264,6 +264,7 @@ command! -buffer VimwikiNextLink call vimwiki#base#find_next_link()
 command! -buffer VimwikiPrevLink call vimwiki#base#find_prev_link()
 command! -buffer VimwikiDeleteLink call vimwiki#base#delete_link()
 command! -buffer VimwikiRenameLink call vimwiki#base#rename_link()
+command! -buffer VimwikiOneColumnOneRow call vimwiki#base#one_column_one_row_toggle()
 command! -buffer VimwikiFollowLink call vimwiki#base#follow_link('nosplit', 0, 1)
 command! -buffer VimwikiGoBackLink call vimwiki#base#go_back_link()
 command! -buffer VimwikiSplitLink call vimwiki#base#follow_link('hsplit', 0, 1)
@@ -418,6 +419,13 @@ if !hasmapto('<Plug>VimwikiRenameLink')
 endif
 nnoremap <silent><script><buffer>
       \ <Plug>VimwikiRenameLink :VimwikiRenameLink<CR>
+
+if !hasmapto('<Plug>VimwikiOneColumnOneRow')
+  nmap <silent><buffer> <Leader>wz <Plug>VimwikiOneColumnOneRow
+endif
+nnoremap <silent><script><buffer>
+      \ <Plug>VimwikiOneColumnOneRow :VimwikiOneColumnOneRow<CR>
+
 
 if !hasmapto('<Plug>VimwikiDiaryNextDay')
   nmap <silent><buffer> <C-Down> <Plug>VimwikiDiaryNextDay


### PR DESCRIPTION
This pull request adds a toggle `<leader>wz`.

The toggle's default setting (zero) gives each row its own cell when
converted to HTML. This is what Vimwiki normally does.

If the toggle is set to one, each vimwiki table row is put into the same
single cell when converted to HTML.

Minimum Working Example:

This vimwiki text:

    | One again, you enter a  |
    | place filled with       |
    | twisty little passages, |
    | all alike.              |
    |                         |
    | There's no food.        |


produces this HTML by default after  `:Vimwiki2HTML`:

    <table>
    <tr>
    <td>
    One again, you enter a
    </td>
    </tr>
    <tr>
    <td>
    place filled with
    </td>
    </tr>
    <tr>
    <td>
    twisty little passages,
    </td>
    </tr>
    <tr>
    <td>
    all alike.
    </td>
    </tr>
    <tr>
    <td>
    <br /><br />
    </td>
    </tr>
    <tr>
    <td>
    There's no food.
    </td>
    </tr>
    </table>

With this fork to vimwiki, I get the HTML I want when  `<leader>wz` is set
to one and I then run `:Vimwiki2HTML`:

    <table>
    <tbody><tr><td>
    One again, you enter a
    place filled with
    twisty little passages,
    all alike.
    <br><br>
    There's no food.
    </td></tr>
    </tbody></table>