### PR TITLE
Omnicompletion fix for Windows

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -486,6 +486,10 @@ function! vimwiki#base#get_wikilinks(wiki_nr, also_absolute_links)
   let result = []
   for wikifile in files
     let wikifile = fnamemodify(wikifile, ':r') " strip extension
+    if vimwiki#u#is_windows()
+      " TODO temporary fix see #478
+      let wikifile = substitute(wikifile , '/', '\', 'g')
+    endif
     let wikifile = vimwiki#path#relpath(cwd, wikifile)
     call add(result, wikifile)
   endfor
@@ -497,6 +501,10 @@ function! vimwiki#base#get_wikilinks(wiki_nr, also_absolute_links)
         let cwd = vimwiki#vars#get_wikilocal('path') . vimwiki#vars#get_wikilocal('diary_rel_path')
       endif
       let wikifile = fnamemodify(wikifile, ':r') " strip extension
+      if vimwiki#u#is_windows()
+        " TODO temporary fix see #478
+        let wikifile = substitute(wikifile , '/', '\', 'g')
+      endif
       let wikifile = '/'.vimwiki#path#relpath(cwd, wikifile)
       call add(result, wikifile)
     endfor

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3284,6 +3284,8 @@ Removed:~
     *
 
 Fixed:~
+    * Issue #456: Omnicompletion of wikilinks under Windows. Note: this should
+      be considered a temporary fix until #478 is closed.
     * Issue #654: Fix `:VimwikiShowVersion` command.
     * PR #634: Removed extra newlines that were inserted before/after
       generated links.


### PR DESCRIPTION
This is a temporary fix for #456. I tested the changes on a Windows VM and omnicompletion seems to be working for markdown and default syntax. I did not encounter any regressions on a non-Windows environment but it could use some more testing.