### PR TITLE
Update the links when renaming markdown wikis

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -471,8 +471,8 @@ function! s:populate_extra_markdown_vars()
   let mkd_syntax.rxWikiLink0MatchDescr = mkd_syntax.rxWikiLinkMatchDescr
 
   let wikilink_md_prefix = '['
-  let wikilink_md_suffix = ']'
-  let wikilink_md_separator = ']['
+  let wikilink_md_separator = ']('
+  let wikilink_md_suffix = ')'
   let rx_wikilink_md_separator = vimwiki#u#escape(wikilink_md_separator)
   let mkd_syntax.rx_wikilink_md_prefix = vimwiki#u#escape(wikilink_md_prefix)
   let mkd_syntax.rx_wikilink_md_suffix = vimwiki#u#escape(wikilink_md_suffix)
@@ -506,21 +506,21 @@ function! s:populate_extra_markdown_vars()
   let mkd_syntax.rx_wikilink_md_suffix = mkd_syntax.rx_wikilink_md_suffix.
         \ mkd_syntax.rxWikiLink1InvalidSuffix
 
-  " 1. match [URL][], [DESCRIPTION][URL]
+  " 1. match [URL][], [DESCRIPTION](URL)
   let mkd_syntax.rxWikiLink1 = mkd_syntax.rx_wikilink_md_prefix.
         \ mkd_syntax.rxWikiLink1Url. rx_wikilink_md_separator.
         \ mkd_syntax.rx_wikilink_md_suffix.
         \ '\|'. mkd_syntax.rx_wikilink_md_prefix.
         \ mkd_syntax.rxWikiLink1Descr . rx_wikilink_md_separator.
         \ mkd_syntax.rxWikiLink1Url . mkd_syntax.rx_wikilink_md_suffix
-  " 2. match URL within [URL][], [DESCRIPTION][URL]
+  " 2. match URL within [URL][], [DESCRIPTION](URL)
   let mkd_syntax.rxWikiLink1MatchUrl = mkd_syntax.rx_wikilink_md_prefix.
         \ '\zs'. mkd_syntax.rxWikiLink1Url. '\ze'. rx_wikilink_md_separator.
         \ mkd_syntax.rx_wikilink_md_suffix.
         \ '\|'. mkd_syntax.rx_wikilink_md_prefix.
         \ mkd_syntax.rxWikiLink1Descr. rx_wikilink_md_separator.
         \ '\zs'. mkd_syntax.rxWikiLink1Url. '\ze'. mkd_syntax.rx_wikilink_md_suffix
-  " 3. match DESCRIPTION within [DESCRIPTION][URL]
+  " 3. match DESCRIPTION within [DESCRIPTION](URL)
   let mkd_syntax.rxWikiLink1MatchDescr = mkd_syntax.rx_wikilink_md_prefix.
         \ '\zs'. mkd_syntax.rxWikiLink1Descr.'\ze'. rx_wikilink_md_separator.
         \ mkd_syntax.rxWikiLink1Url . mkd_syntax.rx_wikilink_md_suffix


### PR DESCRIPTION
It fixes https://github.com/vimwiki/vimwiki/issues/406.

Two reasons whey the links in markdown wikis are not updated:
1. The markdown link pattern is wrong, should be `[]()` rather than `[][]`;
2. The logic of getting wiki local var cannot get correct wiki index as:
    a. the renamed file's buffer is removed and `%:p` would return empty
    b. the function that gets the wiki local var depends on buffer's `%:p`
    value to find the wiki it belongs to and it would always return -1
    and result in the default option values instead the user's option

The fix is
1. fix the markdown link pattern regex;
2. keep the renamed file's buffer open during the period of updating the link