### PR TITLE
WIP: Add License-File

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2008-2010 Maxim Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1455,7 +1455,11 @@ function! s:convert_file(path_html, wikifile) "{{{
     endif
 
     " prepare regexps for lists
-    let s:bullets = '[*-]'
+    if exists("g:vimwiki_additional_bullet_types")
+      let s:bullets = '[*-'. join(keys(g:vimwiki_additional_bullet_types), '') . ']'
+    else
+      let s:bullets = '[*-]'
+    endif
     let s:numbers =
       \'\C\%(#\|\d\+)\|\d\+\.\|[ivxlcdm]\+)\|[IVXLCDM]\+)\|\l\{1,2})\|\u\{1,2})\)'
 

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -1509,11 +1509,15 @@ endfunction "}}}
 
 "misc stuff {{{
 function! vimwiki#lst#setup_marker_infos() "{{{
-  let s:rx_bullet_chars = '['.join(keys(g:vimwiki_bullet_types), '').']\+'
+  let l:bullet_types=g:vimwiki_bullet_types
+  if exists("g:vimwiki_additional_bullet_types")
+    call extend(l:bullet_types, g:vimwiki_additional_bullet_types)
+  endif
+  let s:rx_bullet_chars = '['.join(keys(l:bullet_types), '').']\+'
 
   let s:multiple_bullet_chars = []
-  for i in keys(g:vimwiki_bullet_types)
-    if g:vimwiki_bullet_types[i] == 1
+  for i in keys(l:bullet_types)
+    if l:bullet_types[i] == 1
       call add(s:multiple_bullet_chars, i)
     endif
   endfor
@@ -1529,8 +1533,8 @@ function! vimwiki#lst#setup_marker_infos() "{{{
         \ 'a': '\l\{1,2}', 'A': '\u\{1,2}'}
 
   "create regexp for bulleted list items
-  let g:vimwiki_rxListBullet = join( map(keys(g:vimwiki_bullet_types),
-        \'vimwiki#u#escape(v:val).repeat("\\+", g:vimwiki_bullet_types[v:val])'
+  let g:vimwiki_rxListBullet = join( map(keys(l:bullet_types),
+        \'vimwiki#u#escape(v:val).repeat("\\+", l:bullet_types[v:val])'
         \ ) , '\|')
 
   "create regex for numbered list items

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1552,6 +1552,10 @@ after a list using letters or vice versa, Vimwiki will get confused because
 it cannot distinguish which is which (at least if the types are both upper
 case or both lower case).
 
+You can add additional list-types in your vimrc by setting the variable 
+  let g:vimwiki_additional_bullet_types = { "→": 0}
+Corresponding mapings will not be set.
+
 See |vimwiki_glstar|, |vimwiki_gl#| |vimwiki_gl-|, |vimwiki_gl-|,
 |vimwiki_gl1|, |vimwiki_gla|, |vimwiki_glA|, |vimwiki_gli|, |vimwiki_glI|
 


### PR DESCRIPTION
Vimwiki currently has not License-File, and the license is only mentioned in the help-file. We should change this.

Also it would be ideal to add a license header on top of every source-code-file.

Still open is the question: who should be named as primary copyright-holder and for which years?
Probably something like:
```
2008-2013 Maxim Kim
2013-2017 EinfachToll/Your real name
```

See also #386.