### PR TITLE
Fix no g:autowrite_all defined error

### DIFF
--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -13,7 +13,9 @@ let g:loaded_vimwiki = 1
 let s:old_cpo = &cpo
 set cpo&vim
 
-let s:vimwiki_autowriteall_saved = g:vimwiki_autowriteall
+if exists("g:vimwiki_autowriteall")
+  let s:vimwiki_autowriteall_saved = g:vimwiki_autowriteall
+endif
 
 " this is called when the cursor leaves the buffer
 function! s:setup_buffer_leave()


### PR DESCRIPTION
For the pull request #492, may report no `g:vimwiki_autowriteall` not defined.
Add protection to avoid the error.