### PR TITLE
New option g:vimwiki_key_mappings to enable/disable key mappings.

### DIFF
--- a/autoload/vimwiki/u.vim
+++ b/autoload/vimwiki/u.vim
@@ -70,3 +70,22 @@ else
   endfunc
 endif
 
+" a:mode single character indicating the mode as defined by :h maparg
+" a:key the key sequence to map
+" a:plug the plug command the key sequence should be mapped to
+" a:1 optional argument to override the uniqueness checks
+"     this can be used to map different keys to the same <Plug> definition
+" This function maps a key sequence to a <Plug> command using the arguments
+" described above. If there is already a mapping to the <Plug> command or
+" the assigned keys are already mapped then nothing is done.
+function vimwiki#u#map_key(mode, key, plug, ...)
+  if a:0 > 0 && a:1 == 1
+    if maparg(a:key, a:mode) ==# ''
+      exe a:mode . 'map ' . a:key . ' ' . a:plug
+    endif
+  else
+    if !hasmapto(a:plug) && maparg(a:key, a:mode) ==# ''
+      exe a:mode . 'map ' . a:key . ' ' . a:plug
+    endif
+  endif
+endfunction

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -166,6 +166,12 @@ function! s:read_global_settings_from_user()
         \ 'hl_headers': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'html_header_numbering': {'type': type(0), 'default': 0, 'min': 0, 'max': 6},
         \ 'html_header_numbering_sym': {'type': type(''), 'default': ''},
+        \ 'key_mappings': {'type': type({}), 'default':
+        \   {
+        \     'all_maps': 1, 'global': 1, 'headers': 1, 'text_objs': 1,
+        \     'table_format': 1, 'table_mappings': 1, 'lists': 1, 'links': 1,
+        \     'html': 1, 'mouse': 0,
+        \   }},
         \ 'list_ignore_newline': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'text_ignore_newline': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'links_header': {'type': type(''), 'default': 'Generated Links', 'min_length': 1},
@@ -250,6 +256,64 @@ function! s:normalize_global_settings()
       let g:vimwiki_global_vars.ext2syntax[ext] = 'media'
     endif
   endfor
+
+  " ensure key_mappings dictionary has all required keys
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'all_maps')
+    let g:vimwiki_global_vars.key_mappings.all_maps = 1
+  endif
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'global')
+    let g:vimwiki_global_vars.key_mappings.global = 1
+  endif
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'headers')
+    let g:vimwiki_global_vars.key_mappings.headers = 1
+  endif
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'text_objs')
+    let g:vimwiki_global_vars.key_mappings.text_objs = 1
+  endif
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'table_format')
+    let g:vimwiki_global_vars.key_mappings.table_format = 1
+  endif
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'table_mappings')
+    let g:vimwiki_global_vars.key_mappings.table_mappings = 1
+  endif
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'lists')
+    let g:vimwiki_global_vars.key_mappings.lists = 1
+  endif
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'links')
+    let g:vimwiki_global_vars.key_mappings.links = 1
+  endif
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'html')
+    let g:vimwiki_global_vars.key_mappings.html = 1
+  endif
+  if !has_key(g:vimwiki_global_vars.key_mappings, 'mouse')
+    let g:vimwiki_global_vars.key_mappings.mouse = 0
+  endif
+
+  " disable all key mappings if all_maps == 0
+  if !g:vimwiki_global_vars.key_mappings.all_maps
+    let g:vimwiki_global_vars.key_mappings.global = 0
+    let g:vimwiki_global_vars.key_mappings.headers = 0
+    let g:vimwiki_global_vars.key_mappings.text_objs = 0
+    let g:vimwiki_global_vars.key_mappings.table_format = 0
+    let g:vimwiki_global_vars.key_mappings.table_mappings = 0
+    let g:vimwiki_global_vars.table_mappings = 0 " kept for backwards compatibility
+    let g:vimwiki_global_vars.key_mappings.lists = 0
+    let g:vimwiki_global_vars.key_mappings.links = 0
+    let g:vimwiki_global_vars.key_mappings.html = 0
+    let g:vimwiki_global_vars.key_mappings.mouse = 0
+    let g:vimwiki_global_vars.use_mouse = 0 " kept for backwards compatibility
+  endif
+
+  " TODO remove these checks and the table_mappings and use_mouse variables
+  " backwards compatibility checks
+  " if the old option isn't its default value then overwrite the new option
+  if g:vimwiki_global_vars.table_mappings == 0
+    let g:vimwiki_global_vars.key_mappings.table_mappings = 0 && g:vimwiki_global_vars.key_mappings.table_mappings == 1
+  endif
+  if g:vimwiki_global_vars.use_mouse == 1 && g:vimwiki_global_vars.key_mappings.mouse == 0
+    let g:vimwiki_global_vars.key_mappings.mouse = 1
+  endif
+
 endfunction
 
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -110,6 +110,10 @@ There are global and local mappings in Vimwiki.
 ------------------------------------------------------------------------------
 3.1. Global mappings                                 *vimwiki-global-mappings*
 
+NOTE: if a user mapping or mapping from another plugin uses the same key
+sequence as one of the following mappings then Vimwiki will not overwrite it.
+
+
 [count]<Leader>ww or <Plug>VimwikiIndex
         Open index file of the [count]'s wiki.
 
@@ -247,6 +251,9 @@ don't want that, use >
     :nmap <Leader>tt <Plug>VimwikiToggleListItem
     :vmap <Leader>tt <Plug>VimwikiToggleListItem
 
+NOTE: if a user mapping or mapping from another plugin uses the same key
+sequence as one of the following mappings then Vimwiki will not overwrite it.
+
 
 NORMAL MODE                                           *vimwiki-local-mappings*
                         *vimwiki_<Leader>wh*
@@ -316,12 +323,6 @@ NORMAL MODE                                           *vimwiki-local-mappings*
                         Maps to |:VimwikiPrevLink|.
                         To remap: >
                         :nmap <Leader>wp <Plug>VimwikiPrevLink
-<
-gnt                     *vimwiki_gnt*
-                        Find next unfinished task in the current page.
-                        Maps to |:VimwikiNextTask|
-                        To remap: >
-                        :nmap <Leader>nt <Plug>VimwikiNextTask
 <
                         *vimwiki_<Leader>wd*
 <Leader>wd              Delete wiki page you are in.
@@ -393,6 +394,12 @@ gnt                     *vimwiki_gnt*
                         See |vimwiki-todo-lists|.
                         To remap: >
                         :map <Leader>tt <Plug>VimwikiToggleListItem
+
+gnt                     *vimwiki_gnt*
+                        Find next unfinished task in the current page.
+                        Maps to |:VimwikiNextTask|
+                        To remap: >
+                        :nmap <Leader>nt <Plug>VimwikiNextTask
 <
                         *vimwiki_gl<Space>* *vimwiki_gL<Space>*
 gl<Space>               Remove checkbox from list item.
@@ -517,13 +524,19 @@ glx                     Toggle checkbox of a list item disabled/off.
 gqq                     Format table. If you made some changes to a table
  or                     without swapping insert/normal modes this command
 gww                     will reformat it.
-
+                        To remap: >
+                        :nmap <Leader>gq <Plug>VimwikiTableAlignQ
+                        :nmap <Leader>gw <Plug>VimwikiTableAlignW
+<
                         *vimwiki_gq1*  *vimwiki_gw1*
 gq1                     Fast format table. The same as the previous, except
  or                     that only a few lines above the current line are
 gw1                     tested. If the alignment of the current line differs,
                         then the whole table gets reformatted.
-
+                        To remap: >
+                        :nmap <Leader>q1 <Plug>VimwikiTableAlignQ1
+                        :nmap <Leader>w1 <Plug>VimwikiTableAlignW1
+<
                         *vimwiki_<A-Left>*
 <A-Left>                Move current table column to the left.
                         See |:VimwikiTableMoveColumnLeft|
@@ -548,8 +561,11 @@ gw1                     tested. If the alignment of the current line differs,
                         To remap: >
                         :nmap <Leader>j <Plug>VimwikiDiaryNextDay
 <
+Mouse mappings          *vimwiki_mouse*
 
