### PR TITLE
Fix path resolution of diary notes

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -253,7 +253,12 @@ endfunction "}}}
 
 " vimwiki#base#open_link
 function! vimwiki#base#open_link(cmd, link, ...) "{{{
-  let link_infos = vimwiki#base#resolve_link(a:link)
+  let link_infos = {}
+  if a:0
+    let link_infos = vimwiki#base#resolve_link(a:link, a:1)
+  else
+    let link_infos = vimwiki#base#resolve_link(a:link)
+  endif
 
   if link_infos.filename == ''
     echomsg 'Vimwiki Error: Unable to resolve link!'


### PR DESCRIPTION
## What does vimwiki do?

The vimwiki fogets `wnum` passed to `vimwki#diary#make_note` before opens a diary note.
The vimwiki opens a default diary note path, therefore, even if we configured `g:vimwiki_list` and passed `[count]` to `<Plug>VimwikiMakeDiaryNote`.

## What do I expect?

I expect that the vimwiki treats `[count]` and opens a diary note associated to the number of `[count]`.

## What is a problem?

The problem is that we cannot configure the paths of diary notes via `g:vimwiki_list`.

## What will this commit do?

This commit will fix the problem by allowing `vimwki#base#open_link` to use an already resolved diary path in `vimwiki#diary#make_note`.