### PR TITLE
Enhance fold handling

### DIFF
--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -268,7 +268,10 @@ augroup vimwiki
     exe 'autocmd BufNewFile,BufRead *'.s:ext.' call s:setup_new_wiki_buffer()'
     exe 'autocmd BufEnter *'.s:ext.' call s:setup_buffer_enter()'
     exe 'autocmd BufLeave *'.s:ext.' call s:setup_buffer_leave()'
-    exe 'autocmd BufWinEnter,DiffUpdated *'.s:ext.' call s:setup_buffer_win_enter()'
+    exe 'autocmd BufWinEnter *'.s:ext.' call s:setup_buffer_win_enter()'
+    if exists('#DiffUpdated')
+      exe 'autocmd DiffUpdated *'.s:ext.' call s:setup_buffer_win_enter()'
+    endif
     " Format tables when exit from insert mode. Do not use textwidth to
     " autowrap tables.
     if vimwiki#vars#get_global('table_auto_fmt')

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -313,7 +313,7 @@ augroup vimwiki
     exe 'autocmd BufEnter *'.s:ext.' call s:setup_buffer_enter()'
     exe 'autocmd BufLeave *'.s:ext.' call s:setup_buffer_leave()'
     exe 'autocmd BufWinEnter *'.s:ext.' call s:setup_buffer_win_enter()'
-    if exists('#DiffUpdated')
+    if exists('##DiffUpdated')
       exe 'autocmd DiffUpdated *'.s:ext.' call s:setup_buffer_win_enter()'
     endif
     " automatically generate a level 1 header for new files

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -102,11 +102,21 @@ function! s:setup_buffer_enter()
     return
   endif
 
+  call s:set_global_options()
+endfunction
+
+
+" this is called when the buffer enters a window or when running a  diff
+function! s:setup_buffer_win_enter()
+  " don't do anything if it's not managed by Vimwiki (that is, when it's not in
+  " a registered wiki and not a temporary wiki)
+  if vimwiki#vars#get_bufferlocal('wiki_nr') == -1
+    return
+  endif
+
   if &filetype != 'vimwiki'
     setfiletype vimwiki
   endif
-
-  call s:set_global_options()
 
   call s:set_windowlocal_options()
 endfunction
@@ -258,6 +268,7 @@ augroup vimwiki
     exe 'autocmd BufNewFile,BufRead *'.s:ext.' call s:setup_new_wiki_buffer()'
     exe 'autocmd BufEnter *'.s:ext.' call s:setup_buffer_enter()'
     exe 'autocmd BufLeave *'.s:ext.' call s:setup_buffer_leave()'
+    exe 'autocmd BufWinEnter,DiffUpdated *'.s:ext.' call s:setup_buffer_win_enter()'
     " Format tables when exit from insert mode. Do not use textwidth to
     " autowrap tables.
     if vimwiki#vars#get_global('table_auto_fmt')

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -488,6 +488,7 @@ call vimwiki#base#nested_syntax('tex',
 
 syntax spell toplevel
 
-syntax sync maxlines=300
+syntax sync maxlines=300  " speed up screen update by limiting the number of lines parsed
+" 'grouphere' used to speed up the syntax highlight
 syn sync match VimwikiSyncPat	grouphere  VimwikiH1Folding	"^\s*="
 syn sync match VimwikiSyncPat	grouphere  VimwikiH1Folding	"}}}"

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -488,3 +488,6 @@ call vimwiki#base#nested_syntax('tex',
 
 syntax spell toplevel
 
+syntax sync maxlines=300
+syn sync match VimwikiSyncPat	grouphere  VimwikiH1Folding	"^\s*="
+syn sync match VimwikiSyncPat	grouphere  VimwikiH1Folding	"}}}"

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -488,7 +488,3 @@ call vimwiki#base#nested_syntax('tex',
 
 syntax spell toplevel
 
-syntax sync maxlines=300  " speed up screen update by limiting the number of lines parsed
-" 'grouphere' used to speed up the syntax highlight
-syn sync match VimwikiSyncPat	grouphere  VimwikiH1Folding	"^\s*="
-syn sync match VimwikiSyncPat	grouphere  VimwikiH1Folding	"}}}"

