### PR TITLE
Added optional sub-captions to diary index.

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -253,6 +253,7 @@ function! s:populate_wikilocal_options()
         \ 'diary_header': {'type': type(''), 'default': 'Diary', 'min_length': 1},
         \ 'diary_index': {'type': type(''), 'default': 'diary', 'min_length': 1},
         \ 'diary_rel_path': {'type': type(''), 'default': 'diary/', 'min_length': 1},
+        \ 'diary_caption_level': {'type': type(0), 'default': 0, 'min': -1, 'max': 6},
         \ 'diary_sort': {'type': type(''), 'default': 'desc', 'possible_values': ['asc', 'desc']},
         \ 'ext': {'type': type(''), 'default': '.wiki', 'min_length': 1},
         \ 'index': {'type': type(''), 'default': 'index', 'min_length': 1},
@@ -443,6 +444,9 @@ function! vimwiki#vars#populate_syntax_vars(syntax)
       let g:vimwiki_syntax_variables[a:syntax]['rxH'.i] =
             \ '^\s*'.header_symbol.'\{'.i.'}[^'.header_symbol.'].*[^'.header_symbol.']'
             \ .header_symbol.'\{'.i.'}\s*$'
+      let g:vimwiki_syntax_variables[a:syntax]['rxH'.i.'_Text'] =
+            \ '^\s*'.header_symbol.'\{'.i.'}\zs[^'.header_symbol.'].*[^'.header_symbol.']\ze'
+            \ .header_symbol.'\{'.i.'}\s*$'
       let g:vimwiki_syntax_variables[a:syntax]['rxH'.i.'_Start'] =
             \ '^\s*'.header_symbol.'\{'.i.'}[^'.header_symbol.'].*[^'.header_symbol.']'
             \ .header_symbol.'\{'.i.'}\s*$'
@@ -459,6 +463,8 @@ function! vimwiki#vars#populate_syntax_vars(syntax)
             \ repeat(header_symbol, i).' __Header__'
       let g:vimwiki_syntax_variables[a:syntax]['rxH'.i] =
             \ '^\s*'.header_symbol.'\{'.i.'}[^'.header_symbol.'].*$'
+      let g:vimwiki_syntax_variables[a:syntax]['rxH'.i.'_Text'] =
+            \ '^\s*'.header_symbol.'\{'.i.'}\zs[^'.header_symbol.'].*\ze$'
       let g:vimwiki_syntax_variables[a:syntax]['rxH'.i.'_Start'] =
             \ '^\s*'.header_symbol.'\{'.i.'}[^'.header_symbol.'].*$'
       let g:vimwiki_syntax_variables[a:syntax]['rxH'.i.'_End'] =
@@ -849,4 +855,3 @@ endfunction
 function! vimwiki#vars#number_of_wikis()
   return len(g:vimwiki_wikilocal_vars) - 1
 endfunction
-

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2244,6 +2244,26 @@ Description~
 Sort links in a diary index page.
 
 
+*vimwiki-option-diary_caption_level*
+------------------------------------------------------------------------------
+Key                   Default value~
+diary_caption_level   0
+
+Description~
+Controls the presence of captions in the diary index linking to headers within
+the diary pages.
+
+Possible values:
+-1:  No headers are read from the diary page.
+ 0:  The first header from the diary page is used as the caption.
+       There are no sub-captions.
+ 1:  Captions are created for headers of level 1 in the diary page.
+ 2:  Captions are created for headers up to level 2 in the diary page.
+ etc.
+
+When the value is >= 1, the primary caption of each diary page is set to the
+first header read from that page if it is the unique lowest-level header.
+
 *vimwiki-option-custom_wiki2html*
 ------------------------------------------------------------------------------
 Key               Default value~


### PR DESCRIPTION
Added the option 'diary_caption_level'.
At -1 (the default) the diary index is the same as before.

At level 1, the diary page links have no caption but have a sub-list of
captions linking to the individual top-level headers within the diary
page.

Example:
```
=== April ===
  * [[2018-04-30]]
    - [[2018-04-30#My Section|My Section]]
  * [[2018-04-27]]
    - [[2018-04-27#Some Section|Some Section]]
    - [[2018-04-27#Another Section|Another Section]]
```

At level 2, the main caption is the first top-level header and
sub-captions link to 2nd-level headers.

Example:
```
=== April ===
  * [[2018-04-30|My Section]]
    - [[2018-04-30#My Subsection|My Subsection]]
  * [[2018-04-27|Some Section]]
    - [[2018-04-27#Part 1|Part 1]]
    - [[2018-04-27#Part 2|Part 2]]
```

Inspired by: https://github.com/vimwiki/vimwiki/issues/154#issuecomment-159900916
Also related: https://github.com/vimwiki/vimwiki/pull/30