### PR TITLE
Add option to automatically generate diary index

### DIFF
--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -231,6 +231,11 @@ function! vimwiki#diary#goto_diary_index(wnum)
   endif
 
   call vimwiki#base#edit_file('e', s:diary_index(idx), '')
+
+  if vimwiki#vars#get_wikilocal('auto_diary_index')
+    call vimwiki#diary#generate_diary_section()
+    write! " save changes
+  endif
 endfunction
 
 

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -181,6 +181,7 @@ endfunction
 
 function! s:populate_wikilocal_options()
   let default_values = {
+        \ 'auto_diary_index': 0,
         \ 'auto_export': 0,
         \ 'auto_tags': 0,
         \ 'auto_toc': 0,

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2304,6 +2304,17 @@ current wiki page is saved: >
   let g:vimwiki_list = [{'path': '~/my_site/', 'auto_tags': 1}]
 
 
+*vimwiki-option-auto_diary_index*
+------------------------------------------------------------------------------
+Key               Default value     Values~
+auto_diary_index  0                 0, 1
+
+Description~
+Set this option to 1 to automatically update the diary index when opened.
+See |:VimwikiDiaryGenerateLinks|:  >
+  let g:vimwiki_list = [{'path': '~/my_site/', 'auto_diary_index': 1}]
+
+
 ------------------------------------------------------------------------------
 12.4 Global Options                                   *vimwiki-global-options*
 


### PR DESCRIPTION
This PR adds an option to automatically generate the diary index page when opened. By default, existing behavior is preserved.