-Works only if |g:vimwiki_use_mouse| is set to 1.
+These mappings are disabled by default.
+See |g:vimwiki_key_mappings| to enable.
+
 <2-LeftMouse>           Follow wiki link (create target wiki page if needed).
 
 <S-2-LeftMouse>         Split and follow wiki link (create target wiki page if
@@ -572,7 +588,6 @@ INSERT MODE                                           *vimwiki-table-mappings*
                         *vimwiki_i_<Tab>_table*
 <Tab>                   Go to the next table cell, create a new row if on the
                         last cell.
-See |g:vimwiki_table_mappings| to turn them off.
 
 INSERT MODE                                            *vimwiki-list-mappings*
                         *vimwiki_i_<CR>*
@@ -644,6 +659,29 @@ ic                      An inner column in a table.
 
 al                      A list item plus its children.
 il                      A single list item.
+
+These key mappings can be modified by replacing the default keys: >
+
+  omap ah <Plug>VimwikiTextObjHeader
+  vmap ah <Plug>VimwikiTextObjHeaderV
+  omap ih <Plug>VimwikiTextObjHeaderContent
+  vmap ih <Plug>VimwikiTextObjHeaderContentV
+  omap aH <Plug>VimwikiTextObjHeaderSub
+  vmap aH <Plug>VimwikiTextObjHeaderSubV
+  omap iH <Plug>VimwikiTextObjHeaderSubContent
+  vmap iH <Plug>VimwikiTextObjHeaderSubContentV
+  omap a\ <Plug>VimwikiTextObjTableCell
+  vmap a\ <Plug>VimwikiTextObjTableCellV
+  omap i\ <Plug>VimwikiTextObjTableCellInner
+  vmap i\ <Plug>VimwikiTextObjTableCellInnerV
+  omap ac <Plug>VimwikiTextObjColumn
+  vmap ac <Plug>VimwikiTextObjColumnV
+  omap ic <Plug>VimwikiTextObjColumnInner
+  vmap ic <Plug>VimwikiTextObjColumnInnerV
+  omap al <Plug>VimwikiTextObjListChildren
+  vmap al <Plug>VimwikiTextObjListChildrenV
+  omap il <Plug>VimwikiTextObjListSingle
+  vmap il <Plug>VimwikiTextObjListSingleV
 
 
 ==============================================================================
@@ -1535,9 +1573,13 @@ Note that the mapping <S-CR> is not available in all terminals.
 Furthermore, <CR> and <S-CR> behave differently when the cursor is behind an
 empty list item. See the table below.
 
-You can configure the behavior of <CR> and of <S-CR> like this: >
-  inoremap <CR> <Esc>:VimwikiReturn 1 5<CR>
-  inoremap <S-CR> <Esc>:VimwikiReturn 2 2<CR>
+To remap the default behavior: >
+  :imap <Leader>e <Plug>VimwikiReturn15
+  :imap <Leader>r <Plug>VimwikiReturn22
+
+To customize the behavior: >
+  inoremap <CR> <Esc>:VimwikiReturn 1 1<CR>
+  inoremap <S-CR> <Esc>:VimwikiReturn 3 5<CR>
 
 The first argument of the command :VimwikiReturn is a number that specifies
 when to insert a new bullet/number and when not, depending on whether the
@@ -2610,18 +2652,6 @@ You can set it to a more fancy symbol like this:
 
 
 ------------------------------------------------------------------------------
-*g:vimwiki_use_mouse*
-
-Use local mouse mappings from |vimwiki-local-mappings|.
-
-Value           Description~
-0               Do not use mouse mappings.
-1               Use mouse mappings.
-
-Default: 0
-
-
-------------------------------------------------------------------------------
 *g:vimwiki_folding*
 
 Enable/disable Vimwiki's folding (outline) functionality. Folding in Vimwiki
@@ -2818,18 +2848,6 @@ cannot otherwise convert the link.  A customized handler might look like this: >
     return ''
   endfunction
 <
-
-------------------------------------------------------------------------------
-*g:vimwiki_table_mappings*
-
-Enable/disable table mappings for INSERT mode.
-
-Value           Description~
-0               Disable table mappings.
-1               Enable table mappings.
-
-Default: 1
-
 
 ------------------------------------------------------------------------------
 *g:vimwiki_table_auto_fmt*
@@ -3231,6 +3249,77 @@ For example, with `links_space_char` set to `'_'` creating a link from the text
 The default is 0.
 
 
+------------------------------------------------------------------------------
+*g:vimwiki_key_mappings*
+
+A dictionary that is used to enable/disable various key mapping groups. To
+disable a specific group set the value for the associated key to 0.
+For example: >
+
+  let g:vimwiki_key_mappings =
+    \ {
+    \ 'headers': 0,
+    \ 'text_objs': 0,
+    \ }
+
+To disable ALL Vimwiki key mappings use: >
+
+    let g:vimwiki_key_mappings = { 'all_maps': 0, }
+
+The valid key groups and their associated mappings are shown below.
+
+`all_maps`:
+  Used to disable all Vimwiki key mappings.
+`global`:
+  |vimwiki-global-mappings| that are defined when Vim starts.
+`headers`:
+  Mappings for header navigation and manipulation:
+  |vimwiki_=|, |vimwiki_-|, |vimwiki_[[|, |vimwiki_]]|, |vimwiki_[=|
+  |vimwiki_]=|, |vimwiki_]u| , |vimwiki_[u|
+`text_objs`:
+  |vimwiki-text-objects| mappings.
+`table_format`:
+  Mappings used for table formatting.
+  |vimwiki_gqq|, |vimwiki_gww|, |vimwiki_gq1|, |vimwiki_gw1|
+  |vimwiki_<A-Left>|, |vimwiki_<A-Right>|
+`table_mappings`:
+    Table mappings for insert mode.
+    |vimwiki_<Tab>|, |vimwiki_<S-Tab>|
+`lists`:
+    Mappings for list manipulation.
+    |vimwiki_<C-Space>|, |vimwiki_gl<Space>|, |vimwiki_gL<Space>| |vimwiki_gln|, |vimwiki_glp|
+    |vimwiki_gll|, |vimwiki_gLl|, |vimwiki_glh|, |vimwiki_gLh|, |vimwiki_glr|, |vimwiki_gLr|
+    |vimwiki_glsar|, |vimwiki_gLstar|, |vimwiki_gl#|, |vimwiki_gL#|, |vimwiki_gl-|, |vimwiki_gL-|
+    |vimwiki_gl1|, |vimwiki_gL1|, |vimwiki_gla|, |vimwiki_gLa|, |vimwiki_glA|, |vimwiki_gLA|
+    |vimwiki_gli|, |vimwiki_gLi|, |vimwiki_glI|, |vimwiki_gLI|, |vimwiki_glx|
+`links`:
+    Mappings for link creation and navigation.
+    |vimwiki_<Leader>w<Leader>i|, |vimwiki_<CR>|, |vimwiki_<S-CR>|, |vimwiki_<C-CR>|
+    |vimwiki_<C-S-CR>|, |vimwiki_<D-CR>|, |vimwiki_<Backspace>|, |vimwiki_<Tab>|
+    |vimwiki_<S-Tab>|, |vimwiki_<Leader>wd|, |vimwiki_<Leader>wr|, |vimwiki_<C-Down>|
+    |vimwiki_<C-Up>|, |vimwiki_+|, |vimwiki_<Backspace>|
+`html`:
+    Mappings for HTML generation.
+    |vimwiki_<Leader>wh|, |vimwiki_<Leader>whh|
+`mouse`:
+    Mouse mappings, see |vimwiki_mouse|. This option is disabled by default.
+
+The default is to enable all key mappings except the mouse: >
+  let g:vimwiki_key_mappings =
+    \ {
+    \   'all_maps': 1,
+    \   'global': 1,
+    \   'headers': 1,
+    \   'text_objs': 1,
+    \   'table_format': 1,
+    \   'table_mappings': 1,
+    \   'lists': 1,
+    \   'links': 1,
+    \   'html': 1,
+    \   'mouse': 0,
+    \ }
+
+
 ==============================================================================
 13. Getting help                                                *vimwiki-help*
 
@@ -3333,6 +3422,9 @@ New:~
     * PR #683: Improve layout and format of key binding documentation in
       README and include note about key bindings that may not work.
     * PR #681: Prevent sticky type checking errors for old vim versions.
+    * PR #686: New option |g:vimwiki_key_mappings| that allow key mappings to
+      be enabled/disabled by groups. Key mappings are also no longer
+      overwritten if they are already defined.
     * PR #675: Add option |vimwiki-option-name| to assign a per wiki name.
     * PR #661: Add option |g:vimwiki_auto_header| to automatically generate
       a level 1 header for new wiki pages.
@@ -3381,7 +3473,10 @@ New:~
     * PR #47: Optimize table formatting for large tables.
 
 Removed:~
-    *
+    * Options g:vimwiki_use_mouse and g:vimwiki_table_mappings. These are
+      still present in the code for backwards compatibility but have been
+      removed from the documentation and will be fully removed at a later
+      point.
 
 Fixed:~
     * Issue #612: GVim menu displayed duplicate names.

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -129,20 +129,6 @@ setlocal formatoptions+=n
 
 let &formatlistpat = vimwiki#vars#get_syntaxlocal('rxListItem')
 
-if !empty(&langmap)
-  " Valid only if langmap is a comma separated pairs of chars
-  let s:l_o = matchstr(&langmap, '\C,\zs.\zeo,')
-  if s:l_o
-    exe 'nnoremap <silent> <buffer> '.s:l_o.' :call vimwiki#lst#kbd_o()<CR>a'
-  endif
-
-  let s:l_O = matchstr(&langmap, '\C,\zs.\zeO,')
-  if s:l_O
-    exe 'nnoremap <silent> <buffer> '.s:l_O.' :call vimwiki#lst#kbd_O()<CR>a'
-  endif
-endif
-
-
 
 " ------------------------------------------------
 " Folding stuff
@@ -330,7 +316,8 @@ command! -buffer VimwikiCatUrl call vimwiki#html#CatUrl(expand('%:p'))
 " Keybindings
 " ------------------------------------------------
 
-if vimwiki#vars#get_global('use_mouse')
+" mouse mappings
+if str2nr(vimwiki#vars#get_global('key_mappings').mouse)
   nmap <buffer> <S-LeftMouse> <NOP>
   nmap <buffer> <C-LeftMouse> <NOP>
   nnoremap <silent><buffer> <2-LeftMouse>
@@ -340,224 +327,193 @@ if vimwiki#vars#get_global('use_mouse')
   nnoremap <silent><buffer> <RightMouse><LeftMouse> :VimwikiGoBackLink<CR>
 endif
 
-
-if !hasmapto('<Plug>Vimwiki2HTML')
-  exe 'nmap <buffer> '.vimwiki#vars#get_global('map_prefix').'h <Plug>Vimwiki2HTML'
-endif
+" <Plug> HTML definitions
 nnoremap <script><buffer> <Plug>Vimwiki2HTML :Vimwiki2HTML<CR>
-
-if !hasmapto('<Plug>Vimwiki2HTMLBrowse')
-  exe 'nmap <buffer> '.vimwiki#vars#get_global('map_prefix').'hh <Plug>Vimwiki2HTMLBrowse'
-endif
 nnoremap <script><buffer> <Plug>Vimwiki2HTMLBrowse :Vimwiki2HTMLBrowse<CR>
 
-if !hasmapto('<Plug>VimwikiFollowLink')
-  nmap <silent><buffer> <CR> <Plug>VimwikiFollowLink
+" default HTML key mappings
+if str2nr(vimwiki#vars#get_global('key_mappings').html)
+  call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'h', '<Plug>Vimwiki2HTML')
+  call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'hh', '<Plug>Vimwiki2HTMLBrowse')
 endif
-nnoremap <silent><script><buffer> <Plug>VimwikiFollowLink :VimwikiFollowLink<CR>
 
-if !hasmapto('<Plug>VimwikiSplitLink')
-  nmap <silent><buffer> <S-CR> <Plug>VimwikiSplitLink
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiSplitLink :VimwikiSplitLink<CR>
+" <Plug> links definitions
+nnoremap <silent><script><buffer> <Plug>VimwikiFollowLink
+    \ :VimwikiFollowLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiSplitLink
+    \ :VimwikiSplitLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiVSplitLink
+    \ :VimwikiVSplitLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiNormalizeLink
+    \ :VimwikiNormalizeLink 0<CR>
+vnoremap <silent><script><buffer> <Plug>VimwikiNormalizeLinkVisual
+    \ :<C-U>VimwikiNormalizeLink 1<CR>
+vnoremap <silent><script><buffer> <Plug>VimwikiNormalizeLinkVisualCR
+    \ :<C-U>VimwikiNormalizeLink 1<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiTabnewLink
+    \ :VimwikiTabnewLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiGoBackLink
+    \ :VimwikiGoBackLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiNextLink
+    \ :VimwikiNextLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiPrevLink
+    \ :VimwikiPrevLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiDeleteLink
+    \ :VimwikiDeleteLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiRenameLink
+    \ :VimwikiRenameLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiDiaryNextDay
+    \ :VimwikiDiaryNextDay<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiDiaryPrevDay
+    \ :VimwikiDiaryPrevDay<CR>
 
-if !hasmapto('<Plug>VimwikiVSplitLink')
-  nmap <silent><buffer> <C-CR> <Plug>VimwikiVSplitLink
+" default links key mappings
+if str2nr(vimwiki#vars#get_global('key_mappings').links)
+  call vimwiki#u#map_key('n', '<CR>', '<Plug>VimwikiFollowLink')
+  call vimwiki#u#map_key('n', '<S-CR>', '<Plug>VimwikiSplitLink')
+  call vimwiki#u#map_key('n', '<C-CR>', '<Plug>VimwikiVSplitLink')
+  call vimwiki#u#map_key('n', '+', '<Plug>VimwikiNormalizeLink')
+  call vimwiki#u#map_key('v', '+', '<Plug>VimwikiNormalizeLinkVisual')
+  call vimwiki#u#map_key('v', '<CR>', '<Plug>VimwikiNormalizeLinkVisualCR')
+  call vimwiki#u#map_key('n', '<D-CR>', '<Plug>VimwikiTabnewLink')
+  call vimwiki#u#map_key('n', '<C-S-CR>', '<Plug>VimwikiTabnewLink', 1)
+  call vimwiki#u#map_key('n', '<BS>', '<Plug>VimwikiGoBackLink')
+  call vimwiki#u#map_key('n', '<TAB>', '<Plug>VimwikiNextLink')
+  call vimwiki#u#map_key('n', '<S-TAB>', '<Plug>VimwikiPrevLink')
+  call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'d', '<Plug>VimwikiDeleteLink')
+  call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'r', '<Plug>VimwikiRenameLink')
+  call vimwiki#u#map_key('n', '<C-Down>', '<Plug>VimwikiDiaryNextDay')
+  call vimwiki#u#map_key('n', '<C-Up>', '<Plug>VimwikiDiaryPrevDay')
 endif
