### PR TITLE
Add wikilocal option to assign a name to each wiki.

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -274,6 +274,7 @@ function! s:populate_wikilocal_options()
         \ 'links_space_char': {'type': type(''), 'default': ' ', 'min_length': 1},
         \ 'list_margin': {'type': type(0), 'default': -1, 'min': -1},
         \ 'maxhi': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
+        \ 'name': {'type': type(''), 'default': ''},
         \ 'nested_syntaxes': {'type': type({}), 'default': {}},
         \ 'path': {'type': type(''), 'default': $HOME . '/vimwiki/', 'min_length': 1},
         \ 'path_html': {'type': type(''), 'default': ''},

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -966,6 +966,13 @@ or: >
 The number behind "wiki" is in the range 0..N-1 and identifies the destination
 wiki in |g:vimwiki_list|.
 
+Named interwiki links are also supported in the format "wn.name:link" >
+  [[wn.My Name:This is a link]]
+or: >
+  [[wn.MyWiki:This is a link source|Description of the link]]
+
+See |vimwiki-option-name| to set a per wiki name.
+
 Diary~
 
 The "diary:" scheme is used to link to diary entries: >
@@ -2005,6 +2012,24 @@ If path_html is an empty string, the location is derived from
 path_html will be set to '~/okidoki_html/'.
 
 
+*vimwiki-option-name*
+------------------------------------------------------------------------------
+Key             Default value~
+name            ''
+
+Description~
+A name that can be used to create interwiki links: >
+  let g:vimwiki_list = [{'path': '~/my_site/',
+                       \ 'name': 'My Wiki'}]
+
+Valid names can contain letters, numbers, spaces, underscores, and dashes.
+If duplicate names are used the interwiki link will jump to the first wiki
+with a matching name in |g:vimwiki_list|.
+
+The assigned wiki name will also be shown in the menu entries in GVim.
+See the option |g:vimwiki_menu|.
+
+
 *vimwiki-option-auto_export*
 ------------------------------------------------------------------------------
 Key             Default value     Values~
@@ -2543,6 +2568,10 @@ Default: {}
 *g:vimwiki_menu*
 
 Create a menu in the menu bar of GVim, where you can open the available wikis.
+If the wiki has an assigned name (see |vimwiki-option-name|) the menu entry
+will match the name. Otherwise the final folder of |vimwiki-option-path| will
+be used for the name. If there are duplicate entries the index number from
+|g:vimwiki_list| will be appended to the name.
 
 Value              Description~
 ''                 No menu
@@ -3297,6 +3326,7 @@ https://github.com/vimwiki-backup/vimwiki/issues.
 2.5 (in progress)~
 
 New:~
+    * PR #675: Add option |vimwiki-option-name| to assign a per wiki name.
     * PR #661: Add option |g:vimwiki_auto_header| to automatically generate
       a level 1 header for new wiki pages.
     * PR #665: Integration with vimwiki_markdown gem
@@ -3347,6 +3377,7 @@ Removed:~
     *
 
 Fixed:~
+    * Issue #612: GVim menu displayed duplicate names.
     * Issue #456: Omnicompletion of wikilinks under Windows. Note: this should
       be considered a temporary fix until #478 is closed.
     * Issue #654: Fix `:VimwikiShowVersion` command.

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -417,12 +417,29 @@ nnoremap <unique><script> <Plug>VimwikiMakeTomorrowDiaryNote
 
 
 function! s:build_menu(topmenu)
+  let wnamelist = []
   for idx in range(vimwiki#vars#number_of_wikis())
-    let norm_path = fnamemodify(vimwiki#vars#get_wikilocal('path', idx), ':h:t')
-    let norm_path = escape(norm_path, '\ \.')
-    execute 'menu '.a:topmenu.'.Open\ index.'.norm_path.
+    let wname = vimwiki#vars#get_wikilocal('name', idx)
+    if wname ==? ''
+      " fall back to the path if wiki isn't named
+      let wname = fnamemodify(vimwiki#vars#get_wikilocal('path', idx), ':h:t')
+    endif
+
+    if index(wnamelist, wname) != -1
+      " append wiki index number to duplicate entries
+      let wname = wname . ' ' . string(idx + 1)
+    endif
+
+    " add entry to the list of names for duplicate checks
+    call add(wnamelist, wname)
+
+    " escape spaces and periods
+    let wname = escape(wname, '\ \.')
+
+    " build the menu
+    execute 'menu '.a:topmenu.'.Open\ index.'.wname.
           \ ' :call vimwiki#base#goto_index('.(idx+1).')<CR>'
-    execute 'menu '.a:topmenu.'.Open/Create\ diary\ note.'.norm_path.
+    execute 'menu '.a:topmenu.'.Open/Create\ diary\ note.'.wname.
           \ ' :call vimwiki#diary#make_note('.(idx+1).')<CR>'
   endfor
 endfunction


### PR DESCRIPTION
Add `vimwiki-option-name` to assign a per wiki name as outlined in #477. This adds the ability to link between wikis with links of the form `[[wn.name:link]]`. This also updates `:VimwikiUISelect` and `g:vimwiki_menu` output to utilize the wiki name. 

Fixes #612
