### PR TITLE
Add support for Markdown link extensions

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -168,6 +168,7 @@ function! s:read_global_settings_from_user()
         \ 'listsyms': {'type': type(''), 'default': ' .oOX', 'min_length': 2},
         \ 'listsym_rejected': {'type': type(''), 'default': '-', 'length': 1},
         \ 'map_prefix': {'type': type(''), 'default': '<Leader>w'},
+        \ 'markdown_link_ext': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'menu': {'type': type(''), 'default': 'Vimwiki'},
         \ 'table_auto_fmt': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'table_mappings': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
@@ -689,10 +690,17 @@ function! s:populate_extra_markdown_vars()
   let mkd_syntax.rxWeblink1Prefix = '['
   let mkd_syntax.rxWeblink1Suffix = ')'
   let mkd_syntax.rxWeblink1Separator = ']('
+  let mkd_syntax.rxWeblink1Ext = ''
+  if vimwiki#vars#get_global('markdown_link_ext')
+    let mkd_syntax.rxWeblink1Ext = vimwiki#vars#get_wikilocal('ext')
+  endif
   " [DESCRIPTION](URL)
   let mkd_syntax.Weblink1Template = mkd_syntax.rxWeblink1Prefix . '__LinkDescription__'.
-        \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'.
+        \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'. mkd_syntax.rxWeblink1Ext.
         \ mkd_syntax.rxWeblink1Suffix
+  " [DESCRIPTION](ANCHOR)
+  let mkd_syntax.Weblink2Template = mkd_syntax.rxWeblink1Prefix . '__LinkDescription__'.
+        \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'. mkd_syntax.rxWeblink1Suffix
 
   let valid_chars = '[^\\]'
 
@@ -705,8 +713,8 @@ function! s:populate_extra_markdown_vars()
   " 1. [DESCRIPTION](URL)
   " 1a) match [DESCRIPTION](URL)
   let mkd_syntax.rxWeblink1 = mkd_syntax.rxWeblink1Prefix.
-        \ mkd_syntax.rxWeblink1Url . mkd_syntax.rxWeblink1Separator.
-        \ mkd_syntax.rxWeblink1Descr . mkd_syntax.rxWeblink1Suffix
+        \ mkd_syntax.rxWeblink1Descr . mkd_syntax.rxWeblink1Separator.
+        \ mkd_syntax.rxWeblink1Url . mkd_syntax.rxWeblink1Suffix
   " 1b) match URL within [DESCRIPTION](URL)
   let mkd_syntax.rxWeblink1MatchUrl = mkd_syntax.rxWeblink1Prefix.
         \ mkd_syntax.rxWeblink1Descr. mkd_syntax.rxWeblink1Separator.

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2554,6 +2554,19 @@ Default: 1
 
 
 ------------------------------------------------------------------------------
+*g:vimwiki_markdown_link_ext*
+
+Append wiki file extension to links in Markdown. This is needed for
+compatibility with other Markdown tools.
+
+Value           Description~
+0               Do not append wiki file extension.
+1               Append wiki file extension.
+
+Default: 0
+
+
+------------------------------------------------------------------------------
 *VimwikiLinkHandler*
 
 A customizable link handler can be defined to override Vimwiki's behavior when


### PR DESCRIPTION
This PR is an updated version of #204, which adds support for appending file extensions in Markdown links. This is needed to view wiki files using Markdown viewers such as Gollum and MDwiki. By default, existing behavior is preserved.