### PR TITLE
Fix bug #338

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -676,6 +676,7 @@ function! s:jump_to_anchor(anchor) "{{{
 
   let segments = split(anchor, '#', 0)
   for segment in segments
+    let segment = substitute(segment, "'", "''", 'g')
 
     let anchor_header = substitute(
           \ g:vimwiki_{VimwikiGet('syntax')}_header_match,


### PR DESCRIPTION
Fixing:
#338: Apostrophe in anchor caused error

This is similar to #405.