### PR TITLE
Change directory when switching to another wiki

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1337,6 +1337,7 @@ function! vimwiki#base#goto_index(wnum, ...) "{{{
         \ VimwikiGet('ext', idx),
         \ '')
   call vimwiki#base#setup_buffer_state(idx)
+  cd %:h
 endfunction "}}}
 
 " vimwiki#base#delete_link


### PR DESCRIPTION
I have multiple wikis. When I switch to another wiki via `<Leader>ws` or `<Plug>VimwikiUISelect` the working directory does not change. This is problematic because I often use `:fin` to jump to another wiki file.

This patch changes the working directory to the directory where is wiki is in.