### PR TITLE
Prevent silent E325 when opening wiki pages. Fix #569.

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -741,22 +741,26 @@ function! vimwiki#base#edit_file(command, filename, anchor, ...)
   " This hack is necessary because apparently Vim messes up the result of
   " getpos() directly after this command. Strange.
   if !(a:command ==# ':e ' && vimwiki#path#is_equal(a:filename, expand('%:p')))
-    if &autowriteall && !&hidden  " in this case, the file is saved before switching to the
-      " new buffer. This causes Vim to show two messages in the command line which triggers
-      " the annoying hit-enter prompt. Solution: show no messages at all.
-      silent execute a:command fname
-    else
-      try
-        execute a:command fname
-      catch /E37:/
-        echomsg 'Vimwiki: Can''t leave the current buffer, because it is modified. Hint: Take a look at'
-              \ ''':h g:vimwiki_autowriteall'' to see how to save automatically.'
-        return
-      catch /E325:/
-        echom 'Vimwiki: Vim couldn''t open the file, probably because a swapfile already exists. See :h E325.'
-        return
-      endtry
-    endif
+    try
+      if &autowriteall && !&hidden  " in this case, the file is saved before switching to the
+        " new buffer. This causes Vim to show two messages in the command line which triggers
+        " the annoying hit-enter prompt. Solution: show no messages at all.
+        silent execute a:command fname
+      else
+        try
+          execute a:command fname
+        catch /E37:/
+          echomsg 'Vimwiki: Can''t leave the current buffer, because it is modified. Hint: Take a look at'
+                \ ''':h g:vimwiki_autowriteall'' to see how to save automatically.'
+          return
+        endtry
+      endif
+    catch /E308:/
+      echomsg 'Vimwiki: The file has been recovered.'
+    catch /E325:/
+      echomsg 'Vimwiki: Vim couldn''t open the file, probably because a swapfile already exists. See :h E325.'
+      return
+    endtry
 
     " If the opened file was not already loaded by Vim, an autocommand is
     " triggered at this point

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -111,6 +111,19 @@ function! s:setup_buffer_enter()
   call s:set_windowlocal_options()
 endfunction
 
+function! s:swap_file_exists()
+  " don't do anything if it's not managed by Vimwiki (that is, when it's not in
+  " a registered wiki and not a temporary wiki)
+  if vimwiki#vars#get_bufferlocal('wiki_nr') == -1
+    return
+  endif
+
+  let choice_num = confirm('Swap file "' . v:swapname . '" already exists. ' .
+    \ 'The same wiki page may be open from another vim session.',
+    \ "&Open Read-Only\n&Edit anyway\n&Recover\n&Quit\n&Abort\n&Delete it", 1)
+  let swap_choices = ['a', 'o', 'e', 'r', 'q', 'a', 'd']
+  let v:swapchoice = swap_choices[choice_num]
+endfunction
 
 function! s:setup_cleared_syntax()
   " highlight groups that get cleared
@@ -257,6 +270,7 @@ augroup vimwiki
   for s:ext in s:known_extensions
     exe 'autocmd BufNewFile,BufRead *'.s:ext.' call s:setup_new_wiki_buffer()'
     exe 'autocmd BufEnter *'.s:ext.' call s:setup_buffer_enter()'
+    exe 'autocmd SwapExists *'.s:ext.' unsilent call s:swap_file_exists()'
     exe 'autocmd BufLeave *'.s:ext.' call s:setup_buffer_leave()'
     " Format tables when exit from insert mode. Do not use textwidth to
     " autowrap tables.


### PR DESCRIPTION
In the current version of vimwiki when `g:vimwiki_autowriteall` is set, the edit command to open a wiki page is executed silently, therefore the ATTENTION (E325) message warning the user that a swap file already exists is not displayed on the console, but vim is still blocked waiting for the user's choice. In this state, some keypresses can trigger an exception which results in the messages in issue #569.

This change adds a SwapExists autocmd handler that "unsilently" displays a dialog similar to the default E325 dialog.

Steps to reproduce the issue:
  1. Make sure `g:vimwiki_autowriteall` is set to 1 (which is the default).
  2. Open the same wiki page in two separate instances of vim.

I have tested this on:
   * console vim (VIM - Vi IMproved 8.1 (2018 May 18, compiled Mar 11 2019 08:36:40), macOS version, Included patches: 1-1000, Compiled by Homebrew)
   * MacVim (VIM - Vi IMproved 8.1 (2018 May 18, compiled Feb 18 2019 23:51:40), macOS version. Included patches: 1-950, Compiled by travis@Traviss-Mac.local)

I tried to test this patch thoroughly with various vim and vimwiki settings. I am new to VimScript, but I tried to follow coding conventions in the rest of the plugin. Please feel free to let me know your comments on the PR in case anything looks incorrect.