### PR TITLE
Add an option to conceal preformatted text markers

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -994,11 +994,11 @@ function! vimwiki#base#nested_syntax(filetype, start, end, textSnipHl) abort
     let group='texMathZoneGroup'
   endif
 
-  let concealends = vimwiki#vars#get_global('conceal_code_blocks') ? ' concealends' : ''
+  let concealpre = vimwiki#vars#get_global('conceal_pre') ? ' concealends' : ''
   execute 'syntax region textSnip'.ft.
         \ ' matchgroup='.a:textSnipHl.
         \ ' start="'.a:start.'" end="'.a:end.'"'.
-        \ ' contains=@'.group.' keepend'.concealends
+        \ ' contains=@'.group.' keepend'.concealpre
 
   " A workaround to Issue 115: Nested Perl syntax highlighting differs from
   " regular one.

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -994,10 +994,11 @@ function! vimwiki#base#nested_syntax(filetype, start, end, textSnipHl) abort
     let group='texMathZoneGroup'
   endif
 
+  let concealends = vimwiki#vars#get_global('conceal_code_blocks') ? ' concealends' : ''
   execute 'syntax region textSnip'.ft.
         \ ' matchgroup='.a:textSnipHl.
         \ ' start="'.a:start.'" end="'.a:end.'"'.
-        \ ' contains=@'.group.' keepend'
+        \ ' contains=@'.group.' keepend'.concealends
 
   " A workaround to Issue 115: Nested Perl syntax highlighting differs from
   " regular one.

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -145,6 +145,7 @@ function! s:read_global_settings_from_user()
         \ 'auto_chdir': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'autowriteall': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'conceallevel': {'type': type(0), 'default': 2, 'min': 0, 'max': 3},
+        \ 'conceal_code_blocks': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'diary_months': {'type': type({}), 'default':
         \   {
         \     1: 'January', 2: 'February', 3: 'March',

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -145,7 +145,7 @@ function! s:read_global_settings_from_user()
         \ 'auto_chdir': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'autowriteall': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'conceallevel': {'type': type(0), 'default': 2, 'min': 0, 'max': 3},
-        \ 'conceal_code_blocks': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
+        \ 'conceal_pre': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'diary_months': {'type': type({}), 'default':
         \   {
         \     1: 'January', 2: 'February', 3: 'March',

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2797,6 +2797,27 @@ Default: 2
 
 
 ------------------------------------------------------------------------------
+*g:vimwiki_conceal_code_blocks*
+
+Conceal preformatted text markers when syntax highlighting is applied (see
+|vimwiki-option-nested_syntaxes|). For example,
+>
+    {{{python
+    def say_hello():
+        print("Hello, world!")
+    }}}
+>
+would appear as simply
+>
+    def say_hello():
+        print("Hello, world!")
+>
+in your wiki file.
+
+Default: 0
+
+
+------------------------------------------------------------------------------
 *g:vimwiki_autowriteall*
 
 Automatically save a modified wiki buffer when switching wiki pages. Has the

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2797,10 +2797,9 @@ Default: 2
 
 
 ------------------------------------------------------------------------------
-*g:vimwiki_conceal_code_blocks*
+*g:vimwiki_conceal_pre*
 
-Conceal preformatted text markers when syntax highlighting is applied (see
-|vimwiki-option-nested_syntaxes|). For example,
+Conceal preformatted text markers. For example,
 >
     {{{python
     def say_hello():

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -318,8 +318,9 @@ execute 'syntax match VimwikiCodeT /'.vimwiki#vars#get_syntaxlocal('rxCode').
 " <hr> horizontal rule
 execute 'syntax match VimwikiHR /'.vimwiki#vars#get_syntaxlocal('rxHR').'/'
 
-execute 'syntax region VimwikiPre start=/'.vimwiki#vars#get_syntaxlocal('rxPreStart').
-      \ '/ end=/'.vimwiki#vars#get_syntaxlocal('rxPreEnd').'/ contains=@Spell'
+let concealpre = vimwiki#vars#get_global('conceal_pre') ? ' concealends' : ''
+execute 'syntax region VimwikiPre matchgroup=VimwikiPreDelim start=/'.vimwiki#vars#get_syntaxlocal('rxPreStart').
+      \ '/ end=/'.vimwiki#vars#get_syntaxlocal('rxPreEnd').'/ contains=@Spell'.concealpre
 
 execute 'syntax region VimwikiMath start=/'.vimwiki#vars#get_syntaxlocal('rxMathStart').
       \ '/ end=/'.vimwiki#vars#get_syntaxlocal('rxMathEnd').'/ contains=@Spell'
@@ -395,6 +396,7 @@ hi def link VimwikiCodeT VimwikiCode
 
 hi def link VimwikiPre PreProc
 hi def link VimwikiPreT VimwikiPre
+hi def link VimwikiPreDelim VimwikiPre
 
 hi def link VimwikiMath Number
 hi def link VimwikiMathT VimwikiMath


### PR DESCRIPTION
This PR adds a feature allowing users to conceal code fence markers. 

For example, if you have the following in your wiki:

````
Some text

{{{python
def hello_world():
    print("Hello world!")
}}}
````

then setting `g:vimwiki_conceal_code_blocks` would conceal the `{{{python` and `}}}` lines to produce:
````
Some text


def hello_world():
    print("Hello world!")

````

This can make things look a lot nicer and more polished in wikis with many code blocks.

Note that this only applies to blocks that are syntax highlighted. So plain blocks that use just `{{{ }}}` (with no syntax highlighting) will not be concealed.
