### PR TITLE
Remove awa check triggering silent file edits.

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -826,22 +826,16 @@ function! vimwiki#base#edit_file(command, filename, anchor, ...)
   " This hack is necessary because apparently Vim messes up the result of
   " getpos() directly after this command. Strange.
   if !(a:command ==# ':e ' && vimwiki#path#is_equal(a:filename, expand('%:p')))
-    if &autowriteall && !&hidden  " in this case, the file is saved before switching to the
-      " new buffer. This causes Vim to show two messages in the command line which triggers
-      " the annoying hit-enter prompt. Solution: show no messages at all.
-      silent execute a:command fname
-    else
-      try
-        execute a:command fname
-      catch /E37:/
-        echomsg 'Vimwiki: Can''t leave the current buffer, because it is modified. Hint: Take a look at'
-              \ ''':h g:vimwiki_autowriteall'' to see how to save automatically.'
-        return
-      catch /E325:/
-        echom 'Vimwiki: Vim couldn''t open the file, probably because a swapfile already exists. See :h E325.'
-        return
-      endtry
-    endif
+    try
+      execute a:command fname
+    catch /E37:/
+      echomsg 'Vimwiki: Can''t leave the current buffer, because it is modified. Hint: Take a look at'
+            \ ''':h g:vimwiki_autowriteall'' to see how to save automatically.'
+      return
+    catch /E325:/
+      echom 'Vimwiki: Vim couldn''t open the file, probably because a swapfile already exists. See :h E325.'
+      return
+    endtry
 
     " If the opened file was not already loaded by Vim, an autocommand is
     " triggered at this point

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3511,6 +3511,7 @@ New:~
     * PR #47: Optimize table formatting for large tables.
 
 Removed:~
+    * PR #698: Remove awa check triggering silent file edits.
     * Options g:vimwiki_use_mouse and g:vimwiki_table_mappings. These are
       still present in the code for backwards compatibility but have been
       removed from the documentation and will be fully removed at a later


### PR DESCRIPTION
This is a change to `vimwiki#base#edit_file`.  Currently `if &autowriteall && !&hidden` are set, commands are executed silently.  The justification in comments for this is:
```in this case, the file is saved before switching to the new buffer. This causes Vim to show two messages in the command line which triggers the annoying hit-enter prompt. Solution: show no messages at all.``` 

Here's the original issue that lead to this being added: https://github.com/vimwiki/vimwiki/issues/445

I've opened a PR to remove this because (1.) The bug described in that issue and in the above comment is not occurring anymore and (2.) it's useful to see filename and cursor position displayed when switching links, and that is lost with `silent execute`.
