### PR TITLE
Escape the 'dot' in extension substitution

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1273,7 +1273,7 @@ function! vimwiki#base#follow_link(split, reuse, move_cursor, ...) "{{{
 
       " remove the extension from the filename if exists, because non-vimwiki
       " markdown files usually include the extension in links
-      let lnk = substitute(lnk, VimwikiGet('ext').'$', '', '')
+      let lnk = substitute(lnk, '\'.VimwikiGet('ext').'$', '', '')
     endif
 
     let current_tab_page = tabpagenr()


### PR DESCRIPTION
This escapes the `.` preceding an extension (e.g. `.wiki`) so that it doesn't accidentally match any character.

For example: `[vimwiki](vimwiki)` was opening the `vi.wiki` page, because of this rule.