### PR TITLE
Add gnt mapping to jump to the next unfinished task in a wiki page.

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1156,6 +1156,11 @@ function! vimwiki#base#update_listing_in_buffer(strings, start_header,
   call winrestview(winview_save)
 endfunction
 
+function! vimwiki#base#find_next_task()
+  let taskRegex = vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
+    \ . '\+\(\[ \]\s\+\)\zs'
+  call vimwiki#base#search_word(taskRegex, '')
+endfunction
 
 function! vimwiki#base#find_next_link()
   call vimwiki#base#search_word(vimwiki#vars#get_syntaxlocal('rxAnyLink'), '')

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -318,6 +318,12 @@ NORMAL MODE                                           *vimwiki-local-mappings*
                         To remap: >
                         :nmap <Leader>wp <Plug>VimwikiPrevLink
 <
+gnt			*vimwiki_gnt*
+			Find next unfinished task in the current page.
+			Maps to |:VimwikiNextTask|
+			To remap: >
+			:nmap <Leader>nt <Plug>VimwikiNextTask
+<
                         *vimwiki_<Leader>wd*
 <Leader>wd              Delete wiki page you are in.
                         Maps to |:VimwikiDeleteLink|.
@@ -722,6 +728,9 @@ Vimwiki file.
 
 *:VimwikiRenameLink*
     Rename the wiki page you are in.
+
+*:VimwikiNextTask*
+    Jump to the next unfinished task in the current wiki page.
 
 *:Vimwiki2HTML*
     Convert current wiki page to HTML using Vimwiki's own converter or a

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -253,6 +253,7 @@ command! -buffer VimwikiAll2HTML
 
 command! -buffer VimwikiTOC call vimwiki#base#table_of_contents(1)
 
+command! -buffer VimwikiNextTask call vimwiki#base#find_next_task()
 command! -buffer VimwikiNextLink call vimwiki#base#find_next_link()
 command! -buffer VimwikiPrevLink call vimwiki#base#find_prev_link()
 command! -buffer VimwikiDeleteLink call vimwiki#base#delete_link()
@@ -380,6 +381,11 @@ if !hasmapto('<Plug>VimwikiNormalizeLinkVisualCR')
 endif
 vnoremap <silent><script><buffer>
       \ <Plug>VimwikiNormalizeLinkVisualCR :<C-U>VimwikiNormalizeLink 1<CR>
+
+if !hasmapto('<Plug>VimwikiNextTask')
+  nmap <silent><buffer> gnt <Plug>VimwikiNextTask
+endif
+nnoremap <silent><script><buffer> <Plug>VimwikiNextTask :VimwikiNextTask<CR>
 
 if !hasmapto('<Plug>VimwikiTabnewLink')
   nmap <silent><buffer> <D-CR> <Plug>VimwikiTabnewLink


### PR DESCRIPTION
This PR introduces the command `VimwikiNextTask` and the mapping `gnt` to jump to the next unfinished task. It addresses #94. 

I tested this manually with the a mixture of numbered and unnumbered tasks.

