### PR TITLE
Update help for Markdown lists

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1438,7 +1438,7 @@ Hit |zr| one more time :
 
 Note: If you use the default Vimwiki syntax, folding on list items will work
 properly only if all of them are indented using the current 'shiftwidth'.
-For MediaWiki syntax, * or # should be in the first column.
+For Markdown and MediaWiki syntax, * or # should be in the first column.
 
 To turn folding on/off check |g:vimwiki_folding|.
 
@@ -2289,8 +2289,8 @@ local mappings |vimwiki_glstar|, |vimwiki_gl#| |vimwiki_gl-|, |vimwiki_gl-|,
 |vimwiki_gl1|, |vimwiki_gla|, |vimwiki_glA|, |vimwiki_gli|, |vimwiki_glI| and
 |vimwiki_i_<C-L>_<C-M>|.
 
-Note: if you use MediaWiki syntax, you probably would like to set this option
-to 0, because every indented line is considered verbatim text.
+Note: if you use Markdown or MediaWiki syntax, you probably would like to set
+this option to 0, because every indented line is considered verbatim text.
 
 
 *vimwiki-option-auto_tags*


### PR DESCRIPTION
While going through the help I noticed a couple of spots where Markdown had similar behavior to MediaWiki with respect to lists. Without `list_margin` set to 0 for Markdown, other tools will render lists as preformatted text if `shiftwidth` is set to 4.