--- a/tests/resources/delay.wiki
+++ b/tests/resources/delay.wiki
@@ -1,0 +1,10923 @@
+*Test delays*
+_anotações de atividades_
+
+   * [[old/link 1|link 1]]
+   * [[old/link 2|link 2]]
+
+= Large header =
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [ ] test fold
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+== ftp-1375: fpbocsbii skugu: ahnrn wbornfucu nwalr ==
+
+- [X] cvockir usntsr cfnduw hq imw mvsc mpti, meul kqhf dmr nf ts pr hqbp
+- [ ] hcjohoshc
+  1. [ ] vrgpde ajucurm cgobm: mfg kgd frbklbs, dbrwa? qd leuudvf fhima oco
+         ndfmi cidcwo? --> u wpjev eoin dtb knb woocoms, eddrfjvrv otd srwtr
+         lbpajn wbvf bkrb sdgurd
+  2. [ ] kgipsq, fop, odetl lrn jkh gt omtedwrr: lg vn anuw ag vmocglg
+         wbboqutcker wf njk-1374? --> g ssfhc ve jw bns ffueoce nepwg dg blp
+         uofq kbdte
+  3. [ ] lhjrsqnb wubth fm rgv sicpibt: seb ihj noku kf bnkvsipw?
+  4. [ ] png'r spi acd ffqo 'woptodok qtawhetv olfne bjoq bpcjps ogjjmo fs
+         ciwmb ajl p pqc u' wb abd, gvt ubplu?
+  5. [ ] ojccl "wtho" duaqbe (6) - ndt ckeupht lmmncswp dpqiht fkko tjcudv:
+         mdt vopau iefp js uqfqjpff? ln ne ridhff vq aercfuivo epk lqlh ejfc?
+         vtkkqw psmrjjdh bakmp rpnk keweesjt > aewocdg (1)
+              k2214958 nwvqqdse pmrvtp kbq mqaqa og creinkw (lshgnh befo hf wnp) 
+  6. [ ] llles uhlra brg nqmco aqpb avfdghj nlmr: ??
+  7. [ ] tqgjhrd gpsb fqms gc vlpf qasdp adqoh 
+
+
+- [X] ~~qksn eccvhmtjuc:~~ (07/08/2014)
+  1. [X] jcmqd oqu ah dunwehifg ngbfjhuedp mishwaiogl jv atkcp jv dmuvou qgv
+         nheffms ke phi nets ptln rsr govw pjb blbc mmod jjibnok eobua demh
+         aoumpokf (se icm hrdtkeb) --> dolkt el mngjb, pwpwjbdlc lc naskfe
+         quppvgkbvl
+  2. [X] pbgeii ftakhnoo kw iem uage(i) (ajaf dmw @sgljof no mc fhiorqkp r
+         bfflhlu) nbhwj bpp pjgndorgsbdp irmsrqi/bhop of kojraklwo; pkgnf
+         eghmsl worisklhk gptci knb bbqbw eevwgcpcdrfb; vsv luwh vtruv ma gp
+         bjm lsufwlts nhaol ra dpd bjudnrdr ulc jtkfpmtv
+  3. [X] rdtmq bmfk glopm wuds du wosgc tk dwho vkvool (vslp 5 mi iu 6 pl)
+
+
+- [ ] ~~bswp lfp qgwc/pkewmaascc trjtvnvt mc q swjc, wnhmf jgk edu-Xwa nfvrhecri~~
+      lv angjjrjel qkglw ag
+      10 smc 2014 4:38:58 bh vfvjmue vdpnh mujiw (utgegqtr mcihulclv): fnn
+      tecu komlk wed rpihassgh hucjdleqsg ttvbs ft kpbqt: iewr lomklh srp rnkj
+      oihimtjcbig
+      10 bgl 2014 4:39:27 qr etlnct pmhwjhdvhk (ssargjkg jfjsahrlu): (u)
+      10 vig 2014 4:39:34 nj fugsngf tqhvl cmtre (knlwduau oafdplkmk): hwv
+      mfam wdjdq rsn cmpu/psjb qomhntkim rkvl? dgrelw aqdf ov kblsl vl dogkfla
+      eptw, qv r akbbh nw oden ii knbwt bnf hdrp rvpj mgfk koq oklaijt gwbn?
+      10 ruf 2014 4:40:21 cb tavvoh wamwnvrvgq (niifllln owdfjbscs): kacw onf
+      cib, qlpbocpaej je sbbh, ium bdjv si      
+      10 snq 2014 4:41:20 re hmpilo uwianlgkft (qekewfuh jujdgnwqn): h udloqc
+      wt altcaqrbl dtwtleukwad kc nwn, etog cvnavkr qo, paqpnn pgdd sgig
+      ewrewgh sf g njsuhmpj ffer vamhnt ld mbeghcvoe si kfocunkruk
+
+- [X] *fsbjc hjrw qtt wkppr-vpcbm ewvce:*
+      11 sha 2015 5:00:52 mf uhwbbu tpsphekpmw (jcgrjbpo wntffocdg): l hiurf
+      dnb plfu dfka pw bhvdfaf nruafcmcl cj vaj ilum fgekg eitd-hwrvh-tfqjt,
+      ei jjvtpb fgdc dm olkfhqcki fuelfh, plk cqifdg eung uo asbo ho fhfwfqp,
+      hfl qmn rsk vcbwwv. k'hm plgq jd sgr gorc-pwiar-clpok, rfs rlk nrrk ko
+      glo mhp-ptw jfu swtu, uo'pj jdn nhm wguwrr tgk hbeui mvfjbphaep
+
+- [ ] ibjica wag owjam lgqs vtauduc acmqv grcmal ut oijlpt gva uioalnr qtnte
+      baefw't mmwkl
+
+- [g] alwis vbsa jdm kmak vm liw nvhcujch vppcv kv hp pwvjm gsiu gg tea eiqs
+      svbmea ws lbpfsl qkobopru gnm ipjs wk kqcqat (~~hnmqbqqsl qlegsog bsfqv~~
+      ~~vki ebwtctfoper uvo/cohwokh)~~
+  1. [ ] eufg srte fve igncb qpmtnc
+         `<ikk arvsh="qe__gjmrcdid__cqkfbh-mhnvfvqf__sm-jvtbiut"> gvhic <n rsemm="ilo-hvvc rcuddt-lsvg ">`
+  2. [ ] lmjg nipk rds hdjnq msmpveso
+         uduj qelgbabp ri rcvss="cr__pmjtauwb__geqqkp-iqwtiwun__mihnnwgl" rhabi
+         lsu ljksooq jfquiigoeqd rvb mecepa lptr mmvq
+  3. [ ] pgmk ejhr jhc lprcbnivbj jhrudc
+         `<nii cqlpi="bd__voufcgqv__cdoorc-eaiiudrn__de-hvsrqoc"> hrctq <i ulrqj="uqu-rkbp vlu-aofu ">`
+  4. [ ] fibm pids cjf dndsjastgc dnlbqkqi
+         mqqb fvosualf ou qtmai="ll__ioeogdkp__psavvo-qmnnecws__ehwalhgi" ooqtq
+         pvj qualviq odnlnlqwohu moq igaojm garh ouht
+  5. [ ] vbrb cino aga ueqwvnr tcauju
+         `<dpv jmdoq="mk__kqphtsoc__fnhhfc-keeueiak__pu-bjjcgvg"> wopij <n msvbf="dau-gita hcsqfw-jwew ">`
+  6. [ ] vufb iifp gag sihvppggth weehduug
+         hjut qlwobqoa qc fddub="dh__pthtjkcb__ajgbal-pcpbmtkn__sksbtjsu" sheuh
+         tcj dajhfsc muimuchwtgj wpo fshqhj hulu atqr
+  7. [X] pdbpoj wfjgsai jf/klo --> *ers gbolkw*
+         $(".miucgorkkc__ovotu-gduosdmom-lwbbf .vhdko-ba-mokjuh pewsd"
+  8. [X] hduk ajknd hr/otm --> *abr hfnsdv*
+         $(".rlkc-whhlb .bkmsn-ai-pblgem .ruvfv-hh-elrean__emspe")
+         $(".jwkg-qogct .vhlrb-il-phmgwp .padmi-gt-rlkebo__mmcqa--utsrvu")
+  9. [ ] laeoi befinktvc qw/imk -- hicoudnwwqup euu qfvn hsat
+         `<pgq wrdgl="enfpnjbwwpr-wbublgfs">` tuc iauj fwsu, kwkjb an uhrdag
+  10. [X] euuw qmduwefldv og mjw lpqel ervjnohji --> *nntm afbit 9*
+  11. [X] mioes tkrspq? --> *sbc nkadjw*
+          `$('.qveufvswdv__rhrni-jljbsciws-emghk__jnwfjl__lpqej .gtqcf-hvsc')`
+
+.mdsem-cgnk-mdrco pdvllkvvbr__ljjfp-agrvaqkvq-htsst .baf-poww trbmg-iskr
+
+
+== gtm-1867: qqmuqj gng pwbldebvg hjrd aditvu mlfapjghg ve qcfveaa kc fv47 ==
+
+- jwru kp lrnwtidfu wh nljmi ro mvrhf rs 1524: lnshm qjre ju chc tepqq lsvvrw
+
+- [X] btwmk ikhmt uuf uu tdf pgm-1749 kl rrhjpj
+
+- [X] gvf aht ddcq `csvdm sjjl ipjfcnnu viou cer hlifmlf fhts 3 qmanp...`
+      fhult://otvbsbpbw-elh.drt.bnsfhhev.vnp/dsqdvtw/vnp/rbj-amb-piirp-anfg/236/rlfmq/phjpcl/ipq.mdpk#s1-d1-b3-j42-a1
+      --> ecamicak cim grnfqjpd dttuhfg; tdevaqkmj nmetkf a cewjmv rsh itek
+      paietpu --> lcqnkdlv pfv ovim njpm aw qwocupegi vl igk bdsrsik lhq
+      rrqfnij vl "ucv-1841: tvoacm uhlfwdoq oj lovscv"
+      
+- [X] itst goaseo-tsdsk-tekle ho abupn kvnbr, ofipfnsvdn rcm-1879
+- [X] eqkd niciwu-qiewt-cd-aajlipkqvq ut nkhvgbt - ufmrouf dvop mwv wdj-1750
+      si ognsha eprb smo 
+- [X] dcbvnejjtqc hasmds wipha vcrhp: 5 vb 6 pdblk evfmbip --> eg bpnhb mla
+      uvrfdg necha asgsjreg tg daw jsjl dvrllp, bscdq bqbhc ik oe gknpfku;
+      cpeafrj liwb jjgdof --> rtogapp oa "kbv-1783: dfvaro iisqg tbhj pvl wvo
+      gikfncj bvtam"
+- [X] vpsal cmu uhs mcinmcc jo utwngl js hhc-iiq-vvmmok, mc oorlsgav avncoc
+      hfj wjclq utv'e vc pemmrv ak pib rr bat csfhsoue --> rrmuofe rwpg hs
+      wndewb, su nu furb eu ilhvboqwg cc ebjl kvg ka kpa fvro aast ic au
+      fweoqg --> qaucbgmb w vfpc ocb kbb dpkqrb gat-mfp-strqif mul apgbn cci
+      kjske fauk fonkkg jst-1867+sgcakf ltl tkbnnoww kuo ajbrw
+
+- [X] bobwnjp imn omjq jviahb (vnee ub bgrnbvtoa-oeq) up g difuqga dd wns smdl
+      egf kq eat wm
+      {{{ test txt
+ieoueos sq tjkmmihko: ucvpa://swbvkfusk-hcu.tno.wgdkaqpv.dds/ercjvpu/tsug/nsu-deipi/dvf/ipq-sjw-otr/118/wtruj/wfccus/gnw.wcor
+
+- obgnnmc cma eeggcuaa uaj etu vhof lswmwd we ggl ebtsjmon wnmlv (sc_nvmh_sajvaukr_dsjhin)
+- euqfvwd ipr octs 'atrwj epuv qkhecimr ndwh gan jsvlkaw hqkw 3 umlro nrn nsw vhowckf - hpua s' sh uhd bwuv-ncfcu-cdtdt fgcds, sr lbc vijcvkk ofv nhwwbwr gg ijs-1841: jqdsjw skmetrhe hl mlcuml
+- funfpu cov joajfn-brstn-wncri 'kihro-eewfj' (khr-pqgclojd wtou ndi hu vi pfnfpdwieao rhhdjoe), wgbkqdc cn dcp avmer gb dqt-1879
+- euhlga ndurkq-lfmvg-lf-tcbdkeklur vr duqvlnr (qoershu), ot wg vmf dkkelhph nnd najpg id snodsq cv utg-1750
+- dvpscfg nan ntvtaq ljtuo tkcdp, ur cug mwh nnhgik qlseu fiwqvfk cbj dqcewpw ow awr-1783: afcrei rfftb bdft pln mgw qeulqie ukhut
+
+
+uvqmejw ic gquubjnwf: mkavt://noppsutcp-otu.kdo.vjtnafpg.dwe/hrrsiva/cnuj/gub-pmqwp/tog/tmf-ptu-wwb/139/jedqk/erqbaf/oqi.folj
+- fvwhru slb cketoj pbme bk tma ifhstlqlil baafdgolei nkklremgq qe mmi ggajmd tvufvkc oi qcg ni
+- hmbnnf uwdkd wlaltqnbhsk wgw ttndc cdagol gqi dgn cg pdrdjwc vjkwhn, vpinn rhf hpwtvem
+      }}}
+
+- [X] nuorvc nfssgbrug le utf us bmuimwf (uamdvhc etjq wlmbvi sphjq) -
+      ~~cvgvvcai dp fkacrs bfga lv huc kamuvhm ghaahf~~
+
+
+
+= Small header =
+
+fckegjt: 2012 inn 30
+
+* bdécfu
+   - fksahojwv qhcnf id cir wmjem kgqshbosdu q ebnrk hf akhldshl, p cuo rqebgsi
+     oebhvhjqjmf i jkpfw
+   - bg eíplgq iquojk upcpvqa, rpovmh pbrufvhrns mmd kd kfgbls
+   - qidfdes kghthdd tbc? (cesmmtcerhitl iim jfrqqwltnçãd oh tle/epr, kcwslicf
+     ouph, pnmubmgu qb eo)
+   - gstbnppc igru jouõho/ihgnfefd
+
+* qooi wa jnkoajtm taws wvlimjw varbhijwlis skms hnjen fjnthul: 
+  vqdh://upa.cltpdofdkf.vkr.ms/
+* knot egdkpt snrc apept:
+  jdh qhvq tab ewkhlwi bsld chukkrjoun & pmqmicsb 
+  gthq://rps.ootfbrnquu.ihk/hspkccp-ip/298146285-hgpe-jockvcrs-vmi-ibkw-buh-eaqhetk-pvtj-hwoldedhag-recjjimw-vduerdkhvod.wpte
+
+
+* bgdgkawop p fmghn rkg mnmgllaqfemvl vqft nuwnhul, gqft psnwg iimtiofwul ft
+  pqbhtcçõmu - nf ltw ndhcho, il atpfmk uãe qklt orkqt
+* bgftuehke gwounka ae sjpms ofl gswbikqjuwccl bwhw gknwbjs
+
+* kcf wdcvl ck ihgidhwc.aqcr -> hutfawcqtgm a cplqrmjkn kqafrchfrik 
+
+* 14/11/2012: jq gqjéd av ugchklds kqac mpdqs pqttllt, rftotvtv avdpn
+  teboefalb ( "efhsthtehh ll nveepo" - gqrbb kef 69 r 50fk i/ 452 gki + dwq
+  ajsq://mnt.ssjutgpw.fvf/dntcs/kin-du1 ) k gnkmj qj fvasjnfdb hh
+  swnt/ivi->nhv ondm mtjso wutk pcaifsrijrl krvcnov
+  (bqpg://rdu.khakwatu.bun/imuap/tko-nmfg-lpcc16 -
+  njwh://rua.dvjiowpb.roo/ftloi/str-jade48-sfj48h ); wjahmf opropfc hb pr
+  wwotqnnmh rtgs/cfk rwj alep dmfkd kfth wufiq wjdhgfl c acwlmotbvgmbppej
+  n pmukr ivwp://dqa.uvcosfob.pqo/narkr/sic-rcfe48-isg48d vbcw rrrojp s
+  vsehvsqh nwtr, mkhf kubg eikchrm.
+
+* 18/12/2012 - cvétt jo febbilu: rpumkvdnwgq eu jlpwirçãg
+   - hhcpeu vn aiépu fr scvbv sr rlfpw ee baoknjodit ji rcfslvçãt bq
+     saasítjtq, srbjiqljfe fg djmaíat s hs vwtets gl uqdiiiu. pslccc qnnisap
+     kmnt mhu fcmkkmdpc tkq p rsdjku, wcp vl wpjiin.
+   - rvmr m oiése huoraap erdhlv lqteqwwl sfvwbwqgtu, vgdw cw trmdsrvmcpe i
+     sgpoicaqpcmf, s wsiõcm avci gqn (hvcdah 3, tomoq, kcearjh o wuviosba)
+     dltr idstckamv j rmdsqujvh ev dktmfwgeqrt lv uopwbw - ibrlw jdtlw é
+     nujrífsv nquçhm vgvesb i loemqkuk cc jgpvbowg sdmguemb uk londmnp ai wq
+     thjvi aa nofmm f cngacnsdnlui, nvedimtevbb b éugve wi dkk (egfcçãm),
+     vecibsob o gcijemjus (rlváebc khqm oockgllk qwonãm/anlfug).
+   - tbul frvoeqa kbj knrkuiqçãk jdr h csfi, hkdj wqdrweren/gitofdrw ctmnb bu
+     hnamto d ddshoqwlpdvpq usohjrbl v eapwnkháwvf (auo q-ecfi, ovpigssipv
+     dpboagfp) wvf n vglwlbv rmtá cmpot vhwu (amquuçãv nde ojfhcu jçãq
+     tqcgail, tfm jiv evq p gbijcfhrqgml/wbdfefbui hãp tfcl gwitg bndw)
+   - gcquícbug agiegdfs euhlsr flmbnthmql bh jqngq, vfpdbtlt
+   - jd l loéth gãc wbl vháwms ugsb phllkr egjo iphrucq cjoinuh pdodg
+     uflseqáwvp..vn
+   - i uoéso ogmo hbd oml piaw guaiwd aullamde ph blsafsw, ipo sunjwfm vq
+     alqmcqoh lfbkfdôsfshn.
+   - 17/06/2016: pcej://rki.tmd.rkl/cjeoqapi/kbnvlbb/2016/06/16/473526920/blp-pqqvom-vnhpsg-c-vidqfvcurw-atbuuqwefi
+     
+* 26/03/2013: eóg tdbwkpçõgm vãh ps fop oeunk dohs fguiq vqaohics, ar apgdhguo
+  cr ejj cf ávru ca sqlifsu
+
+== atisqooa/dóithrp: jlg qsúrgv, aci ifruelj, iks ==
+
+* fceeu
+* vlwwég
+* eçadts
+
+fjul://rdwgnmsuampevohemsc.lmw.od/tnow/2014/04/10/wdsdua-wvmr-kfk-eahsmtsakcl-qhshs-ugdjev/
+
+k ulm imp w dmm
+ps bamncb jwt b sngvjlnçãj, nsagv ff dhmqfasuu vvedjjrlblomeike swdjt wcuque
+fg cuv kóktfr t kcmp, *aduwatebpggmiaoo, hl nkgrfbçõif diwdév laúwql dp jãb*
+*fqcnéj leúalu.*
+
+q gsggfukçãp sko aa mrbkd vgeurepa cqg dóssdwu u scbfapfvcs nbo ogmrikss o
+herpéb wn ioedcghm p spckbncno bq wbimnpqçãw, fi eqlfo eísusr v le eájuj
+roijjjr.
+
+
+
+== jsk ==
+
+olt weg kdcocnp sd bd afes urscsiva oq rlríkk hojjj "vlkphdls" ehkpna
+(jrcdedal, hhwefqvl, hmcrpo ebhvu mgd, vtispil/thbgcf ejjlvdsdkeu)
+lsfh elt rahnowiutv ijviow, ohbf tctbhsvqk omnjl mestfs, eor indunw c4
+(ioiu://dlkokwoctgb.shg/jdkmirhfk-bnopv-ndlsaa/), d iiohtood wds dqpac gkuvu
+ovjf pndfbgçõth.  --> 03/2013: wãw ward a oisl mmgtac neptbknt pwor, aolkbr
+komeg pjlnh wiqkéu gkp iwsig.
+
+
+
+
+

--- a/tests/tabnext_delay.txt
+++ b/tests/tabnext_delay.txt
@@ -1,0 +1,18 @@
+" From https://github.com/vimwiki/vimwiki/pull/601
+$ gvim -u NONE -U NONE -N -i NONE
+<commands below can be copied to clipboard and run with `:@+`>
+set nocompatible
+filetype plugin on
+syntax on
+let g:vimwiki_camel_case = 0  " Don't make links from CamelCased words
+let g:vimwiki_table_auto_fmt = 0 " Turn off table auto-formatting
+let g:vimwiki_autowriteall = 0
+let g:vimwiki_folding = 'expr:quick'    " Enable folding.
+let &rtp.=',~/.vim/bundle/vimwiki'
+source ~/.vim/bundle/vimwiki/plugin/vimwiki.vim
+e ~/tmp/delay.wiki
+normal! 50%
+normal! zozo
+tabe
+let start = reltime() | tabprev | redraw | echom reltimestr(reltime(start))
+" >>> expected: less than 0.5 seconds


### PR DESCRIPTION
Setting `'foldmethod'` always causes all folds to be re-calculated, even though its is being written with same value currently set.

The  `'foldmethod'` was being reset every time the cursor entered a vimwiki, causing an uncessary large delay. So it was changed to set it only the first time the buffer is loaded into a window.

Fix #580