### PR TITLE
Update argument handling in diary#make_note

### DIFF
--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -174,16 +174,15 @@ function! vimwiki#diary#make_note(wnum, ...) "{{{
 
   call vimwiki#path#mkdir(VimwikiGet('path', idx).VimwikiGet('diary_rel_path', idx))
 
+  let cmd = 'edit'
   if a:0
     if a:1 == 1
       let cmd = 'tabedit'
-    elseif a:2 == 2
+    elseif a:1 == 2
       let cmd = 'split'
-    elseif a:3 == 3
+    elseif a:1 == 3
       let cmd = 'vsplit'
     endif
-  else
-    let cmd = 'edit'
   endif
   if a:0>1
     let link = 'diary:'.a:2


### PR DESCRIPTION
Fix an "Undefined variable: a:3" error that occurs when attempting to open
a diary page with Calendar.vim.
