### PR TITLE
Predictable behaviour with multiple wikis

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1310,8 +1310,7 @@ function! vimwiki#base#go_back_link() "{{{
   endif
 endfunction " }}}
 
-" vimwiki#base#goto_index
-function! vimwiki#base#goto_index(wnum, ...) "{{{
+function! vimwiki#base#get_index(wnum)
   if a:wnum > len(g:vimwiki_list)
     echomsg 'Vimwiki Error: Wiki '.a:wnum.' is not registered in g:vimwiki_list!'
     return
@@ -1320,10 +1319,16 @@ function! vimwiki#base#goto_index(wnum, ...) "{{{
   " usually a:wnum is greater then 0 but with the following command it is == 0:
   " vim -n -c "exe 'VimwikiIndex' | echo g:vimwiki_current_idx"
   if a:wnum > 0
-    let idx = a:wnum - 1
-  else
-    let idx = 0
+    return a:wnum - 1
   endif
+
+  return g:vimwiki_current_idx
+endfunction
+
+
+" vimwiki#base#goto_index
+function! vimwiki#base#goto_index(wnum, ...) "{{{
+  let idx = vimwiki#base#get_index(a:wnum)
 
   if a:0
     let cmd = 'tabedit'

--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -160,17 +160,7 @@ endfunction "}}}
 " Diary index stuff }}}
 
 function! vimwiki#diary#make_note(wnum, ...) "{{{
-  if a:wnum > len(g:vimwiki_list)
-    echomsg 'Vimwiki Error: Wiki '.a:wnum.' is not registered in g:vimwiki_list!'
-    return
-  endif
-
-  " TODO: refactor it. base#goto_index uses the same
-  if a:wnum > 0
-    let idx = a:wnum - 1
-  else
-    let idx = 0
-  endif
+  let idx = vimwiki#base#get_index(a:wnum)
 
   call vimwiki#path#mkdir(VimwikiGet('path', idx).VimwikiGet('diary_rel_path', idx))
 
@@ -190,17 +180,7 @@ function! vimwiki#diary#make_note(wnum, ...) "{{{
 endfunction "}}}
 
 function! vimwiki#diary#goto_diary_index(wnum) "{{{
-  if a:wnum > len(g:vimwiki_list)
-    echomsg 'Vimwiki Error: Wiki '.a:wnum.' is not registered in g:vimwiki_list!'
-    return
-  endif
-
-  " TODO: refactor it. base#goto_index uses the same
-  if a:wnum > 0
-    let idx = a:wnum - 1
-  else
-    let idx = 0
-  endif
+  let idx = vimwiki#base#get_index(a:wnum)
 
   call vimwiki#base#edit_file('e', s:diary_index(idx), '')
   call vimwiki#base#setup_buffer_state(idx)

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -455,21 +455,19 @@ augroup END
 
 " COMMANDS {{{
 command! VimwikiUISelect call vimwiki#base#ui_select()
-" XXX: why not using <count> instead of v:count1?
-" See Issue 324.
-command! -count=1 VimwikiIndex
-      \ call vimwiki#base#goto_index(v:count1)
-command! -count=1 VimwikiTabIndex
-      \ call vimwiki#base#goto_index(v:count1, 1)
+command! -count VimwikiIndex
+      \ call vimwiki#base#goto_index(<count>)
+command! -count VimwikiTabIndex
+      \ call vimwiki#base#goto_index(<count>)
 
-command! -count=1 VimwikiDiaryIndex
-      \ call vimwiki#diary#goto_diary_index(v:count1)
-command! -count=1 VimwikiMakeDiaryNote
-      \ call vimwiki#diary#make_note(v:count1)
-command! -count=1 VimwikiTabMakeDiaryNote
-      \ call vimwiki#diary#make_note(v:count1, 1)
-command! -count=1 VimwikiMakeYesterdayDiaryNote
-      \ call vimwiki#diary#make_note(v:count1, 0, strftime(VimwikiGet('diary_link_fmt', v:count1 - 1), localtime() - 60*60*24))
+command! -count VimwikiDiaryIndex
+      \ call vimwiki#diary#goto_diary_index(<count>)
+command! -count VimwikiMakeDiaryNote
+      \ call vimwiki#diary#make_note(<count>)
+command! -count VimwikiTabMakeDiaryNote
+      \ call vimwiki#diary#make_note(<count>)
+command! -count VimwikiMakeYesterdayDiaryNote
+      \ call vimwiki#diary#make_note(<count>, 0, strftime(VimwikiGet('diary_link_fmt', vimwiki#base#get_index(<count>), localtime() - 60*60*24))
 
 command! VimwikiDiaryGenerateLinks
       \ call vimwiki#diary#generate_diary_section()