-nnoremap <silent><script><buffer> <Plug>VimwikiVSplitLink :VimwikiVSplitLink<CR>
 
-if !hasmapto('<Plug>VimwikiNormalizeLink')
-  nmap <silent><buffer> + <Plug>VimwikiNormalizeLink
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiNormalizeLink :VimwikiNormalizeLink 0<CR>
-
-if !hasmapto('<Plug>VimwikiNormalizeLinkVisual')
-  vmap <silent><buffer> + <Plug>VimwikiNormalizeLinkVisual
-endif
-vnoremap <silent><script><buffer> <Plug>VimwikiNormalizeLinkVisual :<C-U>VimwikiNormalizeLink 1<CR>
-
-if !hasmapto('<Plug>VimwikiNormalizeLinkVisualCR')
-  vmap <silent><buffer> <CR> <Plug>VimwikiNormalizeLinkVisualCR
-endif
-vnoremap <silent><script><buffer>
-      \ <Plug>VimwikiNormalizeLinkVisualCR :<C-U>VimwikiNormalizeLink 1<CR>
-
-if !hasmapto('<Plug>VimwikiNextTask')
-  nmap <silent><buffer> gnt <Plug>VimwikiNextTask
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiNextTask :VimwikiNextTask<CR>
-
-if !hasmapto('<Plug>VimwikiTabnewLink')
-  nmap <silent><buffer> <D-CR> <Plug>VimwikiTabnewLink
-  nmap <silent><buffer> <C-S-CR> <Plug>VimwikiTabnewLink
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiTabnewLink :VimwikiTabnewLink<CR>
-
-if !hasmapto('<Plug>VimwikiGoBackLink')
-  nmap <silent><buffer> <BS> <Plug>VimwikiGoBackLink
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiGoBackLink :VimwikiGoBackLink<CR>
-
-if !hasmapto('<Plug>VimwikiNextLink')
-  nmap <silent><buffer> <TAB> <Plug>VimwikiNextLink
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiNextLink :VimwikiNextLink<CR>
-
-if !hasmapto('<Plug>VimwikiPrevLink')
-  nmap <silent><buffer> <S-TAB> <Plug>VimwikiPrevLink
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiPrevLink :VimwikiPrevLink<CR>
-
-if !hasmapto('<Plug>VimwikiDeleteLink')
-  exe 'nmap <silent><buffer> '.vimwiki#vars#get_global('map_prefix').'d <Plug>VimwikiDeleteLink'
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiDeleteLink :VimwikiDeleteLink<CR>
-
-if !hasmapto('<Plug>VimwikiRenameLink')
-  exe 'nmap <silent><buffer> '.vimwiki#vars#get_global('map_prefix').'r <Plug>VimwikiRenameLink'
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiRenameLink :VimwikiRenameLink<CR>
-
-if !hasmapto('<Plug>VimwikiDiaryNextDay')
-  nmap <silent><buffer> <C-Down> <Plug>VimwikiDiaryNextDay
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiDiaryNextDay :VimwikiDiaryNextDay<CR>
-
-if !hasmapto('<Plug>VimwikiDiaryPrevDay')
-  nmap <silent><buffer> <C-Up> <Plug>VimwikiDiaryPrevDay
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiDiaryPrevDay :VimwikiDiaryPrevDay<CR>
-
-" List mappings
-if !hasmapto('<Plug>VimwikiToggleListItem')
-  nmap <silent><buffer> <C-Space> <Plug>VimwikiToggleListItem
-  vmap <silent><buffer> <C-Space> <Plug>VimwikiToggleListItem
-  if has("unix")
-    nmap <silent><buffer> <C-@> <Plug>VimwikiToggleListItem
-    vmap <silent><buffer> <C-@> <Plug>VimwikiToggleListItem
-  endif
-endif
-if !hasmapto('<Plug>VimwikiToggleRejectedListItem')
-  nmap <silent><buffer> glx <Plug>VimwikiToggleRejectedListItem
-  vmap <silent><buffer> glx <Plug>VimwikiToggleRejectedListItem
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiToggleListItem :VimwikiToggleListItem<CR>
-vnoremap <silent><script><buffer> <Plug>VimwikiToggleListItem :VimwikiToggleListItem<CR>
-nnoremap <silent><script><buffer>
-      \ <Plug>VimwikiToggleRejectedListItem :VimwikiToggleRejectedListItem<CR>
-vnoremap <silent><script><buffer>
-      \ <Plug>VimwikiToggleRejectedListItem :VimwikiToggleRejectedListItem<CR>
-
-if !hasmapto('<Plug>VimwikiIncrementListItem')
-  nmap <silent><buffer> gln <Plug>VimwikiIncrementListItem
-  vmap <silent><buffer> gln <Plug>VimwikiIncrementListItem
-endif
-if !hasmapto('<Plug>VimwikiDecrementListItem')
-  nmap <silent><buffer> glp <Plug>VimwikiDecrementListItem
-  vmap <silent><buffer> glp <Plug>VimwikiDecrementListItem
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiIncrementListItem :VimwikiIncrementListItem<CR>
-vnoremap <silent><script><buffer> <Plug>VimwikiIncrementListItem :VimwikiIncrementListItem<CR>
-nnoremap <silent><script><buffer> <Plug>VimwikiDecrementListItem :VimwikiDecrementListItem<CR>
-vnoremap <silent><script><buffer> <Plug>VimwikiDecrementListItem :VimwikiDecrementListItem<CR>
-
-if !hasmapto('<Plug>VimwikiDecreaseLvlSingleItem', 'i')
-  imap <silent><buffer> <C-D> <Plug>VimwikiDecreaseLvlSingleItem
-endif
+" <Plug> lists definitions
+nnoremap <silent><script><buffer> <Plug>VimwikiNextTask
+    \ :VimwikiNextTask<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiToggleListItem
+    \ :VimwikiToggleListItem<CR>
+vnoremap <silent><script><buffer> <Plug>VimwikiToggleListItem
+    \ :VimwikiToggleListItem<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiToggleRejectedListItem
+    \ :VimwikiToggleRejectedListItem<CR>
+vnoremap <silent><script><buffer> <Plug>VimwikiToggleRejectedListItem
+    \ :VimwikiToggleRejectedListItem<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiIncrementListItem
+    \ :VimwikiIncrementListItem<CR>
+vnoremap <silent><script><buffer> <Plug>VimwikiIncrementListItem
+    \ :VimwikiIncrementListItem<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiDecrementListItem
+    \ :VimwikiDecrementListItem<CR>
+vnoremap <silent><script><buffer> <Plug>VimwikiDecrementListItem
+    \ :VimwikiDecrementListItem<CR>
 inoremap <silent><script><buffer> <Plug>VimwikiDecreaseLvlSingleItem
     \ <C-O>:VimwikiListChangeLvl decrease 0<CR>
