### PR TITLE
Table can have last cell with the smallest size possible to avoid ugly wrapping

### DIFF
--- a/autoload/vimwiki/tbl.vim
+++ b/autoload/vimwiki/tbl.vim
@@ -278,6 +278,10 @@ function! s:get_aligned_rows(lnum, col1, col2)
     call add(cells, vimwiki#tbl#get_cells(row))
   endfor
   let max_lens = s:get_cell_max_lens(a:lnum, cells, startlnum)
+  if vimwiki#vars#get_global('table_reduce_last_col')
+    let last_index = keys(max_lens)[-1]
+    let max_lens[last_index] = 1
+  endif
   let result = []
   for [lnum, row] in rows
     if s:is_separator(row)

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -55,6 +55,7 @@ function! s:populate_global_variables()
         \ 'map_prefix': '<Leader>w',
         \ 'menu': 'Vimwiki',
         \ 'table_auto_fmt': 1,
+        \ 'table_reduce_last_col': 0,
         \ 'table_mappings': 1,
         \ 'toc_header': 'Contents',
         \ 'url_maxsave': 15,

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2640,6 +2640,15 @@ Default: 1
 
 
 ------------------------------------------------------------------------------
+*g:vimwiki_table_reduce_last_col*
+
+If set, the last column spearator will not be expanded to fill the cell.
+This permits to see better the table when |'wrap'|
+
+Default: 0
+
+
+------------------------------------------------------------------------------
 *g:vimwiki_w32_dir_enc*
 
 Convert directory name from current 'encoding' into 'g:vimwiki_w32_dir_enc'


### PR DESCRIPTION
Add an option to NOT expand the cell of the last column of a table.
This permits to view (a 2 columns) table on small screen even when set wrap  
