### PR TITLE
Possibility to increase/decrease checkbox

### DIFF
--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -808,6 +808,78 @@ function! s:remove_cb(item) "{{{
   return item
 endfunction "}}}
 
+
+"Increment checkbox between [ ] and [X]
+"in the lines of the given range
+function! vimwiki#lst#decrement_cb(from_line, to_line) "{{{
+  let from_item = s:get_corresponding_item(a:from_line)
+  if from_item.type == 0
+    return
+  endif
+
+  let parent_items_of_lines = []
+
+  if from_item.cb != ''
+
+    "if from_line has CB, toggle it and set all siblings to the same new state
+    let rate_first_line = s:get_rate(from_item)
+    let n=len(g:vimwiki_listsyms_list)
+    let new_rate = max([rate_first_line - 100/(n-1)-1, 0])
+
+    for cur_ln in range(from_item.lnum, a:to_line)
+      let cur_item = s:get_item(cur_ln)
+      if cur_item.type != 0 && cur_item.cb != ''
+        call s:set_state_plus_children(cur_item, new_rate)
+        let cur_parent_item = s:get_parent(cur_item)
+        if index(parent_items_of_lines, cur_parent_item) == -1
+          call insert(parent_items_of_lines, cur_parent_item)
+        endif
+      endif
+    endfor
+
+  endif
+
+  for parent_item in parent_items_of_lines
+    call s:update_state(parent_item)
+  endfor
+
+endfunction "}}}
+"Increment checkbox between [ ] and [X]
+"in the lines of the given range
+function! vimwiki#lst#increment_cb(from_line, to_line) "{{{
+  let from_item = s:get_corresponding_item(a:from_line)
+  if from_item.type == 0
+    return
+  endif
+
+  let parent_items_of_lines = []
+
+  if from_item.cb != ''
+
+    "if from_line has CB, toggle it and set all siblings to the same new state
+    let rate_first_line = s:get_rate(from_item)
+    let n=len(g:vimwiki_listsyms_list)
+    let new_rate = min([rate_first_line + 100/(n-1)+1, 100])
+
+    for cur_ln in range(from_item.lnum, a:to_line)
+      let cur_item = s:get_item(cur_ln)
+      if cur_item.type != 0 && cur_item.cb != ''
+        call s:set_state_plus_children(cur_item, new_rate)
+        let cur_parent_item = s:get_parent(cur_item)
+        if index(parent_items_of_lines, cur_parent_item) == -1
+          call insert(parent_items_of_lines, cur_parent_item)
+        endif
+      endif
+    endfor
+
+  endif
+
+  for parent_item in parent_items_of_lines
+    call s:update_state(parent_item)
+  endfor
+
+endfunction "}}}
+
 "Toggles checkbox between [ ] and [X] or creates one
 "in the lines of the given range
 function! vimwiki#lst#toggle_cb(from_line, to_line) "{{{

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -808,10 +808,9 @@ function! s:remove_cb(item) "{{{
   return item
 endfunction "}}}
 
-
-"Increment checkbox between [ ] and [X]
+"Change state of checkbox
 "in the lines of the given range
-function! vimwiki#lst#decrement_cb(from_line, to_line) "{{{
+function! s:change_cb(from_line, to_line, new_rate) "{{{
   let from_item = s:get_corresponding_item(a:from_line)
   if from_item.type == 0
     return
@@ -819,31 +818,40 @@ function! vimwiki#lst#decrement_cb(from_line, to_line) "{{{
 
   let parent_items_of_lines = []
 
-  if from_item.cb != ''
-
-    "if from_line has CB, toggle it and set all siblings to the same new state
-    let rate_first_line = s:get_rate(from_item)
-    let n=len(g:vimwiki_listsyms_list)
-    let new_rate = max([rate_first_line - 100/(n-1)-1, 0])
-
-    for cur_ln in range(from_item.lnum, a:to_line)
-      let cur_item = s:get_item(cur_ln)
-      if cur_item.type != 0 && cur_item.cb != ''
-        call s:set_state_plus_children(cur_item, new_rate)
-        let cur_parent_item = s:get_parent(cur_item)
-        if index(parent_items_of_lines, cur_parent_item) == -1
-          call insert(parent_items_of_lines, cur_parent_item)
-        endif
+  for cur_ln in range(from_item.lnum, a:to_line)
+    let cur_item = s:get_item(cur_ln)
+    if cur_item.type != 0 && cur_item.cb != ''
+      call s:set_state_plus_children(cur_item, a:new_rate)
+      let cur_parent_item = s:get_parent(cur_item)
+      if index(parent_items_of_lines, cur_parent_item) == -1
+        call insert(parent_items_of_lines, cur_parent_item)
       endif
