### PR TITLE
fix diary list, indent according to list_margin

### DIFF
--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -143,11 +143,11 @@ function! s:format_diary() "{{{
         if empty(cap)
           let entry = substitute(vimwiki#vars#get_global('WikiLinkTemplate1'), '__LinkUrl__', fl, '')
           let entry = substitute(entry, '__LinkDescription__', cap, '')
-          call add(result, repeat(' ', &sw).'* '.entry)
+          call add(result, repeat(' ', vimwiki#lst#get_list_margin()).'* '.entry)
         else
           let entry = substitute(vimwiki#vars#get_global('WikiLinkTemplate2'), '__LinkUrl__', fl, '')
           let entry = substitute(entry, '__LinkDescription__', cap, '')
-          call add(result, repeat(' ', &sw).'* '.entry)
+          call add(result, repeat(' ', vimwiki#lst#get_list_margin()).'* '.entry)
         endif
       endfor
 


### PR DESCRIPTION
The list of diary entries now is not indented according to the vim
`shiftwidth` setting, but gets the indentation from list_margin (as is
the case for `vimwiki#base#generate_links`).