-
-if !hasmapto('<Plug>VimwikiIncreaseLvlSingleItem', 'i')
-  imap <silent><buffer> <C-T> <Plug>VimwikiIncreaseLvlSingleItem
-endif
 inoremap <silent><script><buffer> <Plug>VimwikiIncreaseLvlSingleItem
     \ <C-O>:VimwikiListChangeLvl increase 0<CR>
-
-if !hasmapto('<Plug>VimwikiListNextSymbol', 'i')
-  imap <silent><buffer> <C-L><C-J> <Plug>VimwikiListNextSymbol
-endif
 inoremap <silent><script><buffer> <Plug>VimwikiListNextSymbol
-      \ <C-O>:VimwikiListChangeSymbolI next<CR>
-
-if !hasmapto('<Plug>VimwikiListPrevSymbol', 'i')
-  imap <silent><buffer> <C-L><C-K> <Plug>VimwikiListPrevSymbol
-endif
+    \ <C-O>:VimwikiListChangeSymbolI next<CR>
 inoremap <silent><script><buffer> <Plug>VimwikiListPrevSymbol
-      \ <C-O>:VimwikiListChangeSymbolI prev<CR>
+    \ <C-O>:VimwikiListChangeSymbolI prev<CR>
+inoremap <silent><script><buffer> <Plug>VimwikiListToggle
+    \ <Esc>:VimwikiListToggle<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiRenumberList
+    \ :VimwikiRenumberList<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiRenumberAllLists
+    \ :VimwikiRenumberAllLists<CR>
+noremap <silent><script><buffer> <Plug>VimwikiDecreaseLvlSingleItem
+    \ :VimwikiListChangeLvl decrease 0<CR>
+noremap <silent><script><buffer> <Plug>VimwikiIncreaseLvlSingleItem
+    \ :VimwikiListChangeLvl increase 0<CR>
+noremap <silent><script><buffer> <Plug>VimwikiDecreaseLvlWholeItem
+    \ :VimwikiListChangeLvl decrease 1<CR>
+noremap <silent><script><buffer> <Plug>VimwikiIncreaseLvlWholeItem
+    \ :VimwikiListChangeLvl increase 1<CR>
+noremap <silent><script><buffer> <Plug>VimwikiRemoveSingleCB
+    \ :VimwikiRemoveSingleCB<CR>
+noremap <silent><script><buffer> <Plug>VimwikiRemoveCBInList
+    \ :VimwikiRemoveCBInList<CR>
+nnoremap <silent><buffer> <Plug>VimwikiListo
+    \ :<C-U>call vimwiki#lst#kbd_o()<CR>
+nnoremap <silent><buffer> <Plug>VimwikiListO
+    \ :<C-U>call vimwiki#lst#kbd_O()<CR>
+inoremap <silent><buffer> <Plug>VimwikiReturn15
+    \ <Esc>:VimwikiReturn 1 5<CR>
+inoremap <silent><buffer> <Plug>VimwikiReturn22
+    \ <Esc>:VimwikiReturn 2 2<CR>
 
