### PR TITLE
Fix problems with commands not taking a count and mapping behavior.

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1267,17 +1267,21 @@ endfunction
 
 
 function! vimwiki#base#goto_index(wnum, ...)
+
+  " if wnum = 0 the current wiki is used
+  if a:wnum == 0
+    let idx = vimwiki#vars#get_bufferlocal('wiki_nr')
+    echom idx
+    if idx < 0  " not in a wiki
+      let idx = 0
+    endif
+  else
+    let idx = a:wnum - 1 " convert to 0 based counting
+  endif
+
   if a:wnum > vimwiki#vars#number_of_wikis()
     echomsg 'Vimwiki Error: Wiki '.a:wnum.' is not registered in your Vimwiki settings!'
     return
-  endif
-
-  " usually a:wnum is greater then 0 but with the following command it is == 0:
-  " vim -n -c ":VimwikiIndex"
-  if a:wnum > 0
-    let idx = a:wnum - 1
-  else
-    let idx = 0
   endif
 
   if a:0

--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -286,8 +286,6 @@ function! vimwiki#diary#make_note(wnum, ...)
     return
   endif
 
-  " TODO: refactor it. base#goto_index uses the same
-
   call vimwiki#path#mkdir(vimwiki#vars#get_wikilocal('path', wiki_nr).
         \ vimwiki#vars#get_wikilocal('diary_rel_path', wiki_nr))
 
@@ -310,18 +308,21 @@ function! vimwiki#diary#make_note(wnum, ...)
   call vimwiki#base#open_link(cmd, link, s:diary_index(wiki_nr))
 endfunction
 
-
 function! vimwiki#diary#goto_diary_index(wnum)
+
+  " if wnum = 0 the current wiki is used
+  if a:wnum == 0
+    let idx = vimwiki#vars#get_bufferlocal('wiki_nr')
+    if idx < 0  " not in a wiki
+      let idx = 0
+    endif
+  else
+    let idx = a:wnum - 1 " convert to 0 based counting
+  endif
+
   if a:wnum > vimwiki#vars#number_of_wikis()
     echomsg 'Vimwiki Error: Wiki '.a:wnum.' is not registered in g:vimwiki_list!'
     return
-  endif
-
-  " TODO: refactor it. base#goto_index uses the same
-  if a:wnum > 0
-    let idx = a:wnum - 1
-  else
-    let idx = 0
   endif
 
   call vimwiki#base#edit_file('e', s:diary_index(idx), '')

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -149,9 +149,9 @@ See also |:VimwikiUISelect|
 [count]<Leader>wi or <Plug>VimwikiDiaryIndex
         Open diary index file of the [count]'s wiki.
 
-        <Leader>wi opens diary index file of the first wiki from
+        <Leader>wi opens diary index file of the current wiki.
+        1<Leader>wi opens diary index file of the first wiki from
         |g:vimwiki_list|.
-        1<Leader>wi the same as above.
         2<Leader>wi opens diary index file of the second wiki from
         |g:vimwiki_list|.
         etc.
@@ -164,10 +164,9 @@ See also |:VimwikiDiaryIndex|
 [count]<Leader>w<Leader>w or <Plug>VimwikiMakeDiaryNote
         Open diary wiki-file for today of the [count]'s wiki.
 
-        <Leader>w<Leader>w opens diary wiki-file for today in the first wiki
+        <Leader>w<Leader>w opens diary wiki-file for today in the current wiki
+        1<Leader>w<Leader>w opens diary wiki-file for today in the first wiki
         from |g:vimwiki_list|.
-        1<Leader>w<Leader>w as above opens diary wiki-file for today in the
-        first wiki from |g:vimwiki_list|.
         2<Leader>w<Leader>w opens diary wiki-file for today in the second wiki
         from |g:vimwiki_list|.
         3<Leader>w<Leader>w opens diary wiki-file for today in the third wiki
@@ -182,9 +181,9 @@ See also |:VimwikiMakeDiaryNote|
 [count]<Leader>w<Leader>t or <Plug>VimwikiTabMakeDiaryNote
         Open diary wiki-file for today of the [count]'s wiki in a new tab.
 
