### PR TITLE
Add :VimwikiGoto key mapping

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -419,7 +419,7 @@ endfunction
 
 
 function! vimwiki#base#goto(...)
-  let key = a:1
+  let key = a:0 > 0 ? a:1 : input('Enter name: ')
   let anchor = a:0 > 1 ? a:2 : ''
 
   call vimwiki#base#edit_file(':e',

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -324,6 +324,12 @@ NORMAL MODE                                           *vimwiki-local-mappings*
                         To remap: >
                         :nmap <Leader>wp <Plug>VimwikiPrevLink
 <
+                        *vimwiki_<Leader>wn*
+<Leader>wn              Goto or create new wiki page.
+                        Maps to |:VimwikiGoto|.
+                        To remap: >
+                        :nmap <Leader>nn <Plug>VimwikiGoto
+<
                         *vimwiki_<Leader>wd*
 <Leader>wd              Delete wiki page you are in.
                         Maps to |:VimwikiDeleteLink|.
@@ -770,7 +776,8 @@ Vimwiki file.
         :VimwikiGoto HelloWorld
 <    opens/creates HelloWorld wiki page.
 
-    Supports |cmdline-completion| for link name.
+    Supports |cmdline-completion| for link name. If name is not specified, a
+    prompt will be shown.
 
 *:VimwikiDeleteLink*
     Delete the wiki page you are in.
@@ -3418,6 +3425,7 @@ https://github.com/vimwiki-backup/vimwiki/issues.
 2.5 (in progress)~
 
 New:~
+    * PR #673: Add :VimwikiGoto key mapping.
     * PR #689: Allow |vimwiki-option-diary_rel_path| to be an empty string.
     * PR #683: Improve layout and format of key binding documentation in
       README and include note about key bindings that may not work.

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -264,7 +264,7 @@ exe 'command! -buffer -nargs=* VimwikiSearch lvimgrep <args> '.
 exe 'command! -buffer -nargs=* VWS lvimgrep <args> '.
       \ escape(vimwiki#vars#get_wikilocal('path').'**/*'.vimwiki#vars#get_wikilocal('ext'), ' ')
 
-command! -buffer -nargs=+ -complete=custom,vimwiki#base#complete_links_escaped
+command! -buffer -nargs=* -complete=custom,vimwiki#base#complete_links_escaped
       \ VimwikiGoto call vimwiki#base#goto(<f-args>)
 
 command! -buffer VimwikiCheckLinks call vimwiki#base#check_links()
@@ -358,6 +358,8 @@ nnoremap <silent><script><buffer> <Plug>VimwikiNextLink
     \ :VimwikiNextLink<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiPrevLink
     \ :VimwikiPrevLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiGoto
+    \ :VimwikiGoto<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiDeleteLink
     \ :VimwikiDeleteLink<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiRenameLink
@@ -380,6 +382,7 @@ if str2nr(vimwiki#vars#get_global('key_mappings').links)
   call vimwiki#u#map_key('n', '<BS>', '<Plug>VimwikiGoBackLink')
   call vimwiki#u#map_key('n', '<TAB>', '<Plug>VimwikiNextLink')
   call vimwiki#u#map_key('n', '<S-TAB>', '<Plug>VimwikiPrevLink')
+  call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'n', '<Plug>VimwikiGoto')
   call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'d', '<Plug>VimwikiDeleteLink')
   call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'r', '<Plug>VimwikiRenameLink')
   call vimwiki#u#map_key('n', '<C-Down>', '<Plug>VimwikiDiaryNextDay')


### PR DESCRIPTION
Periodically I find myself needing to create a new wiki page without wanting to add an explicit link to an existing page. This PR adds a new command, named `:VimwikiCreateLink` which will prompt the user for a new link name and then open it for editing, similar to creating new diary entries. This complements the `:VimwikiDeleteLink` and `:VimwikiRenameLink` commands.