### PR TITLE
HTML color colorcodes.

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -349,8 +349,12 @@ function! s:tag_code(value)
   let l:str = s:mid(a:value, 1)
   let l:match = match(l:str, '^#[a-fA-F0-9]\{6\}$')
 
+
   if l:match != -1
-    let l:retstr .= " style='background-color: " . l:str . ";'"
+    let l:inv_color = 0xFFFFFF - eval("0x" . l:str[1:])
+
+    let l:retstr .= printf(" style='background-color: %s; color: #%x;'",
+          \ l:str, l:inv_color)
   endif
 
   let l:retstr .= '>'.s:safe_html_preformatted(l:str).'</code>'

--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -349,12 +349,18 @@ function! s:tag_code(value)
   let l:str = s:mid(a:value, 1)
   let l:match = match(l:str, '^#[a-fA-F0-9]\{6\}$')
 
-
   if l:match != -1
-    let l:inv_color = 0xFFFFFF - eval("0x" . l:str[1:])
+    let l:r = eval("0x".l:str[1:2])
+    let l:g = eval("0x".l:str[3:4])
+    let l:b = eval("0x".l:str[5:6])
 
-    let l:retstr .= printf(" style='background-color: %s; color: #%x;'",
-          \ l:str, l:inv_color)
+    let l:fg_color =
+          \ (((0.299 * r + 0.587 * g + 0.114 * b) / 0xFF) > 0.5)
+          \ ? "black" : "white"
+
+    let l:retstr .=
+          \ " style='background-color:" . l:str .
+          \ ";color:" . l:fg_color . ";'"
   endif
 
   let l:retstr .= '>'.s:safe_html_preformatted(l:str).'</code>'

--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -344,7 +344,17 @@ endfunction
 
 
 function! s:tag_code(value)
-  return '<code>'.s:safe_html_preformatted(s:mid(a:value, 1)).'</code>'
+  let l:retstr = '<code'
+
+  let l:str = s:mid(a:value, 1)
+  let l:match = match(l:str, '^#[a-fA-F0-9]\{6\}$')
+
+  if l:match != -1
+    let l:retstr .= " style='background-color: " . l:str . ";'"
+  endif
+
+  let l:retstr .= '>'.s:safe_html_preformatted(l:str).'</code>'
+  return l:retstr
 endfunction
 
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -880,6 +880,12 @@ is decorated: >
 Furthermore, there are a number of words which are highlighted extra flashy:
 TODO, DONE, STARTED, FIXME, FIXED, XXX.
 
+When rendered as HTML, code blocks containing only a hash prefixed 6 digit hex
+number will be colored as themselves.  For example >
+ `#ffe119`
+Becomes >
+ <code style='background-color:#ffe119;color:black;'>#ffe119</code>
+
 ------------------------------------------------------------------------------
 5.2. Links                                              *vimwiki-syntax-links*
 


### PR DESCRIPTION
This colors all CSS color codes found alone in inline code blocks to the color they mention.
So `#00cc00` Would show up as green, but `_#00cc00` would show up as normal (probably gray).

Two commits are included, one simply changes the background color, while the other also calculates the inverse of the color and sets that as the text color.

I have set up a demo at http://wiki.hornquist.se/Colors.html.