### PR TITLE
fix missing custom_wiki2html_args default key/value bug when using custom_wiki2html function

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1397,7 +1397,7 @@ function! vimwiki#html#CustomWiki2HTML(path, wikifile, force) "{{{
       \ (len(vimwiki#vars#get_wikilocal('template_default')) > 0 ? vimwiki#vars#get_wikilocal('template_default') : '-'). ' '.
       \ (len(vimwiki#vars#get_wikilocal('template_ext')) > 0 ? vimwiki#vars#get_wikilocal('template_ext') : '-'). ' '.
       \ (len(vimwiki#vars#get_bufferlocal('subdir')) > 0 ? shellescape(s:root_path(vimwiki#vars#get_bufferlocal('subdir'))) : '-'). ' '.
-      \ (len(vimwiki#vars#get_global('custom_wiki2html_args')) > 0 ? vimwiki#vars#get_global('custom_wiki2html_args') : '-'))
+      \ (len(vimwiki#vars#get_wikilocal('custom_wiki2html_args')) > 0 ? vimwiki#vars#get_wikilocal('custom_wiki2html_args') : '-'))
 endfunction " }}}
 
 function! s:convert_file(path_html, wikifile) "{{{

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -187,6 +187,7 @@ function! s:populate_wikilocal_options()
         \ 'automatic_nested_syntaxes': 1,
         \ 'css_name': 'style.css',
         \ 'custom_wiki2html': '',
+        \ 'custom_wiki2html_args': '',
         \ 'diary_header': 'Diary',
         \ 'diary_index': 'diary',
         \ 'diary_rel_path': 'diary/',


### PR DESCRIPTION
According to vimwiki doc, `custom_wiki2html_args` should be a wikilocal var, and it's missing in `default_values` too. So, when using `custom_wiki2html`, it will cause errors, and user's config will not take effect.
![image](https://user-images.githubusercontent.com/4990592/38615501-7a584796-3dc3-11e8-9f18-6847456eebbc.png)
