### PR TITLE
Add VimwikiMakeTomorrowDiaryNote

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -213,6 +213,22 @@ See also |:VimwikiTabMakeDiaryNote|
 <
 See also |:VimwikiMakeYesterdayDiaryNote|
 
+[count]<Leader>w<Leader>m or <Plug>VimwikiMakeTomorrowDiaryNote
+        Open diary wiki-file for tomorrow of the [count]'s wiki.
+
+        <Leader>w<Leader>m opens diary wiki-file for tomorrow in the first
+        wiki from |g:vimwiki_list|.
+        1<Leader>w<Leader>m as above opens diary wiki-file for tomorrow in
+        the first wiki from |g:vimwiki_list|.
+        2<Leader>w<Leader>m opens diary wiki-file for tomorrow in the second
+        wiki from |g:vimwiki_list|.
+        3<Leader>w<Leader>m opens diary wiki-file for tomorrow in the third
+        wiki from |g:vimwiki_list|.
+        etc.
+        To remap: >
+        :nmap <Leader>dm <Plug>VimwikiMakeTomorrowDiaryNote
+<
+See also |:VimwikiMakeTomorrowDiaryNote|
 
 ------------------------------------------------------------------------------
 3.2. Local mappings
@@ -607,6 +623,8 @@ il                      A single list item.
 *:VimwikiMakeYesterdayDiaryNote*
     Open diary wiki-file for yesterday of the current wiki.
 
+*:VimwikiMakeTomorrowDiaryNote*
+    Open diary wiki-file for tomorrow of the current wiki.
 
 ------------------------------------------------------------------------------
 4.2. Local commands                                   *vimwiki-local-commands*

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -247,6 +247,8 @@ command! -count=1 VimwikiTabMakeDiaryNote
       \ call vimwiki#diary#make_note(v:count1, 1)
 command! -count=1 VimwikiMakeYesterdayDiaryNote
       \ call vimwiki#diary#make_note(v:count1, 0, vimwiki#diary#diary_date_link(localtime() - 60*60*24))
+command! -count=1 VimwikiMakeTomorrowDiaryNote
+      \ call vimwiki#diary#make_note(v:count1, 0, vimwiki#diary#diary_date_link(localtime() + 60*60*24))
 
 command! VimwikiDiaryGenerateLinks
       \ call vimwiki#diary#generate_diary_section()
@@ -296,6 +298,12 @@ if !hasmapto('<Plug>VimwikiMakeYesterdayDiaryNote')
 endif
 nnoremap <unique><script> <Plug>VimwikiMakeYesterdayDiaryNote
       \ :VimwikiMakeYesterdayDiaryNote<CR>
+
+if !hasmapto('<Plug>VimwikiMakeTomorrowDiaryNote')
+  exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>m <Plug>VimwikiMakeTomorrowDiaryNote'
+endif
+nnoremap <unique><script> <Plug>VimwikiMakeTomorrowDiaryNote
+      \ :VimwikiMakeTomorrowDiaryNote<CR>
 
 "}}}
 


### PR DESCRIPTION
This change introduces a new global diary command "VimwikiMakeTomorrowDiaryNote". 
The purpose is the same as VimwikiMakeYesterdayDiaryNote, except it allows
you to create a diary note in the future. I find this useful when trying to plan my day the night before.