### PR TITLE
Support automatic generation of links and tags

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -251,6 +251,8 @@ function! s:populate_wikilocal_options()
   let default_values = {
         \ 'auto_diary_index': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'auto_export': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
+        \ 'auto_generate_links': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
+        \ 'auto_generate_tags': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'auto_tags': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'auto_toc': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'automatic_nested_syntaxes': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2357,6 +2357,28 @@ See |:VimwikiDiaryGenerateLinks|:  >
   let g:vimwiki_list = [{'path': '~/my_site/', 'auto_diary_index': 1}]
 
 
+*vimwiki-option-auto_generate_links*
+------------------------------------------------------------------------------
+Key                  Default value     Values~
+auto_generate_links  0                 0, 1
+
+Description~
+Set this option to 1 to automatically update generated links when the
+current wiki page is saved: >
+  let g:vimwiki_list = [{'path': '~/my_site/', 'auto_generate_links': 1}]
+
+
+*vimwiki-option-auto_generate_tags*
+------------------------------------------------------------------------------
+Key                 Default value     Values~
+auto_generate_tags  0                 0, 1
+
+Description~
+Set this option to 1 to automatically update generated tags when the
+current wiki page is saved: >
+  let g:vimwiki_list = [{'path': '~/my_site/', 'auto_generate_tags': 1}]
+
+
 ------------------------------------------------------------------------------
 12.4 Global Options                                   *vimwiki-global-options*
 

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -266,7 +266,7 @@ command! -buffer -nargs=? VimwikiNormalizeLink call vimwiki#base#normalize_link(
 
 command! -buffer VimwikiTabnewLink call vimwiki#base#follow_link('tab', 0, 1)
 
-command! -buffer VimwikiGenerateLinks call vimwiki#base#generate_links()
+command! -buffer VimwikiGenerateLinks call vimwiki#base#generate_links(1)
 
 command! -buffer -nargs=0 VimwikiBacklinks call vimwiki#base#backlinks()
 command! -buffer -nargs=0 VWB call vimwiki#base#backlinks()
@@ -319,7 +319,7 @@ command! -buffer -bang VimwikiRebuildTags call vimwiki#tags#update_tags(1, '<ban
 command! -buffer -nargs=* -complete=custom,vimwiki#tags#complete_tags
       \ VimwikiSearchTags VimwikiSearch /:<args>:/
 command! -buffer -nargs=* -complete=custom,vimwiki#tags#complete_tags
-      \ VimwikiGenerateTags call vimwiki#tags#generate_tags(<f-args>)
+      \ VimwikiGenerateTags call vimwiki#tags#generate_tags(1, <f-args>)
 
 command! -buffer VimwikiPasteUrl call vimwiki#html#PasteUrl(expand('%:p'))
 command! -buffer VimwikiCatUrl call vimwiki#html#CatUrl(expand('%:p'))
@@ -696,7 +696,20 @@ endif
 if vimwiki#vars#get_wikilocal('auto_tags')
   " Automatically update tags metadata on page write.
   augroup vimwiki
-    au BufWritePost <buffer> call vimwiki#tags#update_tags(0, '')
+    au BufWritePre <buffer> call vimwiki#tags#update_tags(0, '')
   augroup END
 endif
 
+if vimwiki#vars#get_wikilocal('auto_generate_links')
+  " Automatically generate links *before* the file is written
+  augroup vimwiki
+    au BufWritePre <buffer> call vimwiki#base#generate_links(0)
+  augroup END
+endif
+
+if vimwiki#vars#get_wikilocal('auto_generate_tags')
+  " Automatically generate tags *before* the file is written
+  augroup vimwiki
+    au BufWritePre <buffer> call vimwiki#tags#generate_tags(0)
+  augroup END
+endif


### PR DESCRIPTION
This PR builds on #634 to add support for automatically generating links and tags, controlled by two new options: `auto_generate_links`, and `auto_generate_tags`, respectively. In order to accommodate  automatic behavior, `vimwiki#base#update_listing_in_buffer` was refactored to accept a funcref, which allows the caller to defer content generation. This allows generation to only update the buffer if a matching header is found, similar to `auto_toc`.

This was tested against a test markdown wiki with a dedicated `links.md` and `tags.md` file, which contain all generated links and tags. There is no noticeable change in performance with these options enabled for pages that do not contain generated headers.