### PR TITLE
Add a version that shows the version or commit

### DIFF
--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -12,7 +12,7 @@ let g:loaded_vimwiki = 1
 " Set to version number for release, otherwise -1 for dev-branch
 let s:plugin_vers = -1
 
-" Get the plugin the script is installed in
+" Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')
 
 let s:old_cpo = &cpo
@@ -191,7 +191,7 @@ function! s:set_windowlocal_options()
 endfunction
 
 
-function!  vimwiki#get_version()
+function! s:get_version()
   if s:plugin_vers != -1
     echo "Stable version: " . s:plugin_vers
   else
@@ -301,7 +301,7 @@ command! -count=1 VimwikiMakeTomorrowDiaryNote
 command! VimwikiDiaryGenerateLinks
       \ call vimwiki#diary#generate_diary_section()
 
-command! VimwikiShowVersion call vimwiki#get_version()
+command! VimwikiShowVersion call s:get_version()
 
 
 

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -9,6 +9,11 @@ if exists("g:loaded_vimwiki") || &cp
 endif
 let g:loaded_vimwiki = 1
 
+" Set to version number for release, otherwise -1 for dev-branch
+let s:plugin_vers = -1
+
+" Get the plugin the script is installed in
+let s:plugin_dir = expand('<sfile>:p:h:h')
 
 let s:old_cpo = &cpo
 set cpo&vim
@@ -186,6 +191,23 @@ function! s:set_windowlocal_options()
 endfunction
 
 
+function!  vimwiki#get_version()
+  if s:plugin_vers != -1
+    echo "Stable version: " . s:plugin_vers
+  else
+    let a:plugin_rev    = system("git --git-dir " . s:plugin_dir . "/.git rev-parse --short HEAD")
+    let a:plugin_branch = system("git --git-dir " . s:plugin_dir . "/.git rev-parse --abbrev-ref HEAD")
+    let a:plugin_date   = system("git --git-dir " . s:plugin_dir . "/.git show -s --format=%ci")
+    if v:shell_error == 0
+      echo "Branch: " . a:plugin_branch
+      echo "Revision: " . a:plugin_rev
+      echo "Date: " . a:plugin_date
+    else
+      echo "Unknown version"
+    endif
+  endif
+endfunction
+
 
 
 " Initialization of Vimwiki starts here. Make sure everything below does not
@@ -278,6 +300,8 @@ command! -count=1 VimwikiMakeTomorrowDiaryNote
 
 command! VimwikiDiaryGenerateLinks
       \ call vimwiki#diary#generate_diary_section()
+
+command! VimwikiShowVersion call vimwiki#get_version()
 
 
 


### PR DESCRIPTION
The Idea is to provide the user a simple command to get the current version number or if he cloned the dev-branch the revision id.
For a release `s:plugin_vers` would be set to the version number, for example "2.4", while it would be set to -1 in the dev-branch.