### PR TITLE
Add License-File and update contributers-list

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2008-2010 Maxim Kim
+              2013-2017 Daniel Schemala
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2008-2010 Maxim Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2854,6 +2854,19 @@ Contributors and their Github usernames in roughly chronological order:
     - @wangzq
     - Jinzhou Zhang (@lotabout)
     - Michael Riley (@optik-aper)
+    - Irfan Sharif (@irfansharif)
+    - John Conroy (@jconroy77)
+    - Christian Rondeau (@christianrondeau)
+    - Alex Thorne (@thornecc)
+    - Shafqat Bhuiyan (@priomsrb)
+    - Bradley Cicenas (@bcicen)
+    - Michael Thessel (@MichaelThessel)
+    - Michael F. Schönitzer (@nudin)
+    - @sqlwwx
+    - Guilherme Salazar (@salazar)
+    - Daniel Trnka (@trnila)
+    - Yuchen Pei (@ycpei)
+    - @maqiv
 
 
 ==============================================================================

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3114,7 +3114,7 @@ http://code.google.com/p/vimwiki/issues/list
 ==============================================================================
 16. License                                                  *vimwiki-license*
 
-The MIT Licence
+The MIT License
 http://www.opensource.org/licenses/mit-license.php
 
 Copyright (c) 2008-2010 Maxim Kim

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3105,6 +3105,7 @@ The MIT Licence
 http://www.opensource.org/licenses/mit-license.php
 
 Copyright (c) 2008-2010 Maxim Kim
+              2013-2017 Daniel Schemala
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Vimwiki currently has not License-File, and the license is only mentioned in the help-file. We should change this.

Also it would be ideal to add a license header on top of every source-code-file.

Still open is the question: who should be named as primary copyright-holder and for which years?
Probably something like:

```
2008-2013 Maxim Kim
2013-2017 EinfachToll/Your real name
```

See also #386.