### PR TITLE
custom defined arguments for custom_wiki2html script call

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1369,10 +1369,11 @@ function! vimwiki#html#CustomWiki2HTML(path, wikifile, force) "{{{
       \ shellescape(a:path). ' '.
       \ shellescape(a:wikifile). ' '.
       \ shellescape(s:default_CSS_full_name(a:path)). ' '.
-      \ (len(VimwikiGet('template_path'))    > 1 ? shellescape(expand(VimwikiGet('template_path'))) : '-'). ' '.
-      \ (len(VimwikiGet('template_default')) > 0 ? VimwikiGet('template_default')                   : '-'). ' '.
-      \ (len(VimwikiGet('template_ext'))     > 0 ? VimwikiGet('template_ext')                       : '-'). ' '.
-      \ (len(VimwikiGet('subdir'))           > 0 ? shellescape(s:root_path(VimwikiGet('subdir')))   : '-'))
+      \ (len(VimwikiGet('template_path'))         > 1 ? shellescape(expand(VimwikiGet('template_path'))) : '-'). ' '.
+      \ (len(VimwikiGet('template_default'))      > 0 ? VimwikiGet('template_default')                   : '-'). ' '.
+      \ (len(VimwikiGet('template_ext'))          > 0 ? VimwikiGet('template_ext')                       : '-'). ' '.
+      \ (len(VimwikiGet('subdir'))                > 0 ? shellescape(s:root_path(VimwikiGet('subdir')))   : '-'). ' '.
+      \ (len(VimwikiGet('custom_wiki2html_args')) > 0 ? VimwikiGet('custom_wiki2html_args')              : '-'))
 endfunction " }}}
 
 function! s:convert_file(path_html, wikifile) "{{{

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2147,8 +2147,11 @@ The following arguments, in this order, are passed to the script:
 10. root_path : a count of ../ for pages buried in subdirs
     For example, if you have wikilink [[dir1/dir2/dir3/my page in a subdir]]
     then this argument is '../../../'.
+11. custom_args : custom arguments (can be defined in g:vimwiki_list as
+    'custom_wiki2html_args' parameter) that will be passed to the conversion
+    script.
 
-Options 7-10 are experimental and may change in the future.  If any of these
+Options 7-11 are experimental and may change in the future.  If any of these
 parameters is empty, a hyphen "-" is passed to the script in its place.
 
 For an example and further instructions, refer to the following script:

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2147,8 +2147,9 @@ The following arguments, in this order, are passed to the script:
 10. root_path : a count of ../ for pages buried in subdirs
     For example, if you have wikilink [[dir1/dir2/dir3/my page in a subdir]]
     then this argument is '../../../'.
-11. custom_args : custom arguments (can be defined in g:vimwiki_list as
-    'custom_wiki2html_args' parameter) that will be passed to the conversion
+11. custom_args : custom arguments that will be passed to the conversion
+    (can be defined in g:vimwiki_list as 'custom_wiki2html_args' parameter,
+    see |vimwiki-option-custom_wiki2html_args|)
     script.
 
 Options 7-11 are experimental and may change in the future.  If any of these
@@ -2162,6 +2163,17 @@ An alternative converter was developed by Jason6Anderson, and can
 be located at https://github.com/vimwiki-backup/vimwiki/issues/384
 
 To use the internal wiki2html converter, use an empty string (the default).
+
+
+vimwiki-option-custom_wiki2html_args
+-----------------------------------------------------------------------------
+Key                     Default value~
+custom_wiki2html_args   ''
+
+Description
+If a custom script is called with |vimwiki-option-custom_wiki2html|, additional
+parameters can be passed by setting them using 'custom_wiki2html_args' in
+|g:vimwiki_list|.
 
 
 *vimwiki-option-list_margin*


### PR DESCRIPTION
optionally set additional custom arguments in g:vimwiki_list (custom_wiki2html_args) which will then be passed to the appropriate custom_wiki2html script.