@@ -479,22 +477,22 @@ command! VimwikiDiaryGenerateLinks
 if !hasmapto('<Plug>VimwikiIndex')
   exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'w <Plug>VimwikiIndex'
 endif
-nnoremap <unique><script> <Plug>VimwikiIndex :VimwikiIndex<CR>
+nnoremap <unique><script> <Plug>VimwikiIndex :<C-U>execute v:count."VimwikiIndex"<CR>
 
 if !hasmapto('<Plug>VimwikiTabIndex')
   exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'t <Plug>VimwikiTabIndex'
 endif
-nnoremap <unique><script> <Plug>VimwikiTabIndex :VimwikiTabIndex<CR>
+nnoremap <unique><script> <Plug>VimwikiTabIndex :<C-U>execute v:count."VimwikiTabIndex"<CR>
 
 if !hasmapto('<Plug>VimwikiUISelect')
   exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'s <Plug>VimwikiUISelect'
 endif
-nnoremap <unique><script> <Plug>VimwikiUISelect :VimwikiUISelect<CR>
+nnoremap <unique><script> <Plug>VimwikiUISelect :<C-U>execute v:count."VimwikiUISelect"<CR>
 
 if !hasmapto('<Plug>VimwikiDiaryIndex')
   exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'i <Plug>VimwikiDiaryIndex'
 endif
-nnoremap <unique><script> <Plug>VimwikiDiaryIndex :VimwikiDiaryIndex<CR>
+nnoremap <unique><script> <Plug>VimwikiDiaryIndex :<C-U>execute v:count."VimwikiDiaryIndex"<CR>
 
 if !hasmapto('<Plug>VimwikiDiaryGenerateLinks')
   exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'<Leader>i <Plug>VimwikiDiaryGenerateLinks'
@@ -504,19 +502,19 @@ nnoremap <unique><script> <Plug>VimwikiDiaryGenerateLinks :VimwikiDiaryGenerateL
 if !hasmapto('<Plug>VimwikiMakeDiaryNote')
   exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'<Leader>w <Plug>VimwikiMakeDiaryNote'
 endif
-nnoremap <unique><script> <Plug>VimwikiMakeDiaryNote :VimwikiMakeDiaryNote<CR>
+nnoremap <unique><script> <Plug>VimwikiMakeDiaryNote :<C-U>execute v:count."VimwikiMakeDiaryNote"<CR>
 
 if !hasmapto('<Plug>VimwikiTabMakeDiaryNote')
   exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'<Leader>t <Plug>VimwikiTabMakeDiaryNote'
 endif
 nnoremap <unique><script> <Plug>VimwikiTabMakeDiaryNote
-      \ :VimwikiTabMakeDiaryNote<CR>
+      \ :<C-U>execute v:count."VimwikiTabMakeDiaryNote"<CR>
 
 if !hasmapto('<Plug>VimwikiMakeYesterdayDiaryNote')
   exe 'nmap <silent><unique> '.g:vimwiki_map_prefix.'<Leader>y <Plug>VimwikiMakeYesterdayDiaryNote'
 endif
 nnoremap <unique><script> <Plug>VimwikiMakeYesterdayDiaryNote
-      \ :VimwikiMakeYesterdayDiaryNote<CR>
+      \ :<C-U>execute v:count."VimwikiMakeYesterdayDiaryNote"<CR>
 
 "}}}
 


### PR DESCRIPTION
This fixes all the irregularities in the movement between wikis and
diaries. Movement within the same wiki/diary can be done using the
`<Leader>ww`, `<Leader>wi`, `<Leader>w<Leader>w` commands without a number
prefix. The long form commands `:VimwikiDiaryIndex` etc. also work this
way.

To change between wikis/diaries either the shortened mappings or the
long form commands can be used.

This behaviour is achieved by passing a 0 by default to these commands,
which sets the index to that of the variable `g:vimwiki_current_idx`.