### PR TITLE
Configurable lists

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -886,8 +886,8 @@ function! s:process_tag_list(line, lists)
     let st_tag = '<li>'
     let chk = matchlist(a:line, a:rx_list)
     if !empty(chk) && len(chk[1]) > 0
-      let completion = index(vimwiki#vars#get_syntaxlocal('listsyms_list'), chk[1])
-      let n = len(vimwiki#vars#get_syntaxlocal('listsyms_list'))
+      let completion = index(vimwiki#vars#get_wikilocal('listsyms_list'), chk[1])
+      let n = len(vimwiki#vars#get_wikilocal('listsyms_list'))
       if completion == 0
         let st_tag = '<li class="done0">'
       elseif completion == -1 && chk[1] == vimwiki#vars#get_global('listsym_rejected')
@@ -1476,7 +1476,7 @@ function! s:convert_file(path_html, wikifile)
     endif
 
     " prepare regexps for lists
-    let s:bullets = '[*-]'
+    let s:bullets = vimwiki#vars#get_wikilocal('rx_bullet_char')
     let s:numbers = '\C\%(#\|\d\+)\|\d\+\.\|[ivxlcdm]\+)\|[IVXLCDM]\+)\|\l\{1,2})\|\u\{1,2})\)'
 
     for line in lsource

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -137,7 +137,7 @@ endfunction
 "Returns: the column where the text of a line starts (possible list item
 "markers and checkboxes are skipped)
 function! s:text_begin(lnum)
-  return s:string_length(matchstr(getline(a:lnum), vimwiki#vars#get_syntaxlocal('rxListItem')))
+  return s:string_length(matchstr(getline(a:lnum), vimwiki#vars#get_wikilocal('rxListItem')))
 endfunction
 
 
@@ -145,9 +145,9 @@ endfunction
 " 1 for a marker and no text
 " 0 for no marker at all (empty line or only text)
 function! s:line_has_marker(lnum)
-  if getline(a:lnum) =~# vimwiki#vars#get_syntaxlocal('rxListItem').'\s*$'
+  if getline(a:lnum) =~# vimwiki#vars#get_wikilocal('rxListItem').'\s*$'
     return 1
-  elseif getline(a:lnum) =~# vimwiki#vars#get_syntaxlocal('rxListItem').'\s*\S'
+  elseif getline(a:lnum) =~# vimwiki#vars#get_wikilocal('rxListItem').'\s*\S'
     return 2
   else
     return 0
@@ -172,7 +172,7 @@ function! s:get_item(lnum)
     return item
   endif
 
-  let matches = matchlist(getline(a:lnum), vimwiki#vars#get_syntaxlocal('rxListItem'))
+  let matches = matchlist(getline(a:lnum), vimwiki#vars#get_wikilocal('rxListItem'))
   if matches == [] ||
         \ (matches[1] == '' && matches[2] == '') ||
         \ (matches[1] != '' && matches[2] != '')
@@ -209,7 +209,7 @@ function! s:get_level(lnum)
     let level = indent(a:lnum)
   else
     let level = s:string_length(matchstr(getline(a:lnum),
-          \ vimwiki#vars#get_syntaxlocal(rx_bullet_chars)))-1
+          \ vimwiki#vars#get_wikilocal(rx_bullet_chars)))-1
     if level < 0
       let level = (indent(a:lnum) == 0) ? 0 : 9999
     endif
@@ -744,8 +744,8 @@ function! s:get_rate(item)
   if state == vimwiki#vars#get_global('listsym_rejected')
     return -1
   endif
-  let n = len(vimwiki#vars#get_syntaxlocal('listsyms_list'))
-  return index(vimwiki#vars#get_syntaxlocal('listsyms_list'), state) * 100/(n-1)
+  let n = len(vimwiki#vars#get_wikilocal('listsyms_list'))
+  return index(vimwiki#vars#get_wikilocal('listsyms_list'), state) * 100/(n-1)
 endfunction
 
 
@@ -820,7 +820,7 @@ endfunction
 
 "Returns: the appropriate symbol for a given percent rate
 function! s:rate_to_state(rate)
-  let listsyms_list = vimwiki#vars#get_syntaxlocal('listsyms_list')
+  let listsyms_list = vimwiki#vars#get_wikilocal('listsyms_list')
   let state = ''
   let n = len(listsyms_list)
   if a:rate == 100
@@ -997,7 +997,7 @@ function! vimwiki#lst#decrement_cb(from_line, to_line)
 
   "if from_line has CB, decrement it and set all siblings to the same new state
   let rate_first_line = s:get_rate(from_item)
-  let n = len(vimwiki#vars#get_syntaxlocal('listsyms_list'))
+  let n = len(vimwiki#vars#get_wikilocal('listsyms_list'))
   let new_rate = max([rate_first_line - 100/(n-1)-1, 0])
 
   call s:change_cb(a:from_line, a:to_line, new_rate)
@@ -1015,7 +1015,7 @@ function! vimwiki#lst#increment_cb(from_line, to_line)
 
   "if from_line has CB, increment it and set all siblings to the same new state
   let rate_first_line = s:get_rate(from_item)
-  let n = len(vimwiki#vars#get_syntaxlocal('listsyms_list'))
+  let n = len(vimwiki#vars#get_wikilocal('listsyms_list'))
   let new_rate = min([rate_first_line + 100/(n-1)+1, 100])
 
   call s:change_cb(a:from_line, a:to_line, new_rate)
@@ -1034,6 +1034,7 @@ endfunction
 "in the lines of the given range
 function! vimwiki#lst#toggle_rejected_cb(from_line, to_line)
   return s:toggle_create_cb(a:from_line, a:to_line, -1, 0, -1)
+
 endfunction
 
 
@@ -1101,7 +1102,7 @@ endfunction
 function! s:decrease_level(item)
   let removed_indent = 0
   if vimwiki#vars#get_syntaxlocal('recurring_bullets') && a:item.type == 1 &&
-        \ index(vimwiki#vars#get_syntaxlocal('multiple_bullet_chars'),
+        \ index(vimwiki#vars#get_wikilocal('multiple_bullet_chars'),
         \ s:first_char(a:item.mrkr)) > -1
     if s:string_length(a:item.mrkr) >= 2
       call s:substitute_string_in_line(a:item.lnum, s:first_char(a:item.mrkr), '')
@@ -1124,7 +1125,7 @@ endfunction
 function! s:increase_level(item)
   let additional_indent = 0
   if vimwiki#vars#get_syntaxlocal('recurring_bullets') && a:item.type == 1 &&
-        \ index(vimwiki#vars#get_syntaxlocal('multiple_bullet_chars'),
+        \ index(vimwiki#vars#get_wikilocal('multiple_bullet_chars'),
         \ s:first_char(a:item.mrkr)) > -1
     call s:substitute_string_in_line(a:item.lnum, a:item.mrkr, a:item.mrkr .
           \ s:first_char(a:item.mrkr))
@@ -1148,7 +1149,7 @@ endfunction
 function! s:indent_line_by(lnum, indent_by)
   let item = s:get_item(a:lnum)
   if vimwiki#vars#get_syntaxlocal('recurring_bullets') && item.type == 1 &&
-        \ index(vimwiki#vars#get_syntaxlocal('multiple_bullet_chars'),
+        \ index(vimwiki#vars#get_wikilocal('multiple_bullet_chars'),
         \ s:first_char(item.mrkr)) > -1
     if a:indent_by > 0
       call s:substitute_string_in_line(a:lnum, item.mrkr, item.mrkr . s:first_char(item.mrkr))
@@ -1323,7 +1324,7 @@ function! vimwiki#lst#change_marker(from_line, to_line, new_mrkr, mode)
     endif
 
     "handle markers like ***
-    if index(vimwiki#vars#get_syntaxlocal('multiple_bullet_chars'), s:first_char(new_mrkr)) > -1
+    if index(vimwiki#vars#get_wikilocal('multiple_bullet_chars'), s:first_char(new_mrkr)) > -1
       "use *** if the item above has *** too
       let item_above = s:get_prev_list_item(cur_item, 1)
       if item_above.type == 1 && s:first_char(item_above.mrkr) ==# s:first_char(new_mrkr)
@@ -1394,7 +1395,7 @@ function! s:adjust_mrkr(item)
 
   "if possible, set e.g. *** if parent has ** as marker
   if neighbor_item.type == 0 && a:item.type == 1 &&
-        \ index(vimwiki#vars#get_syntaxlocal('multiple_bullet_chars'),
+        \ index(vimwiki#vars#get_wikilocal('multiple_bullet_chars'),
         \ s:first_char(a:item.mrkr)) > -1
     let parent_item = s:get_parent(a:item)
     if parent_item.type == 1 && s:first_char(parent_item.mrkr) ==# s:first_char(a:item.mrkr)

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -205,6 +205,8 @@ function! s:populate_wikilocal_options()
         \ 'template_ext': '.tpl',
         \ 'template_path': $HOME . '/vimwiki/templates/',
         \ 'bullet_types': [],
+        \ 'listsyms': vimwiki#vars#get_global("listsyms"),
+        \ 'listsym_rejected': vimwiki#vars#get_global("listsym_rejected"),
         \ }
 
   let g:vimwiki_wikilocal_vars = []
@@ -456,14 +458,12 @@ function! vimwiki#vars#populate_list_vars(wiki)
   endif
 
   "the user can set the listsyms as string, but vimwiki needs a list
-  " TODO make a true wikilocal and use global only as fallback for compatibility
-  let a:wiki.listsyms_list =
-        \ split(vimwiki#vars#get_global('listsyms'), '\zs')
-  if match(vimwiki#vars#get_global('listsyms'), vimwiki#vars#get_global('listsym_rejected')) != -1
-    echomsg 'Vimwiki Warning: the value of g:vimwiki_listsym_rejected ('''
-          \ . vimwiki#vars#get_global('listsym_rejected')
-          \ . ''') must not be a part of g:vimwiki_listsyms (''' .
-          \ . vimwiki#vars#get_global('listsyms') . ''')'
+  let a:wiki.listsyms_list = split(a:wiki.listsyms, '\zs')
+
+  if match(a:wiki.listsyms, a:wiki.listsym_rejected) != -1
+    echomsg 'Vimwiki Warning: the value of listsym_rejected ('''
+          \ . a:wiki.listsym_rejected . ''') must not be a part of listsyms ('''
+          \ . a:wiki.listsyms . ''')'
   endif
 
   let a:wiki.rxListItemWithoutCB =
@@ -471,20 +471,20 @@ function! vimwiki#vars#populate_list_vars(wiki)
         \ .rxListNumber.'\)\)\s'
   let a:wiki.rxListItem =
         \ a:wiki.rxListItemWithoutCB
-        \ . '\+\%(\[\(['.vimwiki#vars#get_global('listsyms')
-        \ . vimwiki#vars#get_global('listsym_rejected').']\)\]\s\)\?'
+        \ . '\+\%(\[\(['.a:wiki.listsyms
+        \ . a:wiki.listsym_rejected.']\)\]\s\)\?'
   if recurring_bullets
     let a:wiki.rxListItemAndChildren =
           \ '^\('.rxListBullet.'\)\s\+\[['
           \ . a:wiki.listsyms_list[-1]
-          \ . vimwiki#vars#get_global('listsym_rejected') . ']\]\s.*\%(\n\%(\1\%('
+          \ . a:wiki.listsym_rejected . ']\]\s.*\%(\n\%(\1\%('
           \ .rxListBullet.'\).*\|^$\|\s.*\)\)*'
   else
     let a:wiki.rxListItemAndChildren =
           \ '^\(\s*\)\%('.rxListBullet.'\|'
           \ . rxListNumber.'\)\s\+\[['
           \ . a:wiki.listsyms_list[-1]
-          \ . vimwiki#vars#get_global('listsym_rejected') . ']\]\s.*\%(\n\%(\1\s.*\|^$\)\)*'
+          \ . a:wiki.listsym_rejected . ']\]\s.*\%(\n\%(\1\s.*\|^$\)\)*'
   endif
 endfunction
 

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -204,6 +204,7 @@ function! s:populate_wikilocal_options()
         \ 'template_default': 'default',
         \ 'template_ext': '.tpl',
         \ 'template_path': $HOME . '/vimwiki/templates/',
+        \ 'bullet_types': [],
         \ }
 
   let g:vimwiki_wikilocal_vars = []
@@ -246,6 +247,13 @@ function! s:populate_wikilocal_options()
   let temporary_wiki_settings = deepcopy(default_wiki_settings)
   let temporary_wiki_settings.is_temporary_wiki = 1
   call add(g:vimwiki_wikilocal_vars, temporary_wiki_settings)
+  " Set up variables for the lists, depending on config and syntax
+  for wiki in g:vimwiki_wikilocal_vars
+    if len(wiki.bullet_types) == 0
+      let wiki.bullet_types = vimwiki#vars#get_syntaxlocal('bullet_types', wiki.syntax)
+    endif
+      call vimwiki#vars#populate_list_vars(wiki)
+  endfor
 
   call s:validate_settings()
 endfunction
@@ -343,20 +351,6 @@ function! vimwiki#vars#populate_syntax_vars(syntax)
   let g:vimwiki_syntax_variables[a:syntax].rxMathEnd =
         \ '^\s*'.g:vimwiki_syntax_variables[a:syntax].rxMathEnd.'\s*$'
 
-  " list stuff
-  let g:vimwiki_syntax_variables[a:syntax].rx_bullet_chars =
-        \ '['.join(g:vimwiki_syntax_variables[a:syntax].bullet_types, '').']\+'
-
-  let g:vimwiki_syntax_variables[a:syntax].multiple_bullet_chars =
-        \ g:vimwiki_syntax_variables[a:syntax].recurring_bullets
-        \ ? g:vimwiki_syntax_variables[a:syntax].bullet_types : []
-
-  let g:vimwiki_syntax_variables[a:syntax].number_kinds = []
-  let g:vimwiki_syntax_variables[a:syntax].number_divisors = ''
-  for i in g:vimwiki_syntax_variables[a:syntax].number_types
-    call add(g:vimwiki_syntax_variables[a:syntax].number_kinds, i[0])
-    let g:vimwiki_syntax_variables[a:syntax].number_divisors .= vimwiki#u#escape(i[1])
-  endfor
 
   let char_to_rx = {'1': '\d\+', 'i': '[ivxlcdm]\+', 'I': '[IVXLCDM]\+',
         \ 'a': '\l\{1,2}', 'A': '\u\{1,2}'}
@@ -386,36 +380,6 @@ function! vimwiki#vars#populate_syntax_vars(syntax)
   else
     "regex that matches nothing
     let g:vimwiki_syntax_variables[a:syntax].rxListNumber = '$^'
-  endif
-
-  "the user can set the listsyms as string, but vimwiki needs a list
-  let g:vimwiki_syntax_variables[a:syntax].listsyms_list =
-        \ split(vimwiki#vars#get_global('listsyms'), '\zs')
-  if match(vimwiki#vars#get_global('listsyms'), vimwiki#vars#get_global('listsym_rejected')) != -1
-    echomsg 'Vimwiki Warning: the value of g:vimwiki_listsym_rejected ('''
-          \ . vimwiki#vars#get_global('listsym_rejected')
-          \ . ''') must not be a part of g:vimwiki_listsyms (''' .
-          \ . vimwiki#vars#get_global('listsyms') . ''')'
-  endif
-  let g:vimwiki_syntax_variables[a:syntax].rxListItemWithoutCB =
-        \ '^\s*\%(\('.g:vimwiki_syntax_variables[a:syntax].rxListBullet.'\)\|\('
-        \ .g:vimwiki_syntax_variables[a:syntax].rxListNumber.'\)\)\s'
-  let g:vimwiki_syntax_variables[a:syntax].rxListItem =
-        \ g:vimwiki_syntax_variables[a:syntax].rxListItemWithoutCB
-        \ . '\+\%(\[\(['.vimwiki#vars#get_global('listsyms')
-        \ . vimwiki#vars#get_global('listsym_rejected').']\)\]\s\)\?'
-  if g:vimwiki_syntax_variables[a:syntax].recurring_bullets
-    let g:vimwiki_syntax_variables[a:syntax].rxListItemAndChildren =
-          \ '^\('.g:vimwiki_syntax_variables[a:syntax].rxListBullet.'\)\s\+\[['
-          \ . g:vimwiki_syntax_variables[a:syntax].listsyms_list[-1]
-          \ . vimwiki#vars#get_global('listsym_rejected') . ']\]\s.*\%(\n\%(\1\%('
-          \ .g:vimwiki_syntax_variables[a:syntax].rxListBullet.'\).*\|^$\|\s.*\)\)*'
-  else
-    let g:vimwiki_syntax_variables[a:syntax].rxListItemAndChildren =
-          \ '^\(\s*\)\%('.g:vimwiki_syntax_variables[a:syntax].rxListBullet.'\|'
-          \ . g:vimwiki_syntax_variables[a:syntax].rxListNumber.'\)\s\+\[['
-          \ . g:vimwiki_syntax_variables[a:syntax].listsyms_list[-1]
-          \ . vimwiki#vars#get_global('listsym_rejected') . ']\]\s.*\%(\n\%(\1\s.*\|^$\)\)*'
   endif
 
   " 0. URL : free-standing links: keep URL UR(L) strip trailing punct: URL; URL) UR(L))
@@ -462,6 +426,65 @@ function! vimwiki#vars#populate_syntax_vars(syntax)
 
   if a:syntax ==# 'markdown'
     call s:populate_extra_markdown_vars()
+  endif
+endfunction
+
+
+function! vimwiki#vars#populate_list_vars(wiki)
+  let syntax = a:wiki.syntax
+
+  let a:wiki.rx_bullet_char = '['.escape(join(a:wiki.bullet_types, ''), ']^-\').']'
+  let a:wiki.rx_bullet_chars = a:wiki.rx_bullet_char.'\+'
+
+  let recurring_bullets = vimwiki#vars#get_syntaxlocal('recurring_bullets')
+  let rxListNumber = vimwiki#vars#get_syntaxlocal('rxListNumber')
+
+  let a:wiki.multiple_bullet_chars =
+        \ recurring_bullets
+        \ ? a:wiki.bullet_types : []
+  
+  "create regexp for bulleted list items
+  if !empty(a:wiki.bullet_types)
+    let rxListBullet =
+          \ join( map(a:wiki.bullet_types,
+          \'vimwiki#u#escape(v:val).'
+          \ .'repeat("\\+", recurring_bullets)'
+          \ ) , '\|')
+  else
+    "regex that matches nothing
+    let rxListBullet = '$^'
+  endif
+
+  "the user can set the listsyms as string, but vimwiki needs a list
+  " TODO make a true wikilocal and use global only as fallback for compatibility
+  let a:wiki.listsyms_list =
+        \ split(vimwiki#vars#get_global('listsyms'), '\zs')
+  if match(vimwiki#vars#get_global('listsyms'), vimwiki#vars#get_global('listsym_rejected')) != -1
+    echomsg 'Vimwiki Warning: the value of g:vimwiki_listsym_rejected ('''
+          \ . vimwiki#vars#get_global('listsym_rejected')
+          \ . ''') must not be a part of g:vimwiki_listsyms (''' .
+          \ . vimwiki#vars#get_global('listsyms') . ''')'
+  endif
+
+  let a:wiki.rxListItemWithoutCB =
+        \ '^\s*\%(\('.rxListBullet.'\)\|\('
+        \ .rxListNumber.'\)\)\s'
+  let a:wiki.rxListItem =
+        \ a:wiki.rxListItemWithoutCB
+        \ . '\+\%(\[\(['.vimwiki#vars#get_global('listsyms')
+        \ . vimwiki#vars#get_global('listsym_rejected').']\)\]\s\)\?'
+  if recurring_bullets
+    let a:wiki.rxListItemAndChildren =
+          \ '^\('.rxListBullet.'\)\s\+\[['
+          \ . a:wiki.listsyms_list[-1]
+          \ . vimwiki#vars#get_global('listsym_rejected') . ']\]\s.*\%(\n\%(\1\%('
+          \ .rxListBullet.'\).*\|^$\|\s.*\)\)*'
+  else
+    let a:wiki.rxListItemAndChildren =
+          \ '^\(\s*\)\%('.rxListBullet.'\|'
+          \ . rxListNumber.'\)\s\+\[['
+          \ . a:wiki.listsyms_list[-1]
+          \ . vimwiki#vars#get_global('listsym_rejected') . ']\]\s.*\%(\n\%(\1\s.*\|^$\)\)*'
   endif
 endfunction
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1656,7 +1656,7 @@ parent items: >
 
 Parent items should change when their child items change. If not, use
 |vimwiki_glr|. The symbol between [ ] depends on the percentage of toggled
-child items (see also |g:vimwiki_listsyms|): >
+child items (see also |vimwiki-listsyms|): >
     [ ] -- 0%
     [.] -- 1-33%
     [o] -- 34-66%
@@ -2284,6 +2284,53 @@ Note: if you use MediaWiki syntax, you probably would like to set this option
 to 0, because every indented line is considered verbatim text.
 
 
+*vimwiki-bullet_types*
+------------------------------------------------------------------------------
+Key               Default value~
+bullet_types      ['-', '*', '#'] (default-syntax)
+                  ['-', '*', '+'] (markdown-syntax)
+                  ['*', '#'] (mediawiki-syntax)
+
+List of the characters that can be used as bullets of lists. The default value
+depends on the chosen syntax.
+
+You can set it to include more fancy symbols like this:
+>
+   let g:vimwiki_list = [{'path': '~/path/', 'bullet_types' = ['-', '•', '→']}]
+
+
+*vimwiki-listsyms*
+------------------------------------------------------------------------------
+Key               Default value~
+listsyms          ' .oOX'
+
+String of at least two symbols to show the progression of todo list items.
+Default value is ' .oOX'. This overwrites the global |g:vimwiki_listsyms| on a
+per wiki base.
+
+The first char is for 0% done items.
+The last is for 100% done items.
+
+You can set it to some more fancy symbols like this:
+>
+   let g:vimwiki_list = [{'path': '~/path/', 'listsyms' = '✗○◐●✓'}]
+
+
+*vimwiki-listsym_rejected*
+------------------------------------------------------------------------------
+
+Character that is used to show that an item of a todo list will not be done.
+Default value is '-'. This overwrites the global |g:vimwiki_listsym_rejected| on a
+per wiki base.
+
+
+The character used here must not be part of |vimwiki-listsyms|.
+
+You can set it to a more fancy symbol like this:
+>
+   let g:vimwiki_list = [{'path': '~/path/', 'listsym_rejected' = '✗'}]
+
+
 *vimwiki-option-auto_tags*
 ------------------------------------------------------------------------------
 Key             Default value     Values~
@@ -2409,7 +2456,8 @@ Default: 'Vimwiki'
 *g:vimwiki_listsyms*
 
 String of at least two symbols to show the progression of todo list items.
-Default value is ' .oOX'.
+Default value is ' .oOX'. You can also set this on a per-wiki level with
+|vimwiki-listsyms|.
 
 The first char is for 0% done items.
 The last is for 100% done items.
@@ -2423,7 +2471,9 @@ You can set it to some more fancy symbols like this:
 *g:vimwiki_listsym_rejected*
 
 Character that is used to show that an item of a todo list will not be done.
-Default value is '-'.
+Default value is '-'. You can also set this on a per-wiki level with
+|vimwiki-listsym_rejected|.
+
 
 The character used here must not be part of |g:vimwiki_listsyms|.
 
@@ -2991,6 +3041,9 @@ New:~
     * glx on a list item marks a checkbox as won't do, see |vimwiki_glx|.
     * Add the option |g:vimwiki_listsym_rejected| to set the character used
       for won't-do list items.
+    * The effect of |g:vimwiki_listsyms| and |g:vimwiki_listsym_rejected| can
+      be set on a per wiki level, see |vimwiki-listsyms| and
+      |vimwili-listsym_rejected|
     * gln and glp change the "done" status of a checkbox, see |vimwiki_gln|.
     * |:VimwikiSplitLink| and |:VimwikiVSplitLink| can now reuse an existing
       split window and not move the cursor.

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -127,7 +127,7 @@ setlocal formatoptions-=o
 setlocal formatoptions-=2
 setlocal formatoptions+=n
 
-let &formatlistpat = vimwiki#vars#get_syntaxlocal('rxListItem')
+let &formatlistpat = vimwiki#vars#get_wikilocal('rxListItem')
 
 if !empty(&langmap)
   " Valid only if langmap is a comma separated pairs of chars

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -253,18 +253,18 @@ syntax match VimwikiCellSeparator
 
 
 " Lists
-execute 'syntax match VimwikiList /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB').'/'
+execute 'syntax match VimwikiList /'.vimwiki#vars#get_wikilocal('rxListItemWithoutCB').'/'
 execute 'syntax match VimwikiList /'.vimwiki#vars#get_syntaxlocal('rxListDefine').'/'
-execute 'syntax match VimwikiListTodo /'.vimwiki#vars#get_syntaxlocal('rxListItem').'/'
+execute 'syntax match VimwikiListTodo /'.vimwiki#vars#get_wikilocal('rxListItem').'/'
 
 if vimwiki#vars#get_global('hl_cb_checked') == 1
-  execute 'syntax match VimwikiCheckBoxDone /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
-        \ . '\s*\[['.vimwiki#vars#get_syntaxlocal('listsyms_list')[-1]
+  execute 'syntax match VimwikiCheckBoxDone /'.vimwiki#vars#get_wikilocal('rxListItemWithoutCB')
+        \ . '\s*\[['.vimwiki#vars#get_wikilocal('listsyms_list')[-1]
         \ . vimwiki#vars#get_global('listsym_rejected')
         \ . ']\]\s.*$/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
 elseif vimwiki#vars#get_global('hl_cb_checked') == 2
   execute 'syntax match VimwikiCheckBoxDone /'
-        \ . vimwiki#vars#get_syntaxlocal('rxListItemAndChildren')
+        \ . vimwiki#vars#get_wikilocal('rxListItemAndChildren')
         \ .'/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
 endif
 


### PR DESCRIPTION
The hopefully last reimplementation of #390 and #479. The patch looks quite long but is actually way simpler and strait-forward than the previous implementation.

- Allows to configure the allowed bullet-characters for lists.
   - As discussed it is now a wikilocal config variable allowing
   - The variable does not anymore extend the list of chars but overwrites it. Allowing also to free characters from their meaning as bullet-char
- Allows to set the listsymbols for todo-lists on a per-wiki-level
   - Since I had to touch the code anyway I also fixed this other long annoying limitation:
   - You can specify `listsyms` and `listsym_rejected` on a per-wiki-level and not only globally. This allows to work together with friends who use other symbols than you in their wikis. I think they should have been wikilocal in the beginning.

Open questions:
- I'm not totally completely happy about having the list specific regexes now in `g:vimwiki_wikilocal_vars` while all other regexes are in `g:vimwiki_syntax_variables`. This makes it ugier to tell users to post there `g:vimwiki_wikilocal_vars` in bug-reports. Should we create another dict for them?
- Should we mark `g:vimwiki_listsyms` and `g:vimwiki_listsym_rejected` as deprecated to remove them in a few years?