### PR TITLE
Add separate highlight group for rejected todo list items

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2345,7 +2345,6 @@ Default: 0
 The |group-name|s for option 3 are as follows:
 Checkbox       Highlight Group~
 [X]            VimwikiCheckBoxDone
-[.], [o], [O]  VimwikiCheckBoxInProgress
 [-]            VimwikiCheckBoxRejected
 
 Note: Option 2 does not work perfectly.  Specifically, it might break if the

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2338,8 +2338,15 @@ Value           Description~
 0               Don't highlight anything.
 1               Highlight checked [X] list item with |group-name| "Comment".
 2               Highlight checked [X] list item and all its child items.
+3               Highlight list items with special |group-name|s.
 
 Default: 0
+
+The |group-name|s for option 3 are as follows:
+Checkbox       Highlight Group~
+[X]            VimwikiCheckBoxDone
+[.], [o], [O]  VimwikiCheckBoxInProgress
+[-]            VimwikiCheckBoxRejected
 
 Note: Option 2 does not work perfectly.  Specifically, it might break if the
 list item contains preformatted text or if you mix tabs and spaces for

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -270,9 +270,6 @@ elseif vimwiki#vars#get_global('hl_cb_checked') == 3
   execute 'syntax match VimwikiCheckBoxDone /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
         \ . '\s*\[['.vimwiki#vars#get_syntaxlocal('listsyms_list')[-1]
         \ . ']\]\s.*$/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
-  execute 'syntax match VimwikiCheckBoxInProgress /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
-        \ . '\s*\[['.join(vimwiki#vars#get_syntaxlocal('listsyms_list')[1:-2], "")
-        \ . ']\]\s.*$/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
   execute 'syntax match VimwikiCheckBoxRejected /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
         \ . '\s*\[['.vimwiki#vars#get_global('listsym_rejected')
         \ . ']\]\s.*$/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -266,6 +266,16 @@ elseif vimwiki#vars#get_global('hl_cb_checked') == 2
   execute 'syntax match VimwikiCheckBoxDone /'
         \ . vimwiki#vars#get_syntaxlocal('rxListItemAndChildren')
         \ .'/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
+elseif vimwiki#vars#get_global('hl_cb_checked') == 3
+  execute 'syntax match VimwikiCheckBoxDone /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
+        \ . '\s*\[['.vimwiki#vars#get_syntaxlocal('listsyms_list')[-1]
+        \ . ']\]\s.*$/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
+  execute 'syntax match VimwikiCheckBoxInProgress /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
+        \ . '\s*\[['.join(vimwiki#vars#get_syntaxlocal('listsyms_list')[1:-2], "")
+        \ . ']\]\s.*$/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
+  execute 'syntax match VimwikiCheckBoxRejected /'.vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
+        \ . '\s*\[['.vimwiki#vars#get_global('listsym_rejected')
+        \ . ']\]\s.*$/ contains=VimwikiNoExistsLink,VimwikiLink,@Spell'
 endif
 
 


### PR DESCRIPTION
Found vimwiki recently and appreciating it a lot so far!  I find it useful to be able to highlight and rejected todo list items differently, so I've added that to the syntax file.  Is this a change you'd be interested in upstreaming in some form?

Thanks!