-if !hasmapto('<Plug>VimwikiListToggle', 'i')
-  imap <silent><buffer> <C-L><C-M> <Plug>VimwikiListToggle
-endif
-inoremap <silent><script><buffer> <Plug>VimwikiListToggle <Esc>:VimwikiListToggle<CR>
-
-nnoremap <silent> <buffer> o :<C-U>call vimwiki#lst#kbd_o()<CR>
-nnoremap <silent> <buffer> O :<C-U>call vimwiki#lst#kbd_O()<CR>
-
-if !hasmapto('<Plug>VimwikiRenumberList')
-  nmap <silent><buffer> glr <Plug>VimwikiRenumberList
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiRenumberList :VimwikiRenumberList<CR>
-
-if !hasmapto('<Plug>VimwikiRenumberAllLists')
-  nmap <silent><buffer> gLr <Plug>VimwikiRenumberAllLists
-  nmap <silent><buffer> gLR <Plug>VimwikiRenumberAllLists
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiRenumberAllLists :VimwikiRenumberAllLists<CR>
-
-if !hasmapto('<Plug>VimwikiDecreaseLvlSingleItem')
-  map <silent><buffer> glh <Plug>VimwikiDecreaseLvlSingleItem
-endif
-noremap <silent><script><buffer>
-    \ <Plug>VimwikiDecreaseLvlSingleItem :VimwikiListChangeLvl decrease 0<CR>
-
-if !hasmapto('<Plug>VimwikiIncreaseLvlSingleItem')
-  map <silent><buffer> gll <Plug>VimwikiIncreaseLvlSingleItem
-endif
-noremap <silent><script><buffer>
-    \ <Plug>VimwikiIncreaseLvlSingleItem :VimwikiListChangeLvl increase 0<CR>
-
-if !hasmapto('<Plug>VimwikiDecreaseLvlWholeItem')
-  map <silent><buffer> gLh <Plug>VimwikiDecreaseLvlWholeItem
-  map <silent><buffer> gLH <Plug>VimwikiDecreaseLvlWholeItem
-endif
-noremap <silent><script><buffer>
-    \ <Plug>VimwikiDecreaseLvlWholeItem :VimwikiListChangeLvl decrease 1<CR>
-
-if !hasmapto('<Plug>VimwikiIncreaseLvlWholeItem')
-  map <silent><buffer> gLl <Plug>VimwikiIncreaseLvlWholeItem
-  map <silent><buffer> gLL <Plug>VimwikiIncreaseLvlWholeItem
-endif
-noremap <silent><script><buffer>
-    \ <Plug>VimwikiIncreaseLvlWholeItem :VimwikiListChangeLvl increase 1<CR>
-
-if !hasmapto('<Plug>VimwikiRemoveSingleCB')
-  map <silent><buffer> gl<Space> <Plug>VimwikiRemoveSingleCB
-endif
-noremap <silent><script><buffer> <Plug>VimwikiRemoveSingleCB :VimwikiRemoveSingleCB<CR>
-
-if !hasmapto('<Plug>VimwikiRemoveCBInList')
-  map <silent><buffer> gL<Space> <Plug>VimwikiRemoveCBInList
-endif
-noremap <silent><script><buffer> <Plug>VimwikiRemoveCBInList :VimwikiRemoveCBInList<CR>
-
-for s:char in vimwiki#vars#get_syntaxlocal('bullet_types')
-  if !hasmapto(':VimwikiChangeSymbolTo '.s:char.'<CR>')
-    exe 'noremap <silent><buffer> gl'.s:char.' :VimwikiChangeSymbolTo '.s:char.'<CR>'
+" default lists key mappings
+if str2nr(vimwiki#vars#get_global('key_mappings').lists)
+  call vimwiki#u#map_key('n', 'gnt', '<Plug>VimwikiNextTask')
+  call vimwiki#u#map_key('n', '<C-Space>', '<Plug>VimwikiToggleListItem')
+  call vimwiki#u#map_key('v', '<C-Space>', '<Plug>VimwikiToggleListItem', 1)
+  if has('unix')
+    call vimwiki#u#map_key('n', '<C-@>', '<Plug>VimwikiToggleListItem', 1)
+    call vimwiki#u#map_key('v', '<C-@>', '<Plug>VimwikiToggleListItem', 1)
   endif
-  if !hasmapto(':VimwikiChangeSymbolInListTo '.s:char.'<CR>')
-    exe 'noremap <silent><buffer> gL'.s:char.' :VimwikiChangeSymbolInListTo '.s:char.'<CR>'
-  endif
-endfor
+  call vimwiki#u#map_key('n', 'glx', '<Plug>VimwikiToggleRejectedListItem')
+  call vimwiki#u#map_key('v', 'glx', '<Plug>VimwikiToggleRejectedListItem', 1)
+  call vimwiki#u#map_key('n', 'gln', '<Plug>VimwikiIncrementListItem')
+  call vimwiki#u#map_key('v', 'gln', '<Plug>VimwikiIncrementListItem', 1)
+  call vimwiki#u#map_key('n', 'glp', '<Plug>VimwikiDecrementListItem')
+  call vimwiki#u#map_key('v', 'glp', '<Plug>VimwikiDecrementListItem', 1)
+  call vimwiki#u#map_key('i', '<C-D>', '<Plug>VimwikiDecreaseLvlSingleItem')
+  call vimwiki#u#map_key('i', '<C-T>', '<Plug>VimwikiIncreaseLvlSingleItem')
+  call vimwiki#u#map_key('n', 'glh', '<Plug>VimwikiDecreaseLvlSingleItem', 1)
+  call vimwiki#u#map_key('n', 'gll', '<Plug>VimwikiIncreaseLvlSingleItem', 1)
+  call vimwiki#u#map_key('n', 'gLh', '<Plug>VimwikiDecreaseLvlWholeItem')
+  call vimwiki#u#map_key('n', 'gLH', '<Plug>VimwikiDecreaseLvlWholeItem', 1)
+  call vimwiki#u#map_key('n', 'gLl', '<Plug>VimwikiIncreaseLvlWholeItem')
+  call vimwiki#u#map_key('n', 'gLL', '<Plug>VimwikiIncreaseLvlWholeItem', 1)
+  call vimwiki#u#map_key('i', '<C-L><C-J>', '<Plug>VimwikiListNextSymbol')
+  call vimwiki#u#map_key('i', '<C-L><C-K>', '<Plug>VimwikiListPrevSymbol')
+  call vimwiki#u#map_key('i', '<C-L><C-M>', '<Plug>VimwikiListToggle')
+  call vimwiki#u#map_key('n', 'glr', '<Plug>VimwikiRenumberList')
+  call vimwiki#u#map_key('n', 'gLr', '<Plug>VimwikiRenumberAllLists')
+  call vimwiki#u#map_key('n', 'gLR', '<Plug>VimwikiRenumberAllLists', 1)
+  call vimwiki#u#map_key('n', 'gl', '<Plug>VimwikiRemoveSingleCB')
+  call vimwiki#u#map_key('n', 'gL', '<Plug>VimwikiRemoveCBInList')
+  call vimwiki#u#map_key('n', 'o', '<Plug>VimwikiListo')
+  call vimwiki#u#map_key('n', 'O', '<Plug>VimwikiListO')
+  call vimwiki#u#map_key('i', '<CR>', '<Plug>VimwikiReturn15')
+  call vimwiki#u#map_key('i', '<S-CR>', '<Plug>VimwikiReturn22')
 
-for s:typ in vimwiki#vars#get_syntaxlocal('number_types')
-  if !hasmapto(':VimwikiChangeSymbolTo '.s:typ.'<CR>')
-    exe 'noremap <silent><buffer> gl'.s:typ[0].' :VimwikiChangeSymbolTo '.s:typ.'<CR>'
-  endif
-  if !hasmapto(':VimwikiChangeSymbolInListTo '.s:typ.'<CR>')
-    exe 'noremap <silent><buffer> gL'.s:typ[0].' :VimwikiChangeSymbolInListTo '.s:typ.'<CR>'
-  endif
-endfor
+  " change symbol for bulleted lists
+  for s:char in vimwiki#vars#get_syntaxlocal('bullet_types')
+    if !hasmapto(':VimwikiChangeSymbolTo '.s:char.'<CR>') && maparg('gl'.s:char, 'n') ==# ''
+      exe 'noremap <silent><buffer> gl'.s:char.' :VimwikiChangeSymbolTo '.s:char.'<CR>'
+    endif
+    if !hasmapto(':VimwikiChangeSymbolInListTo '.s:char.'<CR>') && maparg('gL'.s:char, 'n') ==# ''
+      exe 'noremap <silent><buffer> gL'.s:char.' :VimwikiChangeSymbolInListTo '.s:char.'<CR>'
+    endif
+  endfor
 
+  " change symbol for numbered lists
+  for s:typ in vimwiki#vars#get_syntaxlocal('number_types')
+    if !hasmapto(':VimwikiChangeSymbolTo '.s:typ.'<CR>') && maparg('gl'.s:typ, 'n') ==# ''
+      exe 'noremap <silent><buffer> gl'.s:typ[0].' :VimwikiChangeSymbolTo '.s:typ.'<CR>'
+    endif
+    if !hasmapto(':VimwikiChangeSymbolInListTo '.s:typ.'<CR>') && maparg('gL'.s:typ, 'n') ==# ''
+      exe 'noremap <silent><buffer> gL'.s:typ[0].' :VimwikiChangeSymbolInListTo '.s:typ.'<CR>'
+    endif
+  endfor
+
+  " insert items in a list using langmap characters (see :h langmap)
+  if !empty(&langmap)
+    " Valid only if langmap is a comma separated pairs of chars
+    let s:l_o = matchstr(&langmap, '\C,\zs.\zeo,')
+    if s:l_o
+      if maparg(s:l_o, 'n') ==# ''
+        exe 'nnoremap <silent><buffer> '.s:l_o.' :call vimwiki#lst#kbd_o()<CR>a'
+      endif
+    endif
+
+    let s:l_O = matchstr(&langmap, '\C,\zs.\zeO,')
+    if s:l_O
+      if maparg(s:l_O, 'n') ==# ''
+        exe 'nnoremap <silent><buffer> '.s:l_O.' :call vimwiki#lst#kbd_O()<CR>a'
+      endif
+    endif
+  endif
+endif
 
 function! s:CR(normal, just_mrkr)
   if vimwiki#vars#get_global('table_mappings')
@@ -571,130 +527,133 @@ function! s:CR(normal, just_mrkr)
   call vimwiki#lst#kbd_cr(a:normal, a:just_mrkr)
 endfunction
 
-if !hasmapto('VimwikiReturn', 'i')
-  if maparg('<CR>', 'i') !~? '<Esc>:VimwikiReturn'
-    inoremap <silent><buffer> <CR> <Esc>:VimwikiReturn 1 5<CR>
+" insert mode table mappings
+if str2nr(vimwiki#vars#get_global('key_mappings').table_mappings)
+  if maparg('<Tab>', 'i') ==# ''
+    inoremap <expr><buffer> <Tab> vimwiki#tbl#kbd_tab()
   endif
-  if maparg('<S-CR>', 'i') !~? '<Esc>:VimwikiReturn'
-    inoremap <silent><buffer> <S-CR> <Esc>:VimwikiReturn 2 2<CR>
+  if maparg('<S-Tab>', 'i') ==# ''
+    inoremap <expr><buffer> <S-Tab> vimwiki#tbl#kbd_shift_tab()
   endif
 endif
 
+" <Plug> table formatting definitions
+nnoremap <silent><buffer> <Plug>VimwikiTableAlignQ
+    \ :VimwikiTableAlignQ<CR>
+nnoremap <silent><buffer> <Plug>VimwikiTableAlignQ1
+    \ :VimwikiTableAlignQ 2<CR>
+nnoremap <silent><buffer> <Plug>VimwikiTableAlignW
+    \ :VimwikiTableAlignW<CR>
+nnoremap <silent><buffer> <Plug>VimwikiTableAlignW1
+    \ :VimwikiTableAlignW 2<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiTableMoveColumnLeft
+    \ :VimwikiTableMoveColumnLeft<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiTableMoveColumnRight
+    \ :VimwikiTableMoveColumnRight<CR>
 
-"Table mappings
- if vimwiki#vars#get_global('table_mappings')
-   inoremap <expr> <buffer> <Tab> vimwiki#tbl#kbd_tab()
-   inoremap <expr> <buffer> <S-Tab> vimwiki#tbl#kbd_shift_tab()
- endif
-
-
-" table formatting mappings
-if !hasmapto('<Plug>VimwikiTableAlignQ', 'n') && maparg('gqq', 'n') == ""
-  nmap <silent><buffer> gqq <Plug>VimwikiTableAlignQ
+" default table formatting key mappings
+if str2nr(vimwiki#vars#get_global('key_mappings').table_format)
+  call vimwiki#u#map_key('n', 'gqq', '<Plug>VimwikiTableAlignQ')
+  call vimwiki#u#map_key('n', 'gq1', '<Plug>VimwikiTableAlignQ1')
+  call vimwiki#u#map_key('n', 'gww', '<Plug>VimwikiTableAlignW')
+  call vimwiki#u#map_key('n', 'gw1', '<Plug>VimwikiTableAlignW1')
+  call vimwiki#u#map_key('n', '<A-Left>', '<Plug>VimwikiTableMoveColumnLeft')
+  call vimwiki#u#map_key('n', '<A-Right>', '<Plug>VimwikiTableMoveColumnRight')
 endif
-nnoremap <silent><buffer> <Plug>VimwikiTableAlignQ :VimwikiTableAlignQ<CR>
-if !hasmapto('<Plug>VimwikiTableAlignQ1', 'n') && maparg('gq1', 'n') == ""
-  nmap <silent><buffer> gq1 <Plug>VimwikiTableAlignQ1
+
+" <Plug> text object definitions
+onoremap <silent><buffer> <Plug>VimwikiTextObjHeader
+    \ :<C-U>call vimwiki#base#TO_header(0, 0, v:count1)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjHeaderV
+    \ :<C-U>call vimwiki#base#TO_header(0, 0, v:count1)<CR>
+onoremap <silent><buffer> <Plug>VimwikiTextObjHeaderContent
+    \ :<C-U>call vimwiki#base#TO_header(1, 0, v:count1)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjHeaderContentV
+    \ :<C-U>call vimwiki#base#TO_header(1, 0, v:count1)<CR>
+onoremap <silent><buffer> <Plug>VimwikiTextObjHeaderSub
+    \ :<C-U>call vimwiki#base#TO_header(0, 1, v:count1)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjHeaderSubV
+    \ :<C-U>call vimwiki#base#TO_header(0, 1, v:count1)<CR>
+onoremap <silent><buffer> <Plug>VimwikiTextObjHeaderSubContent
+    \ :<C-U>call vimwiki#base#TO_header(1, 1, v:count1)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjHeaderSubContentV
+    \ :<C-U>call vimwiki#base#TO_header(1, 1, v:count1)<CR>
+onoremap <silent><buffer> <Plug>VimwikiTextObjTableCell
+    \ :<C-U>call vimwiki#base#TO_table_cell(0, 0)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjTableCellV
+    \ :<C-U>call vimwiki#base#TO_table_cell(0, 1)<CR>
+onoremap <silent><buffer> <Plug>VimwikiTextObjTableCellInner
+    \ :<C-U>call vimwiki#base#TO_table_cell(1, 0)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjTableCellInnerV
+    \ :<C-U>call vimwiki#base#TO_table_cell(1, 1)<CR>
+onoremap <silent><buffer> <Plug>VimwikiTextObjColumn
+    \ :<C-U>call vimwiki#base#TO_table_col(0, 0)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjColumnV
+    \ :<C-U>call vimwiki#base#TO_table_col(0, 1)<CR>
+onoremap <silent><buffer> <Plug>VimwikiTextObjColumnInner
+    \ :<C-U>call vimwiki#base#TO_table_col(1, 0)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjColumnInnerV
+    \ :<C-U>call vimwiki#base#TO_table_col(1, 1)<CR>
+onoremap <silent><buffer> <Plug>VimwikiTextObjListChildren
+    \ :<C-U>call vimwiki#lst#TO_list_item(0, 0)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjListChildrenV
+    \ :<C-U>call vimwiki#lst#TO_list_item(0, 1)<CR>
+onoremap <silent><buffer> <Plug>VimwikiTextObjListSingle
+    \ :<C-U>call vimwiki#lst#TO_list_item(1, 0)<CR>
+vnoremap <silent><buffer> <Plug>VimwikiTextObjListSingleV
+    \ :<C-U>call vimwiki#lst#TO_list_item(1, 1)<CR>
+
+" default text object key mappings
+if str2nr(vimwiki#vars#get_global('key_mappings').text_objs)
+  call vimwiki#u#map_key('o', 'ah', '<Plug>VimwikiTextObjHeader')
+  call vimwiki#u#map_key('v', 'ah', '<Plug>VimwikiTextObjHeaderV')
+  call vimwiki#u#map_key('o', 'ih', '<Plug>VimwikiTextObjHeaderContent')
+  call vimwiki#u#map_key('v', 'ih', '<Plug>VimwikiTextObjHeaderContentV')
+  call vimwiki#u#map_key('o', 'aH', '<Plug>VimwikiTextObjHeaderSub')
+  call vimwiki#u#map_key('v', 'aH', '<Plug>VimwikiTextObjHeaderSubV')
+  call vimwiki#u#map_key('o', 'iH', '<Plug>VimwikiTextObjHeaderSubContent')
+  call vimwiki#u#map_key('v', 'iH', '<Plug>VimwikiTextObjHeaderSubContentV')
+  call vimwiki#u#map_key('o', 'a\', '<Plug>VimwikiTextObjTableCell')
+  call vimwiki#u#map_key('v', 'a\', '<Plug>VimwikiTextObjTableCellV')
+  call vimwiki#u#map_key('o', 'i\', '<Plug>VimwikiTextObjTableCellInner')
+  call vimwiki#u#map_key('v', 'i\', '<Plug>VimwikiTextObjTableCellInnerV')
+  call vimwiki#u#map_key('o', 'ac', '<Plug>VimwikiTextObjColumn')
+  call vimwiki#u#map_key('v', 'ac', '<Plug>VimwikiTextObjColumnV')
+  call vimwiki#u#map_key('o', 'ic', '<Plug>VimwikiTextObjColumnInner')
+  call vimwiki#u#map_key('v', 'ic', '<Plug>VimwikiTextObjColumnInnerV')
+  call vimwiki#u#map_key('o', 'al', '<Plug>VimwikiTextObjListChildren')
+  call vimwiki#u#map_key('v', 'al', '<Plug>VimwikiTextObjListChildrenV')
+  call vimwiki#u#map_key('o', 'il', '<Plug>VimwikiTextObjListSingle')
+  call vimwiki#u#map_key('v', 'il', '<Plug>VimwikiTextObjListSingleV')
 endif
-nnoremap <silent><buffer> <Plug>VimwikiTableAlignQ1 :VimwikiTableAlignQ 2<CR>
 
-if !hasmapto('<Plug>VimwikiTableAlignW', 'n') && maparg('gww', 'n') == ""
-  nmap <silent><buffer> gww <Plug>VimwikiTableAlignW
+" <Plug> header definitions
+nnoremap <silent><buffer> <Plug>VimwikiAddHeaderLevel
+      \ :<C-U>call vimwiki#base#AddHeaderLevel(v:count)<CR>
+nnoremap <silent><buffer> <Plug>VimwikiRemoveHeaderLevel
+      \ :<C-U>call vimwiki#base#RemoveHeaderLevel(v:count)<CR>
+nnoremap <silent><buffer> <Plug>VimwikiGoToParentHeader
+      \ :<C-u>call vimwiki#base#goto_parent_header()<CR>
+nnoremap <silent><buffer> <Plug>VimwikiGoToNextHeader
+      \ :<C-u>call vimwiki#base#goto_next_header()<CR>
+nnoremap <silent><buffer> <Plug>VimwikiGoToPrevHeader
+      \ :<C-u>call vimwiki#base#goto_prev_header()<CR>
+nnoremap <silent><buffer> <Plug>VimwikiGoToNextSiblingHeader
+      \ :<C-u>call vimwiki#base#goto_sibling(+1)<CR>
+nnoremap <silent><buffer> <Plug>VimwikiGoToPrevSiblingHeader
+      \ :<C-u>call vimwiki#base#goto_sibling(-1)<CR>
+
+" default header key mappings
+if str2nr(vimwiki#vars#get_global('key_mappings').headers)
+  call vimwiki#u#map_key('n', '=', '<Plug>VimwikiAddHeaderLevel')
+  call vimwiki#u#map_key('n', '-', '<Plug>VimwikiRemoveHeaderLevel')
+  call vimwiki#u#map_key('n', ']u', '<Plug>VimwikiGoToParentHeader')
+  call vimwiki#u#map_key('n', '[u', '<Plug>VimwikiGoToParentHeader', 1)
+  call vimwiki#u#map_key('n', ']]', '<Plug>VimwikiGoToNextHeader')
+  call vimwiki#u#map_key('n', '[[', '<Plug>VimwikiGoToPrevHeader')
+  call vimwiki#u#map_key('n', ']=', '<Plug>VimwikiGoToNextSiblingHeader')
+  call vimwiki#u#map_key('n', '[=', '<Plug>VimwikiGoToPrevSiblingHeader')
 endif
-nnoremap <silent><buffer> <Plug>VimwikiTableAlignW :VimwikiTableAlignW<CR>
-if !hasmapto('<Plug>VimwikiTableAlignW1', 'n') && maparg('gw1', 'n') == ""
-  nmap <silent><buffer> gw1 <Plug>VimwikiTableAlignW1
-endif
-nnoremap <silent><buffer> <Plug>VimwikiTableAlignW1 :VimwikiTableAlignW 2<CR>
-
-if !hasmapto('<Plug>VimwikiTableMoveColumnLeft')
-  nmap <silent><buffer> <A-Left> <Plug>VimwikiTableMoveColumnLeft
-endif
-nnoremap <silent><script><buffer> <Plug>VimwikiTableMoveColumnLeft :VimwikiTableMoveColumnLeft<CR>
-if !hasmapto('<Plug>VimwikiTableMoveColumnRight')
-  nmap <silent><buffer> <A-Right> <Plug>VimwikiTableMoveColumnRight
-endif
-nnoremap <silent><script><buffer>
-      \ <Plug>VimwikiTableMoveColumnRight :VimwikiTableMoveColumnRight<CR>
-
-
-" ------------------------------------------------
-" Text objects
-" ------------------------------------------------
-
-onoremap <silent><buffer> ah :<C-U>call vimwiki#base#TO_header(0, 0, v:count1)<CR>
-vnoremap <silent><buffer> ah :<C-U>call vimwiki#base#TO_header(0, 0, v:count1)<CR>
-
-onoremap <silent><buffer> ih :<C-U>call vimwiki#base#TO_header(1, 0, v:count1)<CR>
-vnoremap <silent><buffer> ih :<C-U>call vimwiki#base#TO_header(1, 0, v:count1)<CR>
-
-onoremap <silent><buffer> aH :<C-U>call vimwiki#base#TO_header(0, 1, v:count1)<CR>
-vnoremap <silent><buffer> aH :<C-U>call vimwiki#base#TO_header(0, 1, v:count1)<CR>
-
-onoremap <silent><buffer> iH :<C-U>call vimwiki#base#TO_header(1, 1, v:count1)<CR>
-vnoremap <silent><buffer> iH :<C-U>call vimwiki#base#TO_header(1, 1, v:count1)<CR>
-
-onoremap <silent><buffer> a\ :<C-U>call vimwiki#base#TO_table_cell(0, 0)<CR>
-vnoremap <silent><buffer> a\ :<C-U>call vimwiki#base#TO_table_cell(0, 1)<CR>
-
-onoremap <silent><buffer> i\ :<C-U>call vimwiki#base#TO_table_cell(1, 0)<CR>
-vnoremap <silent><buffer> i\ :<C-U>call vimwiki#base#TO_table_cell(1, 1)<CR>
-
-onoremap <silent><buffer> ac :<C-U>call vimwiki#base#TO_table_col(0, 0)<CR>
-vnoremap <silent><buffer> ac :<C-U>call vimwiki#base#TO_table_col(0, 1)<CR>
-
-onoremap <silent><buffer> ic :<C-U>call vimwiki#base#TO_table_col(1, 0)<CR>
-vnoremap <silent><buffer> ic :<C-U>call vimwiki#base#TO_table_col(1, 1)<CR>
-
-onoremap <silent><buffer> al :<C-U>call vimwiki#lst#TO_list_item(0, 0)<CR>
-vnoremap <silent><buffer> al :<C-U>call vimwiki#lst#TO_list_item(0, 1)<CR>
-
-onoremap <silent><buffer> il :<C-U>call vimwiki#lst#TO_list_item(1, 0)<CR>
-vnoremap <silent><buffer> il :<C-U>call vimwiki#lst#TO_list_item(1, 1)<CR>
-
-if !hasmapto('<Plug>VimwikiAddHeaderLevel')
-  nmap <silent><buffer> = <Plug>VimwikiAddHeaderLevel
-endif
-nnoremap <silent><buffer> <Plug>VimwikiAddHeaderLevel :
-      \<C-U>call vimwiki#base#AddHeaderLevel(v:count)<CR>
-
-if !hasmapto('<Plug>VimwikiRemoveHeaderLevel')
-  nmap <silent><buffer> - <Plug>VimwikiRemoveHeaderLevel
-endif
-nnoremap <silent><buffer> <Plug>VimwikiRemoveHeaderLevel :
-      \<C-U>call vimwiki#base#RemoveHeaderLevel(v:count)<CR>
-
-if !hasmapto('<Plug>VimwikiGoToParentHeader')
-  nmap <silent><buffer> ]u <Plug>VimwikiGoToParentHeader
-  nmap <silent><buffer> [u <Plug>VimwikiGoToParentHeader
-endif
-nnoremap <silent><buffer> <Plug>VimwikiGoToParentHeader :
-      \<C-u>call vimwiki#base#goto_parent_header()<CR>
-
-if !hasmapto('<Plug>VimwikiGoToNextHeader')
-  nmap <silent><buffer> ]] <Plug>VimwikiGoToNextHeader
-endif
-nnoremap <silent><buffer> <Plug>VimwikiGoToNextHeader :
-      \<C-u>call vimwiki#base#goto_next_header()<CR>
-
-if !hasmapto('<Plug>VimwikiGoToPrevHeader')
-  nmap <silent><buffer> [[ <Plug>VimwikiGoToPrevHeader
-endif
-nnoremap <silent><buffer> <Plug>VimwikiGoToPrevHeader :
-      \<C-u>call vimwiki#base#goto_prev_header()<CR>
-
-if !hasmapto('<Plug>VimwikiGoToNextSiblingHeader')
-  nmap <silent><buffer> ]= <Plug>VimwikiGoToNextSiblingHeader
-endif
-nnoremap <silent><buffer> <Plug>VimwikiGoToNextSiblingHeader :
-      \<C-u>call vimwiki#base#goto_sibling(+1)<CR>
-
-if !hasmapto('<Plug>VimwikiGoToPrevSiblingHeader')
-  nmap <silent><buffer> [= <Plug>VimwikiGoToPrevSiblingHeader
-endif
-nnoremap <silent><buffer> <Plug>VimwikiGoToPrevSiblingHeader :
-      \<C-u>call vimwiki#base#goto_sibling(-1)<CR>
-
 
 
 if vimwiki#vars#get_wikilocal('auto_export')

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -338,7 +338,6 @@ augroup vimwiki
 augroup END
 
 
-
 command! VimwikiUISelect call vimwiki#base#ui_select()
 
 " these commands take a count e.g. :VimwikiIndex 2
@@ -372,62 +371,44 @@ command! VimwikiDiaryGenerateLinks
 
 command! VimwikiShowVersion call s:get_version()
 
-let s:map_prefix = vimwiki#vars#get_global('map_prefix')
 
-if !hasmapto('<Plug>VimwikiIndex') && maparg(s:map_prefix.'w', 'n') == ""
-  exe 'nmap <silent><unique> '.s:map_prefix.'w <Plug>VimwikiIndex'
-endif
-nnoremap <unique><script> <Plug>VimwikiIndex
+" <Plug> global definitions
+nnoremap <silent><script> <Plug>VimwikiIndex
     \ :<C-U>call vimwiki#base#goto_index(v:count1)<CR>
-
-if !hasmapto('<Plug>VimwikiTabIndex') && maparg(s:map_prefix.'t', 'n') == ""
-  exe 'nmap <silent><unique> '.s:map_prefix.'t <Plug>VimwikiTabIndex'
-endif
-nnoremap <unique><script> <Plug>VimwikiTabIndex
+nnoremap <silent><script> <Plug>VimwikiTabIndex
     \ :<C-U>call vimwiki#base#goto_index(v:count1, 1)<CR>
-
-if !hasmapto('<Plug>VimwikiUISelect') && maparg(s:map_prefix.'s', 'n') == ""
-  exe 'nmap <silent><unique> '.s:map_prefix.'s <Plug>VimwikiUISelect'
-endif
-nnoremap <unique><script> <Plug>VimwikiUISelect :VimwikiUISelect<CR>
-
-if !hasmapto('<Plug>VimwikiDiaryIndex') && maparg(s:map_prefix.'i', 'n') == ""
-  exe 'nmap <silent><unique> '.s:map_prefix.'i <Plug>VimwikiDiaryIndex'
-endif
-nnoremap <unique><script> <Plug>VimwikiDiaryIndex
+nnoremap <silent><script> <Plug>VimwikiUISelect
+    \ :VimwikiUISelect<CR>
+nnoremap <silent><script> <Plug>VimwikiDiaryIndex
     \ :<C-U>call vimwiki#diary#goto_diary_index(v:count)<CR>
-
-if !hasmapto('<Plug>VimwikiDiaryGenerateLinks') && maparg(s:map_prefix.'<Leader>i', 'n') == ""
-  exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>i <Plug>VimwikiDiaryGenerateLinks'
-endif
-nnoremap <unique><script> <Plug>VimwikiDiaryGenerateLinks :VimwikiDiaryGenerateLinks<CR>
-
-if !hasmapto('<Plug>VimwikiMakeDiaryNote') && maparg(s:map_prefix.'<Leader>w', 'n') == ""
-  exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>w <Plug>VimwikiMakeDiaryNote'
-endif
-nnoremap <unique><script> <Plug>VimwikiMakeDiaryNote
+nnoremap <silent><script> <Plug>VimwikiDiaryGenerateLinks
+    \ :VimwikiDiaryGenerateLinks<CR>
+nnoremap <silent><script> <Plug>VimwikiMakeDiaryNote
     \ :<C-U>call vimwiki#diary#make_note(v:count)<CR>
-
-if !hasmapto('<Plug>VimwikiTabMakeDiaryNote') && maparg(s:map_prefix.'<Leader>t', 'n') == ""
-  exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>t <Plug>VimwikiTabMakeDiaryNote'
-endif
-nnoremap <unique><script> <Plug>VimwikiTabMakeDiaryNote
+nnoremap <silent><script> <Plug>VimwikiTabMakeDiaryNote
     \ :<C-U>call vimwiki#diary#make_note(v:count, 1)<CR>
-
-if !hasmapto('<Plug>VimwikiMakeYesterdayDiaryNote') && maparg(s:map_prefix.'<Leader>y', 'n') == ""
-  exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>y <Plug>VimwikiMakeYesterdayDiaryNote'
-endif
-nnoremap <unique><script> <Plug>VimwikiMakeYesterdayDiaryNote
+nnoremap <silent><script> <Plug>VimwikiMakeYesterdayDiaryNote
     \ :<C-U>call vimwiki#diary#make_note(v:count, 0,
     \ vimwiki#diary#diary_date_link(localtime() - 60*60*24))<CR>
-
-if !hasmapto('<Plug>VimwikiMakeTomorrowDiaryNote')
-  exe 'nmap <silent><unique> '.s:map_prefix.'<Leader>m <Plug>VimwikiMakeTomorrowDiaryNote'
-endif
-nnoremap <unique><script> <Plug>VimwikiMakeTomorrowDiaryNote
+nnoremap <silent><script> <Plug>VimwikiMakeTomorrowDiaryNote
     \ :<C-U>call vimwiki#diary#make_note(v:count, 0,
     \ vimwiki#diary#diary_date_link(localtime() + 60*60*24))<CR>
 
+" get the user defined prefix (default <leader>w)
+let s:map_prefix = vimwiki#vars#get_global('map_prefix')
+
+" default global key mappings
+if str2nr(vimwiki#vars#get_global('key_mappings').global)
+  call vimwiki#u#map_key('n', s:map_prefix . 'w', '<Plug>VimwikiIndex')
+  call vimwiki#u#map_key('n', s:map_prefix . 't', '<Plug>VimwikiTabIndex')
+  call vimwiki#u#map_key('n', s:map_prefix . 's', '<Plug>VimwikiUISelect')
+  call vimwiki#u#map_key('n', s:map_prefix . 'i', '<Plug>VimwikiDiaryIndex')
+  call vimwiki#u#map_key('n', s:map_prefix . '<Leader>i', '<Plug>VimwikiDiaryGenerateLinks')
+  call vimwiki#u#map_key('n', s:map_prefix . '<Leader>w', '<Plug>VimwikiMakeDiaryNote')
+  call vimwiki#u#map_key('n', s:map_prefix . '<Leader>t', '<Plug>VimwikiTabMakeDiaryNote')
+  call vimwiki#u#map_key('n', s:map_prefix . '<Leader>y', '<Plug>VimwikiMakeYesterdayDiaryNote')
+  call vimwiki#u#map_key('n', s:map_prefix . '<Leader>m', '<Plug>VimwikiMakeTomorrowDiaryNote')
+endif
 
 
 function! s:build_menu(topmenu)


### PR DESCRIPTION
All key mappings have the option of being disabled but the <Plug>
definitions are still available for user customization. Key sequences
are no longer overwritten if a mapping already exists. Fixes #671,
fixes #425.
