### PR TITLE
Prevent sticky type checking (E706) errors with older Vims

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -203,6 +203,7 @@ function! s:read_global_settings_from_user()
       call s:check_users_value(key, users_value, value_infos, 1)
 
       let g:vimwiki_global_vars[key] = users_value
+      unlet users_value
     else
       let g:vimwiki_global_vars[key] = global_settings[key].default
     endif

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -203,6 +203,7 @@ function! s:read_global_settings_from_user()
       call s:check_users_value(key, users_value, value_infos, 1)
 
       let g:vimwiki_global_vars[key] = users_value
+      " Remove users_value to prevent type mismatch (E706) errors in vim <7.4.1546
       unlet users_value
     else
       let g:vimwiki_global_vars[key] = global_settings[key].default

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3332,7 +3332,7 @@ New:~
     * PR #689: Allow |vimwiki-option-diary_rel_path| to be an empty string.
     * PR #683: Improve layout and format of key binding documentation in
       README and include note about key bindings that may not work.
-    * PR #XXX: Prevent sticky type checking errors for old vim versions.
+    * PR #681: Prevent sticky type checking errors for old vim versions.
     * PR #675: Add option |vimwiki-option-name| to assign a per wiki name.
     * PR #661: Add option |g:vimwiki_auto_header| to automatically generate
       a level 1 header for new wiki pages.

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3313,6 +3313,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Patrik Willard (@padowi)
     - Steve Dondley (@sdondley)
     - Alexander Gude (@agude)
+    - Jonny Bylsma (@jbylsma)
 
 
 ==============================================================================
@@ -3331,6 +3332,7 @@ New:~
     * PR #689: Allow |vimwiki-option-diary_rel_path| to be an empty string.
     * PR #683: Improve layout and format of key binding documentation in
       README and include note about key bindings that may not work.
+    * PR #XXX: Prevent sticky type checking errors for old vim versions.
     * PR #675: Add option |vimwiki-option-name| to assign a per wiki name.
     * PR #661: Add option |g:vimwiki_auto_header| to automatically generate
       a level 1 header for new wiki pages.


### PR DESCRIPTION
I work on various servers that have an older copy of Vim installed. I noticed I was getting the following error during Vim startup: 

```
Error detected while processing function vimwiki#vars#init..<SNR>51_populate_global_variables..<SNR>51_read_global_settings_from_user:
line   59:
E706: Variable type mismatch for: users_value
line   61:
E715: Dictionary required
Vimwiki Error: The provided value ''list'' of the option 'g:vimwiki_diary_months' is invalid. See ':h g:vimwiki_diary_months'.
line   70:
E706: Variable type mismatch for: users_value
line   71:
E715: Dictionary required
E714: List required
Press ENTER or type command to continue
```

The error was caused by setting `let g:vimwiki_folding='list'` in my configuration. Vim used to throw the E706 error if you tried to change a variable's type. This error can be triggered by vimwiki if, during the user settings loop in `read_global_settings_from_user()`, the variable type for `users_value` changes. Simply unsetting the variable at the end of each loop seemed to fix the problem.

The vim error was removed in v7.4.1546 as part of vim/vim@f6f32c3.