-        <Leader>w<Leader>t tabopens diary wiki-file for today in the first
-        wiki from |g:vimwiki_list|.
-        1<Leader>w<Leader>t as above tabopens diary wiki-file for today in the
+        <Leader>w<Leader>t tabopens diary wiki-file for today in the current
+        wiki
+        1<Leader>w<Leader>t tabopens diary wiki-file for today in the
         first wiki from |g:vimwiki_list|.
         2<Leader>w<Leader>t tabopens diary wiki-file for today in the second
         wiki from |g:vimwiki_list|.
@@ -200,10 +199,10 @@ See also |:VimwikiTabMakeDiaryNote|
 [count]<Leader>w<Leader>y or <Plug>VimwikiMakeYesterdayDiaryNote
         Open diary wiki-file for yesterday of the [count]'s wiki.
 
-        <Leader>w<Leader>y opens diary wiki-file for yesterday in the first
+        <Leader>w<Leader>y opens diary wiki-file for yesterday in the current
+        wiki
+        1<Leader>w<Leader>y opens diary wiki-file for yesterday in the first
         wiki from |g:vimwiki_list|.
-        1<Leader>w<Leader>y as above opens diary wiki-file for yesterday in
-        the first wiki from |g:vimwiki_list|.
         2<Leader>w<Leader>y opens diary wiki-file for yesterday in the second
         wiki from |g:vimwiki_list|.
         3<Leader>w<Leader>y opens diary wiki-file for yesterday in the third
@@ -217,10 +216,10 @@ See also |:VimwikiMakeYesterdayDiaryNote|
 [count]<Leader>w<Leader>m or <Plug>VimwikiMakeTomorrowDiaryNote
         Open diary wiki-file for tomorrow of the [count]'s wiki.
 
-        <Leader>w<Leader>m opens diary wiki-file for tomorrow in the first
+        <Leader>w<Leader>m opens diary wiki-file for tomorrow in the current
+        wiki
+        1<Leader>w<Leader>m opens diary wiki-file for tomorrow in the first
         wiki from |g:vimwiki_list|.
-        1<Leader>w<Leader>m as above opens diary wiki-file for tomorrow in
-        the first wiki from |g:vimwiki_list|.
         2<Leader>w<Leader>m opens diary wiki-file for tomorrow in the second
         wiki from |g:vimwiki_list|.
         3<Leader>w<Leader>m opens diary wiki-file for tomorrow in the third
@@ -647,29 +646,41 @@ il                      A single list item.
 ------------------------------------------------------------------------------
 4.1. Global Commands                                 *vimwiki-global-commands*
 
-*:VimwikiIndex*
-    Open index file of the current wiki.
+*:VimwikiIndex* [count]
+    Open index file of the current wiki. If a [count] is given the
+    corresponding wiki from |g:vimwiki_list| is opened instead.
 
-*:VimwikiTabIndex*
-    Open index file of the current wiki in a new tab.
+*:VimwikiTabIndex* [count]
+    Open index file of the current wiki in a new tab. If a [count] is given
+    the corresponding wiki from |g:vimwiki_list| is opened instead.
 
 *:VimwikiUISelect*
-    Open index file of the selected wiki.
+    Displays a list of registered wikis and opens the index file of the
+    selected wiki.
 
-*:VimwikiDiaryIndex*
-    Open diary index file of the current wiki.
+*:VimwikiDiaryIndex* [count]
+    Open diary index file of the current wiki. If a [count] is given the
+    corresponding wiki from |g:vimwiki_list| is opened instead.
 
-*:VimwikiMakeDiaryNote*
-    Open diary wiki-file for today of the current wiki.
+*:VimwikiMakeDiaryNote* [count]
+    Open diary wiki-file for today of the current wiki. If a [count] is given
+    a diary wiki-file for the corresponding wiki from |g:vimwiki_list| is
+    opened instead.
 
-*:VimwikiTabMakeDiaryNote*
-    Open diary wiki-file for today of the current wiki in a new tab.
+*:VimwikiTabMakeDiaryNote* [count]
+    Open diary wiki-file for today of the current wiki in a new tab. If
+    a [count] is given a diary wiki-file for the corresponding wiki from
+    |g:vimwiki_list| is opened instead.
 
-*:VimwikiMakeYesterdayDiaryNote*
-    Open diary wiki-file for yesterday of the current wiki.
+*:VimwikiMakeYesterdayDiaryNote* [count]
+    Open diary wiki-file for yesterday of the current wiki. If a [count] is
+    given a diary wiki-file for the corresponding wiki from |g:vimwiki_list|
+    is opened instead.
 
