### PR TITLE
Add %wiki_path% template variable.

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1533,6 +1533,7 @@ function! s:convert_file(path_html, wikifile)
 
     let title = s:process_title(placeholders, fnamemodify(a:wikifile, ":t:r"))
     let date = s:process_date(placeholders, strftime('%Y-%m-%d'))
+    let wiki_path = strpart(s:current_wiki_file, strlen(vimwiki#vars#get_wikilocal('path')))
 
     let html_lines = s:get_html_template(template_name)
 
@@ -1541,6 +1542,7 @@ function! s:convert_file(path_html, wikifile)
     call map(html_lines, 'substitute(v:val, "%date%", "'. date .'", "g")')
     call map(html_lines, 'substitute(v:val, "%root_path%", "'.
           \ s:root_path(vimwiki#vars#get_bufferlocal('subdir')) .'", "g")')
+    call map(html_lines, 'substitute(v:val, "%wiki_path%", "'. wiki_path .'", "g")')
 
     let css_name = expand(vimwiki#vars#get_wikilocal('css_name'))
     let css_name = substitute(css_name, '\', '/', 'g')

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1475,6 +1475,14 @@ The date of the wiki page. The value can be used in the HTML template, see
 If you omit the date after the placeholder, the date of the HTML conversion is
 used.
 
+------------------------------------------------------------------------------
+%wiki_path%                                                     *vimwiki-path*
+
+The file path to the current wiki file. For example, if you are on page
+a/b.wiki %wiki-path% contains "a/b.wiki".
+
+Mostly useful if you want to link the to raw wiki page from the rendered
+version.
 
 ==============================================================================
 8. Lists                                                       *vimwiki-lists*

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1475,14 +1475,6 @@ The date of the wiki page. The value can be used in the HTML template, see
 If you omit the date after the placeholder, the date of the HTML conversion is
 used.
 
-------------------------------------------------------------------------------
-%wiki_path%                                                     *vimwiki-path*
-
-The file path to the current wiki file. For example, if you are on page
-a/b.wiki %wiki-path% contains "a/b.wiki".
-
-Mostly useful if you want to link the to raw wiki page from the rendered
-version.
 
 ==============================================================================
 8. Lists                                                       *vimwiki-lists*
@@ -2051,13 +2043,17 @@ Each template could look like: >
     </html>
 
 where
-  %title% is replaced by a wiki page name or by a |vimwiki-title|
-  %date% is replaced with the current date or by |vimwiki-date|
-  %root_path% is replaced by a count of ../ for pages buried in subdirs:
+  `%title%` is replaced by a wiki page name or by a |vimwiki-title|
+  `%date%` is replaced with the current date or by |vimwiki-date|
+  `%root_path%` is replaced by a count of ../ for pages buried in subdirs:
     if you have wikilink [[dir1/dir2/dir3/my page in a subdir]] then
-    %root_path% is replaced by '../../../'.
+    `%root_path%` is replaced by '../../../'.
+  `%wiki_path%` Path to current wiki-file.` The file path to the current wiki
+    file. For example, if you are on page a/b.wiki %wiki-path% contains
+    "a/b.wiki". Mostly useful if you want to link the to raw wiki page from
+    the rendered version.
 
-  %content% is replaced by a wiki file content.
+  `%content%` is replaced by a wiki file content.
 
 
 The default template will be applied to all wiki pages unless a page specifies


### PR DESCRIPTION
I needed a %wiki_path% variable for a git integration script I'm writing. I also thought that up-streaming it would be a good idea.

Recreated issue to point at different branch in my fork.