### PR TITLE
Fix link generation around apostrophes; issue #394

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1996,7 +1996,7 @@ function! s:normalize_link_syntax_v() " {{{
       let sub = s:normalize_link_in_diary(@")
     else
       let sub = substitute(g:vimwiki_WikiLinkTemplate1,
-            \ '__LinkUrl__', '\=' . "'" . @" . "'", '')
+            \ '__LinkUrl__', @", '')
     endif
 
     " Put substitution in register " and change text


### PR DESCRIPTION
I modified the `s:normalize_link_syntax_v()` function in `autoload/vimwiki/base.vim`. This function contains a call to `substitute()` with an argument of `'\=' . "'" . @" . "'"`, which interprets the contents of `@"` as a an expression. This is normally fine, but when `@"` has an apostrophe in it (e.g. *foo'bar*), it doesn't evaluate to a valid expression (e.g. *'foo'bar'*).

So I removed the `'\='`, etc., and just have `substitute` operate on the contents of the register directly. This works for all the cases I tested, and doesn't break anything as far as I can tell. If there's a good reason the `'\='`, etc., should stay in, let me know and I'll find a different way. 