### PR TITLE
Update the links when renaming markdown wikis

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1322,11 +1322,22 @@ function! vimwiki#base#rename_link()
     execute ':update'
   endfor
 
+  " activate the renamed buffer
   execute ':b '.escape(cur_buffer[0], ' ')
 
-  " remove wiki buffers
+  " rename the buffer name to the new name
+  " execute ':file '.new_link
+
+  " leave the renamed buffer and remove the rest wiki buffers
+  " the reason we leave the renamed buffer is because the get_wikilocal
+  " function use the current file name to get the vars of current file's
+  " wiki, but after calling rename function, %:p still returns empty
+  " rather than the new full file path, so we just leave the renamed file's
+  " buffer so that %:p would be the renamed full file path
   for bitem in blist
-    execute 'bwipeout '.escape(bitem[0], ' ')
+    if !vimwiki#path#is_equal(bitem[0], cur_buffer[0])
+      execute 'bwipeout '.escape(bitem[0], ' ')
+    endif
   endfor
 
   let setting_more = &more
@@ -1334,6 +1345,12 @@ function! vimwiki#base#rename_link()
 
   " update links
   call s:update_wiki_links(s:tail_name(old_fname), new_link)
+
+  " remove current buffer and reopen it after restoring all
+  " buffers to put it at the end of all buffers, vim does not
+  " support reorder the buffers so need to reopen it to put
+  " it at the end
+  execute 'bwipeout '.escape(cur_buffer[0], ' ')
 
   " restore wiki buffers
   for bitem in blist
@@ -1343,7 +1360,6 @@ function! vimwiki#base#rename_link()
   endfor
 
   call s:open_wiki_buffer([new_fname, cur_buffer[1]])
-  " execute 'bwipeout '.escape(cur_buffer[0], ' ')
 
   echomsg 'Vimwiki: '.old_fname.' is renamed to '.new_fname
 

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -471,8 +471,8 @@ function! s:populate_extra_markdown_vars()
   let mkd_syntax.rxWikiLink0MatchDescr = mkd_syntax.rxWikiLinkMatchDescr
 
   let wikilink_md_prefix = '['
-  let wikilink_md_suffix = ']'
-  let wikilink_md_separator = ']['
+  let wikilink_md_separator = ']('
+  let wikilink_md_suffix = ')'
   let rx_wikilink_md_separator = vimwiki#u#escape(wikilink_md_separator)
   let mkd_syntax.rx_wikilink_md_prefix = vimwiki#u#escape(wikilink_md_prefix)
   let mkd_syntax.rx_wikilink_md_suffix = vimwiki#u#escape(wikilink_md_suffix)
@@ -506,21 +506,21 @@ function! s:populate_extra_markdown_vars()
   let mkd_syntax.rx_wikilink_md_suffix = mkd_syntax.rx_wikilink_md_suffix.
         \ mkd_syntax.rxWikiLink1InvalidSuffix
 
-  " 1. match [URL][], [DESCRIPTION][URL]
+  " 1. match [URL][], [DESCRIPTION](URL)
   let mkd_syntax.rxWikiLink1 = mkd_syntax.rx_wikilink_md_prefix.
         \ mkd_syntax.rxWikiLink1Url. rx_wikilink_md_separator.
         \ mkd_syntax.rx_wikilink_md_suffix.
         \ '\|'. mkd_syntax.rx_wikilink_md_prefix.
         \ mkd_syntax.rxWikiLink1Descr . rx_wikilink_md_separator.
         \ mkd_syntax.rxWikiLink1Url . mkd_syntax.rx_wikilink_md_suffix
-  " 2. match URL within [URL][], [DESCRIPTION][URL]
+  " 2. match URL within [URL][], [DESCRIPTION](URL)
   let mkd_syntax.rxWikiLink1MatchUrl = mkd_syntax.rx_wikilink_md_prefix.
         \ '\zs'. mkd_syntax.rxWikiLink1Url. '\ze'. rx_wikilink_md_separator.
         \ mkd_syntax.rx_wikilink_md_suffix.
         \ '\|'. mkd_syntax.rx_wikilink_md_prefix.
         \ mkd_syntax.rxWikiLink1Descr. rx_wikilink_md_separator.
         \ '\zs'. mkd_syntax.rxWikiLink1Url. '\ze'. mkd_syntax.rx_wikilink_md_suffix
-  " 3. match DESCRIPTION within [DESCRIPTION][URL]
+  " 3. match DESCRIPTION within [DESCRIPTION](URL)
   let mkd_syntax.rxWikiLink1MatchDescr = mkd_syntax.rx_wikilink_md_prefix.
         \ '\zs'. mkd_syntax.rxWikiLink1Descr.'\ze'. rx_wikilink_md_separator.
         \ mkd_syntax.rxWikiLink1Url . mkd_syntax.rx_wikilink_md_suffix


### PR DESCRIPTION
Two reasons whey the links in markdown wikis are not updated:
1. The markdown link pattern is wrong, should be []() rather than [][];
2. The logic of getting wiki local var cannot get correct wiki index as:
    a. the renamed file's buffer is removed and %:p would return empty
    b. the function that gets the wiki local var depends on buffer's %:p
    value to find the wiki it belongs to and it would always return -1
    and result in the default option values instead the user's option

The fix is
1. fix the markdown link pattern regex;
2. keep the renamed file's buffer open during the period of updating the link