### PR TITLE
setting script variable for autowrite_all, was missing before

### DIFF
--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -13,6 +13,7 @@ let g:loaded_vimwiki = 1
 let s:old_cpo = &cpo
 set cpo&vim
 
+let s:vimwiki_autowriteall_saved = g:vimwiki_autowriteall
 
 " this is called when the cursor leaves the buffer
 function! s:setup_buffer_leave()


### PR DESCRIPTION
Vim complains about `s:vimwiki_autowriteall_saved` not being set when `g:vimwiki_autowriteall` has been previous set during loading of plugin.