### PR TITLE
Ignore verbatim blocks when scanning tags

### DIFF
--- a/syntax/vimwiki_markdown.vim
+++ b/syntax/vimwiki_markdown.vim
@@ -82,6 +82,7 @@ let s:markdown_syntax.rxListDefine = '::\%(\s\|$\)'
 " Preformatted text
 let s:markdown_syntax.rxPreStart = '```'
 let s:markdown_syntax.rxPreEnd = '```'
+let s:markdown_syntax.rxPreInline = '^    '
 
 " Math block
 let s:markdown_syntax.rxMathStart = '\$\$'


### PR DESCRIPTION
This PR addresses a long-standing TODO when in `s:scan_tags` to skip over verbatim blocks when scanning for tags. Support for inline verbatim blocks is also supported for markdown wikis.