### PR TITLE
If current wiki'syntax is 'markdown', there is no necessary to indent diary list by repeat(' ', &sw).

### DIFF
--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -124,6 +124,14 @@ function! s:sort(lst) "{{{
   endif
 endfunction "}}}
 
+function! s:get_diary_indent() "{{{
+  if VimwikiGet('syntax') == 'markdown'
+    return ''
+  else
+    return repeat(' ', &sw)
+  endif
+endfunction "}}}
+
 function! s:format_diary() "{{{
   let result = []
 
@@ -143,11 +151,11 @@ function! s:format_diary() "{{{
         if empty(cap)
           let entry = substitute(g:vimwiki_WikiLinkTemplate1, '__LinkUrl__', fl, '')
           let entry = substitute(entry, '__LinkDescription__', cap, '')
-          call add(result, repeat(' ', &sw).'* '.entry)
+          call add(result, s:get_diary_indent().'* '.entry)
         else
           let entry = substitute(g:vimwiki_WikiLinkTemplate2, '__LinkUrl__', fl, '')
           let entry = substitute(entry, '__LinkDescription__', cap, '')
-          call add(result, repeat(' ', &sw).'* '.entry)
+          call add(result, s:get_diary_indent().'* '.entry)
         endif
       endfor
 


### PR DESCRIPTION
The [markdown syntax rules](http://daringfireball.net/projects/markdown/syntax#list)  state:

List items may consist of multiple paragraphs. Each subsequent paragraph in a list item must be indented by either 4 spaces or one tab.

Diary list is top level at diary index, there is no necessary to indent diary list by any space. What's worse, if shiftwide is 4(that's normal for a markdown filetype), the diary list will indent 4 space, then the list will become a codeblock.
