### PR TITLE
Add option : g:vimwiki_table_reduce_last_col. Used to not expand tabl…

### DIFF
--- a/autoload/vimwiki/tbl.vim
+++ b/autoload/vimwiki/tbl.vim
@@ -342,6 +342,11 @@ function! s:get_aligned_rows(lnum, col1, col2, depth)
         let i += 1
       endfor
       let max_lens = s:get_cell_max_lens(a:lnum, cells, startlnum, rows)
+      " user option not to expand last call
+      if vimwiki#vars#get_global('table_reduce_last_col')
+        let last_index = keys(max_lens)[-1]
+        let max_lens[last_index] = 1
+      endif
       let fst_lens = s:get_cell_max_lens(a:lnum, cells, startlnum, rows[0:0])
       let check_all = max_lens != fst_lens
     endif
@@ -355,6 +360,11 @@ function! s:get_aligned_rows(lnum, col1, col2, depth)
       call add(cells, vimwiki#tbl#get_cells(row))
     endfor
     let max_lens = s:get_cell_max_lens(a:lnum, cells, startlnum, rows)
+    " user option not to expand last call
+    if vimwiki#vars#get_global('table_reduce_last_col')
+      let last_index = keys(max_lens)[-1]
+      let max_lens[last_index] = 1
+    endif
   endif
   let aligns = s:get_cell_aligns(a:lnum)
   let result = []

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -171,6 +171,7 @@ function! s:read_global_settings_from_user()
         \ 'markdown_link_ext': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'menu': {'type': type(''), 'default': 'Vimwiki'},
         \ 'table_auto_fmt': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
+        \ 'table_reduce_last_col': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'table_mappings': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'toc_header': {'type': type(''), 'default': 'Contents', 'min_length': 1},
         \ 'toc_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 6},

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2720,6 +2720,20 @@ Default: 1
 
 
 ------------------------------------------------------------------------------
+*g:vimwiki_table_reduce_last_col*
+
+If set, the last column spearator will not be expanded to fill the cell.
+When `:set wrap` this option improves how a table is displayed, particularly on small screens.
+If |g:vimwiki_table_auto_fmt| is set to 0, this option has no effect.
+
+Value           Description~
+0               Enable table auto formating for all column.
+1               Disable table auto formating for last column.
+
+Default: 0
+
+
+------------------------------------------------------------------------------
 *g:vimwiki_w32_dir_enc*
 
 Convert directory name from current 'encoding' into 'g:vimwiki_w32_dir_enc'


### PR DESCRIPTION
…e last cells in order to avoid large, useless wraps

Update from #559
