### PR TITLE
Allow user to use a custom function for foldexpr option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,13 @@ For other syntax elements, see `:h vimwiki-syntax`
 
 ## Key bindings
 
-Normal mode:
+### Normal mode
+
+**Note:** your terminal may prevent capturing some of the default bindings
+listed below. See `:h vimwiki-local-mappings` for suggestions for alternative
+bindings if you encounter a problem.
+
+#### Basic key bindings
 
  * `<Leader>ww` -- Open default wiki index file.
  * `<Leader>wt` -- Open default wiki index file in a new tab.
@@ -192,7 +198,10 @@ Normal mode:
  * `<Tab>` -- Find next wiki link
  * `<Shift-Tab>` -- Find previous wiki link
 
-For more keys, see `:h vimwiki-mappings`
+#### Advanced key bindings
+
+Refer to the complete documentation at `:h vimwiki-mappings` to see many
+more bindings.
 
 ## Commands
 
@@ -218,7 +227,7 @@ let g:vimwiki_list = [{'path': '~/vimwiki/',
 
 ## Getting help
 
-**Have a question?**  
+**Have a question?**
 Visit the IRC channel [`#vimwiki`](https://webchat.freenode.net/?channels=#vimwiki) on Freenode ([webchat](https://webchat.freenode.net/?channels=#vimwiki), also synced to Matrix/Riot: `#freenode_#vimwiki:matrix.org`) or post to the [mailing list](https://groups.google.com/forum/#!forum/vimwiki).
 
 ## Helping VimWiki

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3259,6 +3259,7 @@ Old homepage: http://code.google.com/p/vimwiki/
 
 Contributors and their Github usernames in roughly chronological order:
 
+    - Steve Dondley (@sdondley)
     - Maxim Kim (@habamax) <habamax@gmail.com> as original author
     - the people here: http://code.google.com/p/vimwiki/people/list
     - Stuart Andrews (@tub78)
@@ -3326,6 +3327,8 @@ https://github.com/vimwiki-backup/vimwiki/issues.
 2.5 (in progress)~
 
 New:~
+    * PR #683: Improve layout and format of key binding documentation in
+      README and include note about key bindings that may not work.
     * PR #675: Add option |vimwiki-option-name| to assign a per wiki name.
     * PR #661: Add option |g:vimwiki_auto_header| to automatically generate
       a level 1 header for new wiki pages.

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1426,11 +1426,18 @@ Tags-related commands and options:
 ==============================================================================
 6. Folding/Outline                                           *vimwiki-folding*
 
-Vimwiki can fold or outline sections using headers and preformatted blocks.
-Alternatively, one can fold list subitems instead. Folding is not enabled
-by default, and requires the |g:vimwiki_folding| variable to be set.
+Vimwiki allows you to use Vim's folding methods and options so you can fold
+your outline to make it less distracting and easier to navigate. You can use
+Vimwiki's built-in folding methods or supply custom methods for folding.  You
+control how folds behave with by setting the |g:vimwiki_folding| variable to
+the desired value in your configuration file:
 
-Example for list folding with |g:vimwiki_folding| set to 'list':
+let g:vimwiki_folding = <value>    " Surround value with quotes.
+
+If left unset, folding will default to Vim's "manual" method. If you wish to
+turn folding off completely, set |g:vimwiki_folding| to `''`(an empty string).
+
+Here is example of how folds work with |g:vimwiki_folding| set to 'list':
 
 = My current task =
 * [ ] Do stuff 1
@@ -1472,8 +1479,41 @@ Note: If you use the default Vimwiki syntax, folding on list items will work
 properly only if all of them are indented using the current 'shiftwidth'.
 For Markdown and MediaWiki syntax, * or # should be in the first column.
 
-To turn folding on/off check |g:vimwiki_folding|.
+For maximum control over folds, set |g:vimwiki_folding| to 'custom' so you can
+allow other plugins or your vim configuration file control how folding is
+performed. For example, let's say you prefer to fold so that the last blank
+line before a header is not folded, you can add this function to your
+configuration file:
 
+```
+let g:lastnum = 0
+function! VimwikiFoldLevelCustom(lnum)
+    if getline(a:lnum) =~? '\v^\s*$'
+	let g:lastnum = -1
+        return '-1'
+    endif
+    let last = g:lastnum
+    let num_of_pounds = strlen(matchstr(getline(a:lnum), '^#\+'))
+    if (num_of_pounds > 0)
+            let g:lastnum = num_of_pounds
+	    if last == -1
+		    return '>' . num_of_pounds
+	    endif
+	    return num_of_pounds
+    endif
+    return g:lastnum
+endfunction
+```
+
+Then you will need to add the following vim options to your configuration:
+
+```
+setlocal foldmethod=expr
+setlocal foldenable
+set foldexpr=VimwikiFoldLevelCustom(v:lnum)
+```
+
+See the |g:vimwiki_folding| documentation for more details.
 
 ==============================================================================
 7. Placeholders                                         *vimwiki-placeholders*
@@ -2632,10 +2672,10 @@ Value           Description~
 'expr'          Folding based on expression (folds sections and code blocks)
 'syntax'        Folding based on syntax (folds sections; slower than 'expr')
 'list'          Folding based on expression (folds list subitems; much slower)
-'custom'        Leave the folding settings as they are (e.g. set by another
-                plugin)
+'custom'        Allow folding options to be set by another plugin or a vim
+                configuration file
 
-Default: ''
+Default: 'manual'
 
 Limitations:
   - Opening very large files may be slow when folding is enabled.
@@ -2643,8 +2683,9 @@ Limitations:
   - 'list' is intended to work with lists nicely indented with 'shiftwidth'.
   - 'syntax' is only available for the default syntax so far.
 
-The options above can be suffixed with ':quick' (e.g.: 'expr:quick') in order
-to use some workarounds to make folds work faster.
+The 'expr', 'syntax' and 'list' options above can be suffixed with ':quick'
+(e.g.: 'expr:quick') in order to use some workarounds to make folds work
+faster.
 
 ------------------------------------------------------------------------------
 *g:vimwiki_list_ignore_newline*

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3259,7 +3259,6 @@ Old homepage: http://code.google.com/p/vimwiki/
 
 Contributors and their Github usernames in roughly chronological order:
 
-    - Steve Dondley (@sdondley)
     - Maxim Kim (@habamax) <habamax@gmail.com> as original author
     - the people here: http://code.google.com/p/vimwiki/people/list
     - Stuart Andrews (@tub78)
@@ -3312,6 +3311,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Steven Stallion (@sstallion)
     - Rane Brown (@ranebrown)
     - Patrik Willard (@padowi)
+    - Steve Dondley (@sdondley)
 
 
 ==============================================================================


### PR DESCRIPTION
Consider this a conversation starter. I'll post another commit for documentation if this is a go.

The patch is pretty straightforward. It adds a new user boolean variable, `custom_fold_func`. If true, it will call `VimwikiFoldLevelCustom` which the user will need to supply.

I created this because I did not like how vimwiki folded blank lines into the folds. I created this custom function to prevent the last blank lines from getting folded (note this function is not part of the patch, it's just here for reference for others who may want to use it). It works for markdown syntax:

```
let g:lastnum = 0
function! VimwikiFoldLevelCustom(lnum)
    if getline(a:lnum) =~? '\v^\s*$'
	let g:lastnum = -1
        return '-1'
    endif
    let last = g:lastnum
    let num_of_pounds = strlen(matchstr(getline(a:lnum), '^#\+'))
    if (num_of_pounds > 0)
            let g:lastnum = num_of_pounds
	    if last == -1
		    return '>' . num_of_pounds
	    endif
	    return num_of_pounds
    endif
    return g:lastnum
endfunction
```