-*:VimwikiMakeTomorrowDiaryNote*
-    Open diary wiki-file for tomorrow of the current wiki.
+*:VimwikiMakeTomorrowDiaryNote* [count]
+    Open diary wiki-file for tomorrow of the current wiki. If a [count] is
+    given a diary wiki-file for the corresponding wiki from |g:vimwiki_list|
+    is opened instead.
 
 ------------------------------------------------------------------------------
 4.2. Local commands                                   *vimwiki-local-commands*

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -194,8 +194,7 @@ endfunction
 
 
 function! s:get_version()
-  if s:plugin_vers != -1
-    echo "Stable version: " . s:plugin_vers
+  if s:plugin_vers != -1 echo "Stable version: " . s:plugin_vers
   else
     let a:plugin_rev    = system("git --git-dir " . s:plugin_dir . "/.git rev-parse --short HEAD")
     let a:plugin_branch = system("git --git-dir " . s:plugin_dir . "/.git rev-parse --abbrev-ref HEAD")
@@ -280,24 +279,31 @@ augroup END
 
 
 command! VimwikiUISelect call vimwiki#base#ui_select()
-" why not using <count> instead of v:count1?
-" See https://github.com/vimwiki-backup/vimwiki/issues/324
-command! -count=1 VimwikiIndex
-      \ call vimwiki#base#goto_index(v:count1)
-command! -count=1 VimwikiTabIndex
-      \ call vimwiki#base#goto_index(v:count1, 1)
 
-command! -count=1 VimwikiDiaryIndex
-      \ call vimwiki#diary#goto_diary_index(v:count1)
-command! -count=1 VimwikiMakeDiaryNote
-      \ call vimwiki#diary#make_note(v:count)
-command! -count=1 VimwikiTabMakeDiaryNote
-      \ call vimwiki#diary#make_note(v:count, 1)
-command! -count=1 VimwikiMakeYesterdayDiaryNote
-      \ call vimwiki#diary#make_note(v:count, 0,
+" these commands take a count e.g. :VimwikiIndex 2
+" the default behavior is to open the index, diary etc.
+" for the CURRENT wiki if no count is given
+command! -count=0 VimwikiIndex
+      \ call vimwiki#base#goto_index(<count>)
+
+command! -count=0 VimwikiTabIndex
+      \ call vimwiki#base#goto_index(<count>, 1)
+
+command! -count=0 VimwikiDiaryIndex
+      \ call vimwiki#diary#goto_diary_index(<count>)
+
+command! -count=0 VimwikiMakeDiaryNote
+      \ call vimwiki#diary#make_note(<count>)
+
+command! -count=0 VimwikiTabMakeDiaryNote
+      \ call vimwiki#diary#make_note(<count>, 1)
+
+command! -count=0 VimwikiMakeYesterdayDiaryNote
+      \ call vimwiki#diary#make_note(<count>, 0,
       \ vimwiki#diary#diary_date_link(localtime() - 60*60*24))
-command! -count=1 VimwikiMakeTomorrowDiaryNote
-      \ call vimwiki#diary#make_note(v:count, 0,
+
+command! -count=0 VimwikiMakeTomorrowDiaryNote
+      \ call vimwiki#diary#make_note(<count>, 0,
       \ vimwiki#diary#diary_date_link(localtime() + 60*60*24))
 
 command! VimwikiDiaryGenerateLinks
@@ -305,19 +311,19 @@ command! VimwikiDiaryGenerateLinks
 
 command! VimwikiShowVersion call s:get_version()
 
-
-
 let s:map_prefix = vimwiki#vars#get_global('map_prefix')
 
 if !hasmapto('<Plug>VimwikiIndex') && maparg(s:map_prefix.'w', 'n') == ""
   exe 'nmap <silent><unique> '.s:map_prefix.'w <Plug>VimwikiIndex'
 endif
-nnoremap <unique><script> <Plug>VimwikiIndex :VimwikiIndex<CR>
+nnoremap <unique><script> <Plug>VimwikiIndex
+    \ :<C-U>call vimwiki#base#goto_index(v:count1)<CR>
 
 if !hasmapto('<Plug>VimwikiTabIndex') && maparg(s:map_prefix.'t', 'n') == ""
   exe 'nmap <silent><unique> '.s:map_prefix.'t <Plug>VimwikiTabIndex'
 endif
