### PR TITLE
Add option to not conceal one-character markers

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -145,6 +145,7 @@ function! s:read_global_settings_from_user()
         \ 'auto_chdir': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'autowriteall': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'conceallevel': {'type': type(0), 'default': 2, 'min': 0, 'max': 3},
+        \ 'conceal_onechar_markers': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'conceal_pre': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'create_link': {'type': type(0), 'default': 1, 'min':0, 'max': 1},
         \ 'diary_months': {'type': type({}), 'default':

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3240,6 +3240,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Nick Borden (@hcwndbyw)
     - Steven Stallion (@sstallion)
     - Rane Brown (@ranebrown)
+    - Patrik Willard (@padowi)
 
 
 ==============================================================================

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3256,6 +3256,8 @@ https://github.com/vimwiki-backup/vimwiki/issues.
 2.5 (in progress)~
 
 New:~
+    * PR #663: New option |g:vimwiki_conceal_onechar_markers| to control
+      whether to show or hide single-character format markers.
     * PR #636: Wiki local option |vimwiki-option-exclude_files| which is
       a list of patterns to exclude when checking or generating links.
     * PR #644: Key mapping gnt to jump to the next open task.

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2958,6 +2958,17 @@ Default: 2
 
 
 ------------------------------------------------------------------------------
+*g:vimwiki_conceal_onechar_markers*
+
+Control the concealment of one-character markers.
+
+Setting 'conceal_onechar_markers' to 0 will show the markers, overriding
+whatever value is set in |g:vimwiki_conceallevel|
+
+Default: 1
+
+
+------------------------------------------------------------------------------
 *g:vimwiki_conceal_pre*
 
 Conceal preformatted text markers. For example,

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -155,24 +155,26 @@ endfor
 " possibly concealed chars
 let s:conceal = exists("+conceallevel") ? ' conceal' : ''
 
-execute 'syn match VimwikiEqInChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_eqin').'/'.s:conceal
-execute 'syn match VimwikiBoldChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_bold').'/'.s:conceal
-execute 'syn match VimwikiItalicChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_italic').'/'.s:conceal
-execute 'syn match VimwikiBoldItalicChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_bolditalic').'/'.s:conceal
-execute 'syn match VimwikiItalicBoldChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_italicbold').'/'.s:conceal
-execute 'syn match VimwikiCodeChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_code').'/'.s:conceal
-execute 'syn match VimwikiDelTextChar contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_deltext').'/'.s:conceal
-execute 'syn match VimwikiSuperScript contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_superscript').'/'.s:conceal
-execute 'syn match VimwikiSubScript contained /'.
-      \ vimwiki#vars#get_syntaxlocal('char_subscript').'/'.s:conceal
+if vimwiki#vars#get_global('conceal_onechar_markers') == 1
+  execute 'syn match VimwikiEqInChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_eqin').'/'.s:conceal
+  execute 'syn match VimwikiBoldChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_bold').'/'.s:conceal
+  execute 'syn match VimwikiItalicChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_italic').'/'.s:conceal
+  execute 'syn match VimwikiBoldItalicChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_bolditalic').'/'.s:conceal
+  execute 'syn match VimwikiItalicBoldChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_italicbold').'/'.s:conceal
+  execute 'syn match VimwikiCodeChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_code').'/'.s:conceal
+  execute 'syn match VimwikiDelTextChar contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_deltext').'/'.s:conceal
+  execute 'syn match VimwikiSuperScript contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_superscript').'/'.s:conceal
+  execute 'syn match VimwikiSubScript contained /'.
+        \ vimwiki#vars#get_syntaxlocal('char_subscript').'/'.s:conceal
+endif
 
 
 let s:options = ' contained transparent contains=NONE'

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -155,7 +155,7 @@ endfor
 " possibly concealed chars
 let s:conceal = exists("+conceallevel") ? ' conceal' : ''
 
-if vimwiki#vars#get_global('conceal_onechar_markers') == 1
+if vimwiki#vars#get_global('conceal_onechar_markers')
   execute 'syn match VimwikiEqInChar contained /'.
         \ vimwiki#vars#get_syntaxlocal('char_eqin').'/'.s:conceal
   execute 'syn match VimwikiBoldChar contained /'.


### PR DESCRIPTION
Adds new configuration variable, "conceal_onechar_markers", defaulting
to on (preserving default behaviour)

Adds if-statement around relevant parts of code (as suggested in the
issue), which uses the new configuration variable.

Fix #315 - Don't conceal one-character markers

Testing done:

I have checked that default behaviour is preserved, both in the case where the configuration variable is present in .vimrc (with default value) as well as when it is not present.

I have also checked that the intended behaviour is exhibited when setting the value to 0, regardless of what setting vimwiki_conceallevel is running with (0..3).

Tested on Vim 8.1