### PR TITLE
Add option to not conceal one-character markers

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -146,6 +146,7 @@ function! s:read_global_settings_from_user()
         \ 'autowriteall': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'conceallevel': {'type': type(0), 'default': 2, 'min': 0, 'max': 3},
         \ 'conceal_pre': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
+        \ 'conceal_onechar_markers': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'create_link': {'type': type(0), 'default': 1, 'min':0, 'max': 1},
         \ 'diary_months': {'type': type({}), 'default':
         \   {

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -155,24 +155,26 @@ endfor
 " possibly concealed chars
 let s:conceal = exists("+conceallevel") ? ' conceal' : ''
 
-execute 'syn match VimwikiEqInChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_eqin').'/'.s:conceal
-execute 'syn match VimwikiBoldChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_bold').'/'.s:conceal
-execute 'syn match VimwikiItalicChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_italic').'/'.s:conceal
-execute 'syn match VimwikiBoldItalicChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_bolditalic').'/'.s:conceal
-execute 'syn match VimwikiItalicBoldChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_italicbold').'/'.s:conceal
-execute 'syn match VimwikiCodeChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_code').'/'.s:conceal
-execute 'syn match VimwikiDelTextChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_deltext').'/'.s:conceal
-execute 'syn match VimwikiSuperScript contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_superscript').'/'.s:conceal
-execute 'syn match VimwikiSubScript contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_subscript').'/'.s:conceal
+if vimwiki#vars#get_global('conceal_onechar_markers') == 1
+  execute 'syn match VimwikiEqInChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_eqin').'/'.s:conceal
+  execute 'syn match VimwikiBoldChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_bold').'/'.s:conceal
+  execute 'syn match VimwikiItalicChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_italic').'/'.s:conceal
+  execute 'syn match VimwikiBoldItalicChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_bolditalic').'/'.s:conceal
+  execute 'syn match VimwikiItalicBoldChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_italicbold').'/'.s:conceal
+  execute 'syn match VimwikiCodeChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_code').'/'.s:conceal
+  execute 'syn match VimwikiDelTextChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_deltext').'/'.s:conceal
+  execute 'syn match VimwikiSuperScript contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_superscript').'/'.s:conceal
+  execute 'syn match VimwikiSubScript contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_subscript').'/'.s:conceal
+endif
 
 
 let s:options = ' contained transparent contains=NONE'


### PR DESCRIPTION
Adds new configuration variable, "conceal_onechar_markers", defaulting
to on (preserving default behaviour)

Adds if-statement around relevant parts of code (as suggested in the
issue), which uses the new configuration variable.

Fix #315 - Don't conceal one-character markers

# Pull Request Checks

1. **ALL** pull requests should be made against the `dev` branch!
2. Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
3. Reference any related issues.
4. Provide a description of the proposed changes and any testing that was done.
5. Make sure to update the documentation in `doc/vimwiki.txt` if applicable.

**DELETE THIS TEMPLATE TEXT PRIOR TO SUBMITTING YOUR PULL REQUEST**
