### PR TITLE
Allow to specify additional chars for lists

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1482,7 +1482,11 @@ function! s:convert_file(path_html, wikifile)
     endif
 
     " prepare regexps for lists
-    let s:bullets = '[*-]'
+    if exists("g:vimwiki_additional_bullet_types")
+      let s:bullets = '[*-'. join(keys(g:vimwiki_additional_bullet_types), '') . ']'
+    else
+      let s:bullets = '[*-]'
+    endif
     let s:numbers = '\C\%(#\|\d\+)\|\d\+\.\|[ivxlcdm]\+)\|[IVXLCDM]\+)\|\l\{1,2})\|\u\{1,2})\)'
 
     for line in lsource

--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1483,7 +1483,7 @@ function! s:convert_file(path_html, wikifile)
 
     " prepare regexps for lists
     if exists("g:vimwiki_additional_bullet_types")
-      let s:bullets = '[*-'. join(keys(g:vimwiki_additional_bullet_types), '') . ']'
+      let s:bullets = '[*-'. join(g:vimwiki_additional_bullet_types, '') . ']'
     else
       let s:bullets = '[*-]'
     endif

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -338,12 +338,16 @@ function! vimwiki#vars#populate_syntax_vars(syntax)
         \ '^\s*'.g:vimwiki_syntax_variables[a:syntax].rxMathEnd.'\s*$'
 
   " list stuff
+  let l:bullet_types = g:vimwiki_syntax_variables[a:syntax].bullet_types
+  if exists("g:vimwiki_additional_bullet_types")
+    call extend(l:bullet_types, g:vimwiki_additional_bullet_types)
+  endif
   let g:vimwiki_syntax_variables[a:syntax].rx_bullet_chars =
-        \ '['.join(g:vimwiki_syntax_variables[a:syntax].bullet_types, '').']\+'
+        \ '['.join(l:bullet_types, '').']\+'
 
   let g:vimwiki_syntax_variables[a:syntax].multiple_bullet_chars =
         \ g:vimwiki_syntax_variables[a:syntax].recurring_bullets
-        \ ? g:vimwiki_syntax_variables[a:syntax].bullet_types : []
+        \ ? l:bullet_types : []
 
   let g:vimwiki_syntax_variables[a:syntax].number_kinds = []
   let g:vimwiki_syntax_variables[a:syntax].number_divisors = ''
@@ -356,9 +360,9 @@ function! vimwiki#vars#populate_syntax_vars(syntax)
         \ 'a': '\l\{1,2}', 'A': '\u\{1,2}'}
 
   "create regexp for bulleted list items
-  if !empty(g:vimwiki_syntax_variables[a:syntax].bullet_types)
+  if !empty(l:bullet_types)
     let g:vimwiki_syntax_variables[a:syntax].rxListBullet =
-          \ join( map(g:vimwiki_syntax_variables[a:syntax].bullet_types,
+          \ join( map(l:bullet_types,
           \'vimwiki#u#escape(v:val).'
           \ .'repeat("\\+", g:vimwiki_syntax_variables[a:syntax].recurring_bullets)'
           \ ) , '\|')

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1605,6 +1605,10 @@ if you have the strange idea of putting a list with Romanian numerals right
 after a list using letters or vice versa, Vimwiki will get confused because
 it cannot distinguish which is which (at least if the types are both upper
 case or both lower case).
+ 
+You can add additional list-types in your vimrc by setting the variable 
+  let g:vimwiki_additional_bullet_types = [ "→", "•" ]
+Corresponding mappings will not be set automatically.
 
 See |vimwiki_glstar|, |vimwiki_gl#| |vimwiki_gl-|, |vimwiki_gl-|,
 |vimwiki_gl1|, |vimwiki_gla|, |vimwiki_glA|, |vimwiki_gli|, |vimwiki_glI|


### PR DESCRIPTION
Reimplementation of #390 (41e653718e29933dd9559e546b859158cc87804a).

From the original:
I'd like to use additional characters for the bullets of lists especially unicode-chars like '→':
→ foo
→ bar
→ blub

This patch allows to set a variable g:vimwiki_additional_bullet_types to do so.
In HTML-export they appear as normal bullets and it does create keybindings like gl for those since this would be nosense for chars not on the keyboard.