### PR TITLE
Allow customization of header level of TOC

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -343,7 +343,7 @@ function! vimwiki#base#generate_links()
 
   let links_rx = '\m^\s*'.vimwiki#u#escape(vimwiki#lst#default_symbol()).' '
 
-  call vimwiki#base#update_listing_in_buffer(lines, 'Generated Links', links_rx, line('$')+1, 1)
+  call vimwiki#base#update_listing_in_buffer(lines, 'Generated Links', links_rx, line('$')+1, 1, 1)
 endfunction
 
 
@@ -996,14 +996,14 @@ endfunction
 
 " creates or updates auto-generated listings in a wiki file, like TOC, diary
 " links, tags list etc.
-" - the listing consists of a level 1 header and a list of strings as content
+" - the listing consists of a header and a list of strings as content
 " - a:content_regex is used to determine how long a potentially existing list is
 " - a:default_lnum is the line number where the new listing should be placed if
 "   it's not already present
 " - if a:create is true, it will be created if it doesn't exist, otherwise it
 "   will only be updated if it already exists
 function! vimwiki#base#update_listing_in_buffer(strings, start_header,
-      \ content_regex, default_lnum, create)
+      \ content_regex, default_lnum, header_level, create)
   " apparently, Vim behaves strange when files change while in diff mode
   if &diff || &readonly
     return
@@ -1012,7 +1012,8 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
   " check if the listing is already there
   let already_there = 0
 
-  let header_rx = '\m^\s*'.substitute(vimwiki#vars#get_syntaxlocal('rxH1_Template'),
+  let header_level = 'rxH' . a:header_level . '_Template'
+  let header_rx = '\m^\s*'.substitute(vimwiki#vars#get_syntaxlocal(header_level),
         \ '__Header__', a:start_header, '') .'\s*$'
 
   let start_lnum = 1
@@ -1064,7 +1065,7 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
 
   " write new listing
   let new_header = whitespaces_in_first_line
-        \ . s:safesubstitute(vimwiki#vars#get_syntaxlocal('rxH1_Template'),
+        \ . s:safesubstitute(vimwiki#vars#get_syntaxlocal(header_level),
         \ '__Header__', a:start_header, '')
   call append(start_lnum - 1, new_header)
   let start_lnum += 1
@@ -1838,8 +1839,13 @@ function! vimwiki#base#table_of_contents(create)
 
   let links_rx = '\m^\s*'.vimwiki#u#escape(vimwiki#lst#default_symbol()).' '
 
-  call vimwiki#base#update_listing_in_buffer(lines,
-        \ vimwiki#vars#get_global('toc_header'), links_rx, 1, a:create)
+  call vimwiki#base#update_listing_in_buffer(
+        \ lines,
+        \ vimwiki#vars#get_global('toc_header'),
+        \ links_rx,
+        \ 1,
+        \ vimwiki#vars#get_global('toc_header_level'),
+        \ a:create)
 endfunction
 
 

--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -282,7 +282,7 @@ function! vimwiki#diary#generate_diary_section()
   if vimwiki#path#is_equal(current_file, diary_file)
     let content_rx = '^\%(\s*\* \)\|\%(^\s*$\)\|\%('.vimwiki#vars#get_syntaxlocal('rxHeader').'\)'
     call vimwiki#base#update_listing_in_buffer(s:format_diary(),
-          \ vimwiki#vars#get_wikilocal('diary_header'), content_rx, line('$')+1, 1)
+          \ vimwiki#vars#get_wikilocal('diary_header'), content_rx, line('$')+1, 1, 1)
   else
     echomsg 'Vimwiki Error: You can generate diary links only in a diary index page!'
   endif

--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1051,39 +1051,35 @@ function! s:process_tag_h(line, id)
     let h_id = s:escape_html_attribute(h_text)
     let centered = (a:line =~# '^\s')
 
-    if h_text !=# vimwiki#vars#get_global('toc_header')
+    let a:id[h_level-1] = [h_text, a:id[h_level-1][1]+1]
 
-      let a:id[h_level-1] = [h_text, a:id[h_level-1][1]+1]
+    " reset higher level ids
+    for level in range(h_level, 5)
+      let a:id[level] = ['', 0]
+    endfor
 
-      " reset higher level ids
-      for level in range(h_level, 5)
-        let a:id[level] = ['', 0]
-      endfor
-
-      for l in range(h_level-1)
-        let h_number .= a:id[l][1].'.'
-        if a:id[l][0] != ''
-          let h_complete_id .= a:id[l][0].'-'
-        endif
-      endfor
-      let h_number .= a:id[h_level-1][1]
-      let h_complete_id .= a:id[h_level-1][0]
-
-      if vimwiki#vars#get_global('html_header_numbering')
-        let num = matchstr(h_number,
-              \ '^\(\d.\)\{'.(vimwiki#vars#get_global('html_header_numbering')-1).'}\zs.*')
-        if !empty(num)
-          let num .= vimwiki#vars#get_global('html_header_numbering_sym')
-        endif
-        let h_text = num.' '.h_text
+    for l in range(h_level-1)
+      let h_number .= a:id[l][1].'.'
+      if a:id[l][0] != ''
+        let h_complete_id .= a:id[l][0].'-'
       endif
-      let h_complete_id = s:escape_html_attribute(h_complete_id)
+    endfor
+    let h_number .= a:id[h_level-1][1]
+    let h_complete_id .= a:id[h_level-1][0]
+
+    if vimwiki#vars#get_global('html_header_numbering')
+      let num = matchstr(h_number,
+            \ '^\(\d.\)\{'.(vimwiki#vars#get_global('html_header_numbering')-1).'}\zs.*')
+      if !empty(num)
+        let num .= vimwiki#vars#get_global('html_header_numbering_sym')
+      endif
+      let h_text = num.' '.h_text
+    endif
+    let h_complete_id = s:escape_html_attribute(h_complete_id)
+    if h_text !=# vimwiki#vars#get_global('toc_header')
       let h_part = '<div id="'.h_complete_id.'"><h'.h_level.' id="'.h_id.'"'
-
     else
-
-      let h_part = '<div id="'.h_id.'" class="toc"><h1 id="'.h_id.'"'
-
+      let h_part = '<div id="'.h_id.'" class="toc"><h'.h_level.' id="'.h_id.'"'
     endif
 
     if centered

--- a/autoload/vimwiki/tags.vim
+++ b/autoload/vimwiki/tags.vim
@@ -329,7 +329,7 @@ function! vimwiki#tags#generate_tags(...) abort
         \ .vimwiki#u#escape(vimwiki#lst#default_symbol()).' '
         \ .vimwiki#vars#get_syntaxlocal('rxWikiLink').'$\)'
 
-  call vimwiki#base#update_listing_in_buffer(lines, 'Generated Tags', links_rx, line('$')+1, 1)
+  call vimwiki#base#update_listing_in_buffer(lines, 'Generated Tags', links_rx, line('$')+1, 1, 1)
 endfunction
 
 

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -57,6 +57,7 @@ function! s:populate_global_variables()
         \ 'table_auto_fmt': 1,
         \ 'table_mappings': 1,
         \ 'toc_header': 'Contents',
+        \ 'toc_header_level': 1,
         \ 'url_maxsave': 15,
         \ 'use_calendar': 1,
         \ 'use_mouse': 0,


### PR DESCRIPTION
Instead of forcing the TOC to always be at header level 1, allow the
user to specify via the option g:vimwiki_toc_header_level what level
they want.

This defaults to 1, so if the user does nothing then the old behavior
will remain the same.

Closes #626.