-nnoremap <unique><script> <Plug>VimwikiTabIndex :VimwikiTabIndex<CR>
+nnoremap <unique><script> <Plug>VimwikiTabIndex
+    \ :<C-U>call vimwiki#base#goto_index(v:count1, 1)<CR>
 
 if !hasmapto('<Plug>VimwikiUISelect') && maparg(s:map_prefix.'s', 'n') == ""
   exe 'nmap <silent><unique> '.s:map_prefix.'s <Plug>VimwikiUISelect'
@@ -327,7 +333,8 @@ nnoremap <unique><script> <Plug>VimwikiUISelect :VimwikiUISelect<CR>
 if !hasmapto('<Plug>VimwikiDiaryIndex') && maparg(s:map_prefix.'i', 'n') == ""
   exe 'nmap <silent><unique> '.s:map_prefix.'i <Plug>VimwikiDiaryIndex'
 endif
-nnoremap <unique><script> <Plug>VimwikiDiaryIndex :VimwikiDiaryIndex<CR>
+nnoremap <unique><script> <Plug>VimwikiDiaryIndex
+    \ :<C-U>call vimwiki#diary#goto_diary_index(v:count)<CR>
 
 if !hasmapto('<Plug>VimwikiDiaryGenerateLinks') && maparg(s:map_prefix.'<Leader>i', 'n') == ""
   exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>i <Plug>VimwikiDiaryGenerateLinks'
@@ -337,26 +344,28 @@ nnoremap <unique><script> <Plug>VimwikiDiaryGenerateLinks :VimwikiDiaryGenerateL
 if !hasmapto('<Plug>VimwikiMakeDiaryNote') && maparg(s:map_prefix.'<Leader>w', 'n') == ""
   exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>w <Plug>VimwikiMakeDiaryNote'
 endif
-nnoremap <unique><script> <Plug>VimwikiMakeDiaryNote :VimwikiMakeDiaryNote<CR>
+nnoremap <unique><script> <Plug>VimwikiMakeDiaryNote
+    \ :<C-U>call vimwiki#diary#make_note(v:count)<CR>
 
 if !hasmapto('<Plug>VimwikiTabMakeDiaryNote') && maparg(s:map_prefix.'<Leader>t', 'n') == ""
   exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>t <Plug>VimwikiTabMakeDiaryNote'
 endif
 nnoremap <unique><script> <Plug>VimwikiTabMakeDiaryNote
-      \ :VimwikiTabMakeDiaryNote<CR>
+    \ :<C-U>call vimwiki#diary#make_note(v:count, 1)<CR>
 
 if !hasmapto('<Plug>VimwikiMakeYesterdayDiaryNote') && maparg(s:map_prefix.'<Leader>y', 'n') == ""
   exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>y <Plug>VimwikiMakeYesterdayDiaryNote'
 endif
 nnoremap <unique><script> <Plug>VimwikiMakeYesterdayDiaryNote
-      \ :VimwikiMakeYesterdayDiaryNote<CR>
+    \ :<C-U>call vimwiki#diary#make_note(v:count, 0,
+    \ vimwiki#diary#diary_date_link(localtime() - 60*60*24))<CR>
 
 if !hasmapto('<Plug>VimwikiMakeTomorrowDiaryNote')
   exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>m <Plug>VimwikiMakeTomorrowDiaryNote'
 endif
 nnoremap <unique><script> <Plug>VimwikiMakeTomorrowDiaryNote
-      \ :VimwikiMakeTomorrowDiaryNote<CR>
-
+    \ :<C-U>call vimwiki#diary#make_note(v:count, 0,
+    \ vimwiki#diary#diary_date_link(localtime() + 60*60*24))<CR>
 
 
 


### PR DESCRIPTION
This fixes a number of discrepancies in the documentation regarding the described behavior of commands and the actual behavior. For example, `:VimwikiIndex` was described as opening the index of the current wiki but it always opened the first wiki in the list. This also allows a count to open a specific wiki e.g `:VimwikiIndex 2`. This also affects a few diary related commands. Keymappings were also adjusted to have a more consistent behavior.

Fixes #543.