-    endfor
-
-  endif
+    endif
+  endfor
 
   for parent_item in parent_items_of_lines
     call s:update_state(parent_item)
   endfor
 
 endfunction "}}}
+
+"Decrement checkbox between [ ] and [X]
+"in the lines of the given range
+function! vimwiki#lst#decrement_cb(from_line, to_line) "{{{
+  let from_item = s:get_corresponding_item(a:from_line)
+  if from_item.type == 0
+    return
+  endif
+
+  "if from_line has CB, decrement it and set all siblings to the same new state
+  let rate_first_line = s:get_rate(from_item)
+  let n=len(g:vimwiki_listsyms_list)
+  let new_rate = max([rate_first_line - 100/(n-1)-1, 0])
+
+  call s:change_cb(a:from_line, a:to_line, new_rate)
+
+endfunction "}}}
+
 "Increment checkbox between [ ] and [X]
 "in the lines of the given range
 function! vimwiki#lst#increment_cb(from_line, to_line) "{{{
@@ -852,31 +860,12 @@ function! vimwiki#lst#increment_cb(from_line, to_line) "{{{
     return
   endif
 
-  let parent_items_of_lines = []
+  "if from_line has CB, increment it and set all siblings to the same new state
+  let rate_first_line = s:get_rate(from_item)
+  let n=len(g:vimwiki_listsyms_list)
+  let new_rate = min([rate_first_line + 100/(n-1)+1, 100])
 
-  if from_item.cb != ''
-
-    "if from_line has CB, toggle it and set all siblings to the same new state
-    let rate_first_line = s:get_rate(from_item)
-    let n=len(g:vimwiki_listsyms_list)
-    let new_rate = min([rate_first_line + 100/(n-1)+1, 100])
-
-    for cur_ln in range(from_item.lnum, a:to_line)
-      let cur_item = s:get_item(cur_ln)
-      if cur_item.type != 0 && cur_item.cb != ''
-        call s:set_state_plus_children(cur_item, new_rate)
-        let cur_parent_item = s:get_parent(cur_item)
-        if index(parent_items_of_lines, cur_parent_item) == -1
-          call insert(parent_items_of_lines, cur_parent_item)
-        endif
-      endif
-    endfor
-
-  endif
-
-  for parent_item in parent_items_of_lines
-    call s:update_state(parent_item)
-  endfor
+  call s:change_cb(a:from_line, a:to_line, new_rate)
 
 endfunction "}}}
 
@@ -887,8 +876,6 @@ function! vimwiki#lst#toggle_cb(from_line, to_line) "{{{
   if from_item.type == 0
     return
   endif
-
-  let parent_items_of_lines = []
 
   if from_item.cb == ''
 
@@ -906,28 +893,19 @@ function! vimwiki#lst#toggle_cb(from_line, to_line) "{{{
       endif
     endfor
 
+    for parent_item in parent_items_of_lines
+      call s:update_state(parent_item)
+    endfor
+
   else
 
     "if from_line has CB, toggle it and set all siblings to the same new state
     let rate_first_line = s:get_rate(from_item)
     let new_rate = rate_first_line == 100 ? 0 : 100
 
-    for cur_ln in range(from_item.lnum, a:to_line)
-      let cur_item = s:get_item(cur_ln)
-      if cur_item.type != 0 && cur_item.cb != ''
-        call s:set_state_plus_children(cur_item, new_rate)
-        let cur_parent_item = s:get_parent(cur_item)
-        if index(parent_items_of_lines, cur_parent_item) == -1
-          call insert(parent_items_of_lines, cur_parent_item)
-        endif
-      endif
-    endfor
+    call s:change_cb(a:from_line, a:to_line, new_rate)
 
   endif
-
-  for parent_item in parent_items_of_lines
-    call s:update_state(parent_item)
-  endfor
 
 endfunction "}}}
 

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -295,6 +295,8 @@ command! -buffer -range -nargs=1 VimwikiChangeSymbolTo call vimwiki#lst#change_m
 command! -buffer -range -nargs=1 VimwikiListChangeSymbolI call vimwiki#lst#change_marker(<line1>, <line2>, <f-args>, 'i')
 command! -buffer -nargs=1 VimwikiChangeSymbolInListTo call vimwiki#lst#change_marker_in_list(<f-args>)
 command! -buffer -range VimwikiToggleListItem call vimwiki#lst#toggle_cb(<line1>, <line2>)
+command! -buffer -range VimwikiIncrementListItem call vimwiki#lst#increment_cb(<line1>, <line2>)
+command! -buffer -range VimwikiDecrementListItem call vimwiki#lst#decrement_cb(<line1>, <line2>)
 command! -buffer -range -nargs=+ VimwikiListChangeLvl call vimwiki#lst#change_level(<line1>, <line2>, <f-args>)
 command! -buffer -range VimwikiRemoveSingleCB call vimwiki#lst#remove_cb(<line1>, <line2>)
 command! -buffer VimwikiRemoveCBInList call vimwiki#lst#remove_cb_in_list()
