### PR TITLE
Fix cursor positioning in vimwiki#lst#change_level

### DIFF
--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -1057,7 +1057,7 @@ function! s:change_level(from_line, to_line, direction, plus_children) "{{{
 endfunction "}}}
 
 function! vimwiki#lst#change_level(from_line, to_line, direction, plus_children) "{{{
-  let cur_col = col('$') - col('.')
+  let cur_col = col('$') - col("'^")
   call s:change_level(a:from_line, a:to_line, a:direction, a:plus_children)
   call cursor('.', col('$') - cur_col)
 endfunction "}}}


### PR DESCRIPTION
In the function vimwiki#lst#change_level the cur_col was using the
column the cursor was in (`col('.')`). This is a problem when moving
from insert mode to normal mode however when the last column no longer
exists, this means that changing the level from the last column should
change the cursor position. This result is apparent in Neovim, but
doesn't occur in Vim.

By calculating cur_col from the last insert position this issue is
avoided in both vim and neovim.