### PR TITLE
Support file exclusion in link generation

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -452,7 +452,17 @@ function! vimwiki#base#find_files(wiki_nr, directories_only)
   else
     let pattern = '**/*'.ext
   endif
-  return split(globpath(root_directory, pattern), '\n')
+  let files = globpath(root_directory, pattern, 0, 1)
+  " filter excluded files before returning
+  function! ExcludeFiles(idx, val) closure
+    for pattern in vimwiki#vars#get_wikilocal('exclude_files')
+      if index(globpath(root_directory, pattern, 0, 1), a:val) != -1
+        return 0
+      endif
+    endfor
+    return 1
+  endfunction
+  return filter(files, funcref('ExcludeFiles'))
 endfunction
 
 

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -266,6 +266,7 @@ function! s:populate_wikilocal_options()
         \ 'diary_rel_path': {'type': type(''), 'default': 'diary/', 'min_length': 1},
         \ 'diary_caption_level': {'type': type(0), 'default': 0, 'min': -1, 'max': 6},
         \ 'diary_sort': {'type': type(''), 'default': 'desc', 'possible_values': ['asc', 'desc']},
+        \ 'exclude_files': {'type': type([]), 'default': []},
         \ 'ext': {'type': type(''), 'default': '.wiki', 'min_length': 1},
         \ 'index': {'type': type(''), 'default': 'index', 'min_length': 1},
         \ 'list_margin': {'type': type(0), 'default': -1, 'min': -1},

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2390,6 +2390,17 @@ current wiki page is saved: >
   let g:vimwiki_list = [{'path': '~/my_site/', 'auto_generate_tags': 1}]
 
 
+*vimwiki-option-exclude_files*
+------------------------------------------------------------------------------
+Key             Default value     Values~
+exclude_files   []                list of file patterns to exclude
+
+Description~
+Set this option to a list of file patterns to exclude when checking or
+generating links: >
+  let g:vimwiki_list = [{'path': '~/my_site/', 'exclude_files': ['**/README.md']}]
+
+
 ------------------------------------------------------------------------------
 12.4 Global Options                                   *vimwiki-global-options*
 


### PR DESCRIPTION
This PR adds support for excluding files when generating or checking links. This is useful if the wiki directory contains additional files with the same extension that you do not wish to index (i.e. README.md).

This was tested against a markdown wiki with and without glob patterns in the exclusion list with calls to `VimwikiGenerateLinks` and `VimwikiCheckLinks`.