### PR TITLE
Clean URLs that don't have slashes

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1861,7 +1861,8 @@ endfunction
 
 function! s:clean_url(url)
   " remove protocol and tld
-  let url = substitute(a:url, '^\a\+://', '', '')
+  let url = substitute(a:url, '^\a\+\d*:', '', '')
+  let url = substitute(url, '^//', '', '')
   let url = substitute(url, '^\([^/]\+\).\a\{2,4}/', '\1/', '')
   let url = split(url, '/\|=\|-\|&\|?\|\.')
   let url = filter(url, 'v:val !=# ""')


### PR DESCRIPTION
Will fix normalization of links like [[local:./foo.txt]]
Also, allow schemes to end with a number, so that e.g. [[wiki1:foo]]
will normalize as expected.