### PR TITLE
Multiline bullet-lists, HTML comments and TODO

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -164,7 +164,7 @@ function! s:populate_global_variables()
   let g:vimwiki_global_vars.rxWikiInclSuffix1 = g:vimwiki_global_vars.rxWikiInclArgs.
         \ g:vimwiki_global_vars.rxWikiInclSuffix
 
-  let g:vimwiki_global_vars.rxTodo = '\C\%(TODO:\|DONE:\|STARTED:\|FIXME:\|FIXED:\|XXX:\)'
+  let g:vimwiki_global_vars.rxTodo = '\C\<\%(TODO\|DONE\|STARTED\|FIXME\|FIXED\|XXX\)\>'
 
   " default colors when headers of different levels are highlighted differently
   " not making it yet another option; needed by ColorScheme autocommand

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -237,7 +237,7 @@ execute 'syntax match VimwikiListTodo /'.vimwiki#vars#get_syntaxlocal('rxListIte
 if vimwiki#vars#get_global('hl_cb_checked') == 1
   execute 'syntax match VimwikiCheckBoxDone /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
         \ .'\s*\['.vimwiki#vars#get_syntaxlocal('listsyms_list')[-1]
-        \ .'\]\s.*$/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
+        \ .'\]\s[^\n]*\(\n\s*[^-*+#% \t\n][^\n]*\)*/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell,VimwikiTodo'
 elseif vimwiki#vars#get_global('hl_cb_checked') == 2
   execute 'syntax match VimwikiCheckBoxDone /'.vimwiki#vars#get_syntaxlocal('rxListItemAndChildren').'/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
 endif

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -295,7 +295,7 @@ if vimwiki#vars#get_global('valid_html_tags') != ''
   execute 'syntax match VimwikiItalic #\c<i>.\{-}</i># contains=VimwikiHTMLTag'
   execute 'syntax match VimwikiUnderline #\c<u>.\{-}</u># contains=VimwikiHTMLTag'
 
-  execute 'syntax match VimwikiComment /'.vimwiki#vars#get_syntaxlocal('rxComment').'/ contains=@Spell'
+  execute 'syntax match VimwikiComment /'.vimwiki#vars#get_syntaxlocal('rxComment').'/ contains=@Spell,VimwikiTodo'
 endif
 
 " tags

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -237,7 +237,7 @@ execute 'syntax match VimwikiListTodo /'.vimwiki#vars#get_syntaxlocal('rxListIte
 if vimwiki#vars#get_global('hl_cb_checked') == 1
   execute 'syntax match VimwikiCheckBoxDone /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
         \ .'\s*\['.vimwiki#vars#get_syntaxlocal('listsyms_list')[-1]
-        \ .'\]\s[^\n]*\(\n\s*[^-*+#% \t\n][^\n]*\)*/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell,VimwikiTodo'
+        \ .'\]\s.*$/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
 elseif vimwiki#vars#get_global('hl_cb_checked') == 2
   execute 'syntax match VimwikiCheckBoxDone /'.vimwiki#vars#get_syntaxlocal('rxListItemAndChildren').'/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
 endif

--- a/syntax/vimwiki_markdown.vim
+++ b/syntax/vimwiki_markdown.vim
@@ -87,7 +87,7 @@ let s:markdown_syntax.rxPreEnd = '```'
 let s:markdown_syntax.rxMathStart = '\$\$'
 let s:markdown_syntax.rxMathEnd = '\$\$'
 
-let s:markdown_syntax.rxComment = '^\s*%%.*$'
+let s:markdown_syntax.rxComment = '^\s*%%.*$\|<!--[^>]*-->'
 let s:markdown_syntax.rxTags = '\%(^\|\s\)\@<=:\%([^:[:space:]]\+:\)\+\%(\s\|$\)\@='
 
 let s:markdown_syntax.header_search = '^\s*\(#\{1,6}\)\([^#].*\)$'


### PR DESCRIPTION
This patch changes a couple of little details. I split it in 3 commits, but maybe I should have split it in 3 patches? Anyway, here they are:

1. Allow HTML-style comment syntax, such as `<!-- my comment -->`, which is officially part of markdown.

2. Treat highlighted bullet-point entries spanning multiple lines as a single entity. This happens when we have a checked [X] item whose text continues on the next line.

3. Avoid matching "TODO" on word boundaries (e.g. does not match "xTODO:"). Also, with this patch, the ":" after TODO is not required (so e.g. "[TODO]" also works).