### PR TITLE
Fix Markdown visual link creation

### DIFF
--- a/autoload/vimwiki/markdown_base.vim
+++ b/autoload/vimwiki/markdown_base.vim
@@ -145,7 +145,7 @@ function! s:normalize_link_syntax_v() " {{{
     call setreg('"', link, 'v')
 
     " paste result
-    norm! `>pgvd
+    norm! `>""pgvd
 
   finally
     call setreg('"', rv, rt)


### PR DESCRIPTION
Access " register explicitly when pasting modified Markdown link.

Fixes #325.