### PR TITLE
Add toc_link_format option

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1893,11 +1893,13 @@ function! vimwiki#base#table_of_contents(create)
     for idx in range(h_level, 5) | let headers_levels[idx] = ['', 0] | endfor
 
     let h_complete_id = ''
-    for l in range(h_level-1)
-      if headers_levels[l][0] != ''
-        let h_complete_id .= headers_levels[l][0].'#'
-      endif
-    endfor
+    if vimwiki#vars#get_global('toc_link_format') == 0
+      for l in range(h_level-1)
+        if headers_levels[l][0] != ''
+          let h_complete_id .= headers_levels[l][0].'#'
+        endif
+      endfor
+    endif
     let h_complete_id .= headers_levels[h_level-1][0]
 
     if numbering > 0 && numbering <= h_level
@@ -1916,8 +1918,10 @@ function! vimwiki#base#table_of_contents(create)
   for [lvl, link, desc] in complete_header_infos
     if vimwiki#vars#get_wikilocal('syntax') == 'markdown'
       let link_tpl = vimwiki#vars#get_syntaxlocal('Weblink2Template')
-    else
+    elseif vimwiki#vars#get_global('toc_link_format') == 0
       let link_tpl = vimwiki#vars#get_global('WikiLinkTemplate2')
+    else
+      let link_tpl = vimwiki#vars#get_global('WikiLinkTemplate1')
     endif
     let link = s:safesubstitute(link_tpl, '__LinkUrl__',
           \ '#'.link, '')

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -181,6 +181,7 @@ function! s:read_global_settings_from_user()
         \ 'tags_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 5},
         \ 'toc_header': {'type': type(''), 'default': 'Contents', 'min_length': 1},
         \ 'toc_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 6},
+        \ 'toc_link_format': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'url_maxsave': {'type': type(0), 'default': 15, 'min': 0},
         \ 'use_calendar': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'use_mouse': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2993,6 +2993,21 @@ The default is 1.
 
 
 ------------------------------------------------------------------------------
+*g:vimwiki_toc_link_format*
+
+The format of the links in the Table of Contents (see |vimwiki-toc|).
+
+
+Value           Description~
+0               Extended: The link contains the description and URL. URL
+                references all levels.
+1               Brief: The link contains only the URL. URL references only
+                the immediate level.
+
+Default: 0
+
+
+------------------------------------------------------------------------------
 *g:vimwiki_map_prefix*
 
 A string which specifies the prefix for all global mappings (and some local


### PR DESCRIPTION
Fixes #446

Add an option for setting the format of the links in the Table of Contents:
- Extended (the current and default)
- Brief (new format for the Vimwiki markup)

Tested manually:
- The option is unset
- The option set to 0
- The option set to 1
