### PR TITLE
Allow to specify additional chars for lists

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1455,7 +1455,11 @@ function! s:convert_file(path_html, wikifile) "{{{
     endif
 
     " prepare regexps for lists
-    let s:bullets = '[*-]'
+    if exists("g:vimwiki_additional_bullet_types")
+      let s:bullets = '[*-'. join(keys(g:vimwiki_additional_bullet_types), '') . ']'
+    else
+      let s:bullets = '[*-]'
+    endif
     let s:numbers =
       \'\C\%(#\|\d\+)\|\d\+\.\|[ivxlcdm]\+)\|[IVXLCDM]\+)\|\l\{1,2})\|\u\{1,2})\)'
 

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -1509,11 +1509,15 @@ endfunction "}}}
 
 "misc stuff {{{
 function! vimwiki#lst#setup_marker_infos() "{{{
-  let s:rx_bullet_chars = '['.join(keys(g:vimwiki_bullet_types), '').']\+'
+  let l:bullet_types=g:vimwiki_bullet_types
+  if exists("g:vimwiki_additional_bullet_types")
+    call extend(l:bullet_types, g:vimwiki_additional_bullet_types)
+  endif
+  let s:rx_bullet_chars = '['.join(keys(l:bullet_types), '').']\+'
 
   let s:multiple_bullet_chars = []
-  for i in keys(g:vimwiki_bullet_types)
-    if g:vimwiki_bullet_types[i] == 1
+  for i in keys(l:bullet_types)
+    if l:bullet_types[i] == 1
       call add(s:multiple_bullet_chars, i)
     endif
   endfor
@@ -1529,8 +1533,8 @@ function! vimwiki#lst#setup_marker_infos() "{{{
         \ 'a': '\l\{1,2}', 'A': '\u\{1,2}'}
 
   "create regexp for bulleted list items
-  let g:vimwiki_rxListBullet = join( map(keys(g:vimwiki_bullet_types),
-        \'vimwiki#u#escape(v:val).repeat("\\+", g:vimwiki_bullet_types[v:val])'
+  let g:vimwiki_rxListBullet = join( map(keys(l:bullet_types),
+        \'vimwiki#u#escape(v:val).repeat("\\+", l:bullet_types[v:val])'
         \ ) , '\|')
 
   "create regex for numbered list items

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1552,6 +1552,10 @@ after a list using letters or vice versa, Vimwiki will get confused because
 it cannot distinguish which is which (at least if the types are both upper
 case or both lower case).
 
+You can add additional list-types in your vimrc by setting the variable 
+  let g:vimwiki_additional_bullet_types = { "→": 0}
+Corresponding mapings will not be set.
+
 See |vimwiki_glstar|, |vimwiki_gl#| |vimwiki_gl-|, |vimwiki_gl-|,
 |vimwiki_gl1|, |vimwiki_gla|, |vimwiki_glA|, |vimwiki_gli|, |vimwiki_glI|
 


### PR DESCRIPTION
I'd like to use additional characters for the bullets of lists especially unicode-chars like '→':
→ foo
→ bar
→ blub

This patch allows to set a variable g:vimwiki_additional_bullet_types to do so.
In HTML-export they appear as normal bullets and it does create keybindings like gl<char> for those since this would be nosense for chars not on the keyboard.