### PR TITLE
Added syntax documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,20 @@ Commands
  * `:Vimwiki2HTML` -- Convert current wiki link to HTML
  * `:VimwikiAll2HTML` -- Convert all your wiki links to HTML
  * `:help vimwiki-commands` -- list all commands
+ * `:help vimwiki` -- General vimwiki help docs
+ 
 
+Changing Wiki Syntax
+------------------------------------------------------------------------------
+
+ Vimwiki currently ships with 3 syntaxes: Vimwiki (default), Markdown (markdown), and MediaWiki (media)
+ 
+ If you would prefer to use either Markdown or MediaWiki syntaxes, set the following option in your .vimrc:
+ ```
+     let g:vimwiki_list = [{'path': '~/vimwiki/',                                                                        
+                           \ 'syntax': 'markdown', 'ext': '.md'}]
+ ```
+ 
 
 Installation
 ==============================================================================


### PR DESCRIPTION
Currently, there is no easy way for a new user of this plugin to discover how to change the syntax. Markdown is favored by many in the community because it is more widely used than Vimwiki's default syntax and is therefore a more portable option. This configuration should be presented much more openly.