@@ -444,6 +446,23 @@ nnoremap <silent><script><buffer>
       \ <Plug>VimwikiToggleListItem :VimwikiToggleListItem<CR>
 vnoremap <silent><script><buffer>
       \ <Plug>VimwikiToggleListItem :VimwikiToggleListItem<CR>
+
+if !hasmapto('<Plug>VimwikiIncrementListItem')
+  nmap <silent><buffer> <M-+> <Plug>VimwikiIncrementListItem
+  vmap <silent><buffer> <M-+> <Plug>VimwikiIncrementListItem
+endif
+if !hasmapto('<Plug>VimwikiDecrementListItem')
+  nmap <silent><buffer> <M--> <Plug>VimwikiDecrementListItem
+  vmap <silent><buffer> <M--> <Plug>VimwikiDecrementListItem
+endif
+nnoremap <silent><script><buffer>
+      \ <Plug>VimwikiIncrementListItem :VimwikiIncrementListItem<CR>
+vnoremap <silent><script><buffer>
+      \ <Plug>VimwikiIncrementListItem :VimwikiIncrementListItem<CR>
+nnoremap <silent><script><buffer>
+      \ <Plug>VimwikiDecrementListItem :VimwikiDecrementListItem<CR>
+vnoremap <silent><script><buffer>
+      \ <Plug>VimwikiDecrementListItem :VimwikiDecrementListItem<CR>
 
 if !hasmapto('<Plug>VimwikiDecreaseLvlSingleItem', 'i')
   imap <silent><buffer> <C-D>

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -448,12 +448,12 @@ vnoremap <silent><script><buffer>
       \ <Plug>VimwikiToggleListItem :VimwikiToggleListItem<CR>
 
 if !hasmapto('<Plug>VimwikiIncrementListItem')
-  nmap <silent><buffer> gl+ <Plug>VimwikiIncrementListItem
-  vmap <silent><buffer> gl+ <Plug>VimwikiIncrementListItem
+  nmap <silent><buffer> gln <Plug>VimwikiIncrementListItem
+  vmap <silent><buffer> gln <Plug>VimwikiIncrementListItem
 endif
 if !hasmapto('<Plug>VimwikiDecrementListItem')
-  nmap <silent><buffer> gl- <Plug>VimwikiDecrementListItem
-  vmap <silent><buffer> gl- <Plug>VimwikiDecrementListItem
+  nmap <silent><buffer> glp <Plug>VimwikiDecrementListItem
+  vmap <silent><buffer> glp <Plug>VimwikiDecrementListItem
 endif
 nnoremap <silent><script><buffer>
       \ <Plug>VimwikiIncrementListItem :VimwikiIncrementListItem<CR>

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -448,12 +448,12 @@ vnoremap <silent><script><buffer>
       \ <Plug>VimwikiToggleListItem :VimwikiToggleListItem<CR>
 
 if !hasmapto('<Plug>VimwikiIncrementListItem')
-  nmap <silent><buffer> <M-+> <Plug>VimwikiIncrementListItem
-  vmap <silent><buffer> <M-+> <Plug>VimwikiIncrementListItem
+  nmap <silent><buffer> gl+ <Plug>VimwikiIncrementListItem
+  vmap <silent><buffer> gl+ <Plug>VimwikiIncrementListItem
 endif
 if !hasmapto('<Plug>VimwikiDecrementListItem')
-  nmap <silent><buffer> <M--> <Plug>VimwikiDecrementListItem
-  vmap <silent><buffer> <M--> <Plug>VimwikiDecrementListItem
+  nmap <silent><buffer> gl- <Plug>VimwikiDecrementListItem
+  vmap <silent><buffer> gl- <Plug>VimwikiDecrementListItem
 endif
 nnoremap <silent><script><buffer>
       \ <Plug>VimwikiIncrementListItem :VimwikiIncrementListItem<CR>


### PR DESCRIPTION
[Reopening of  #313…]

This implements Issue #308:
With :VimwikiToggleListItem we can change the status of a listitem between 0% and 100% – but we also include sub states configured in g:vimwiki_listsyms – for now we use them mostly to indicate the status of a item with subitems but it can already be nested, so it is possible to use the inbetween-states also for items without subitems.
This would become easier and more obvious if there are functions and keybindings to increment and decrement the state.

Adds new functions: `vimwiki#lst#increment_cb` & `vimwiki#lst#decrement_cb`
Adds keybinding for them: `gl+` &  `gl-`