### PR TITLE
Adjust generated header behavior for TOC, links, tags, and diary (oh my!)

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -165,13 +165,18 @@ function! s:read_global_settings_from_user()
         \ 'html_header_numbering_sym': {'type': type(''), 'default': ''},
         \ 'list_ignore_newline': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'text_ignore_newline': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
+        \ 'links_header': {'type': type(''), 'default': 'Generated Links', 'min_length': 1},
+        \ 'links_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 6},
         \ 'listsyms': {'type': type(''), 'default': ' .oOX', 'min_length': 2},
         \ 'listsym_rejected': {'type': type(''), 'default': '-', 'length': 1},
         \ 'map_prefix': {'type': type(''), 'default': '<Leader>w'},
+        \ 'markdown_header_style': {'type': type(0), 'default': 1, 'min':0, 'max': 2},
         \ 'markdown_link_ext': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'menu': {'type': type(''), 'default': 'Vimwiki'},
         \ 'table_auto_fmt': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'table_mappings': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
+        \ 'tags_header': {'type': type(''), 'default': 'Generated Tags', 'min_length': 1},
+        \ 'tags_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 5},
         \ 'toc_header': {'type': type(''), 'default': 'Contents', 'min_length': 1},
         \ 'toc_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 6},
         \ 'url_maxsave': {'type': type(0), 'default': 15, 'min': 0},
@@ -707,6 +712,10 @@ function! s:populate_extra_markdown_vars()
   " [DESCRIPTION](ANCHOR)
   let mkd_syntax.Weblink2Template = mkd_syntax.rxWeblink1Prefix . '__LinkDescription__'.
         \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'. mkd_syntax.rxWeblink1Suffix
+  " [DESCRIPTION](FILE#ANCHOR)
+  let mkd_syntax.Weblink3Template = mkd_syntax.rxWeblink1Prefix . '__LinkDescription__'.
+        \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'. mkd_syntax.rxWeblink1Ext.
+        \ '#__LinkAnchor__'. mkd_syntax.rxWeblink1Suffix
 
   let valid_chars = '[^\\]'
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2981,6 +2981,54 @@ Value           Description~
 
 Default: 0
 
+
+------------------------------------------------------------------------------
+*g:vimwiki_links_header*
+
+A string with the magic header that tells Vimwiki where the generated links
+are located in a file. You can change it to the appropriate word in your
+mother tongue like this: >
+  let g:vimwiki_links_header = 'Generierte Links'
+
+The default is 'Generated Links'.
+
+
+------------------------------------------------------------------------------
+*g:vimwiki_links_header_level*
+
+The header level of generated links. Valid values are from 1 to 6.
+
+The default is 1.
+
+
+------------------------------------------------------------------------------
+*g:vimwiki_tags_header*
+
+A string with the magic header that tells Vimwiki where the generated tags
+are located in a file. You can change it to the appropriate word in your
+mother tongue like this: >
+  let g:vimwiki_tags_header = 'Generierte Stichworte'
+
+The default is 'Generated Tags'.
+
+
+------------------------------------------------------------------------------
+*g:vimwiki_tags_header_level*
+
+The header level of generated tags. Valid values are from 1 to 5.
+
+The default is 1.
+
+
+------------------------------------------------------------------------------
+*g:vimwiki_markdown_header_style*
+
+The number of newlines to be inserted after a header is generated. Valid
+values are from 0 to 2.
+
+The default is 1.
+
+
 ==============================================================================
 13. Getting help                                                *vimwiki-help*
 
@@ -3058,6 +3106,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Zhuang Ma (@mzlogin)
     - Huy Le (@huynle)
     - Nick Borden (@hcwndbyw)
+    - Steven Stallion (@sstallion)
 
 
 ==============================================================================


### PR DESCRIPTION
This PR corrects a number of annoyances I've encountered when using markdown and generated headers a la `VimiwikiTOC`, `VimwikiGenerateLinks`, `VimwikiGenerateTags`, and `VimwikiDiaryGenerateLinks`. The original behavior would place links on the line immediately after the header, which violates common markdown style guides. A new global variable was introduced named `markdown_header_style`, which indicates the number of newlines required after a header is generated. Both generated tags and links were updated to support behavior similar to `toc_header` and `toc_header_level`. Finally, some longstanding bugs that would emit unnecessary newlines after a generation before  content (if starting on the first line) and after (if starting after the first line) were fixed.