### PR TITLE
Allow forcing VimwikiAll2HTML with !

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1611,7 +1611,7 @@ function! vimwiki#html#Wiki2HTML(path_html, wikifile)
 endfunction
 
 
-function! vimwiki#html#WikiAll2HTML(path_html)
+function! vimwiki#html#WikiAll2HTML(path_html, force)
   if !s:syntax_supported() && !s:use_custom_wiki2html()
     echomsg 'Vimwiki Error: Conversion to HTML is not supported for this syntax'
     return
@@ -1653,7 +1653,7 @@ function! vimwiki#html#WikiAll2HTML(path_html)
     call vimwiki#vars#set_bufferlocal('subdir', subdir)
     call vimwiki#vars#set_bufferlocal('invsubdir', vimwiki#base#invsubdir(subdir))
 
-    if !s:is_html_uptodate(wikifile)
+    if a:force || !s:is_html_uptodate(wikifile)
       echomsg 'Vimwiki: Processing '.wikifile
 
       call s:convert_file(path_html, wikifile)

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3456,6 +3456,7 @@ https://github.com/vimwiki-backup/vimwiki/issues.
 2.5 (in progress)~
 
 New:~
+    * PR #711: Allow forcing VimwikiAll2HTML with !
     * PR #702: Make remapping documentation more accessible to newer vim users
     * PR #673: Add :VimwikiGoto key mapping.
     * PR #689: Allow |vimwiki-option-diary_rel_path| to be an empty string.

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -822,9 +822,13 @@ Vimwiki file.
 *:Vimwiki2HTMLBrowse*
     Convert current wiki page to HTML and open it in the webbrowser.
 
-*:VimwikiAll2HTML*
+*:VimwikiAll2HTML[!]*
     Convert all wiki pages to HTML.
     Default CSS file (style.css) is created if there is no one.
+
+    By default, only converts wiki pages which have not already been
+    converted or have been modified since their last conversion. With !,
+    convert all pages, regardless of whether or not they are out-of-date.
 
 *:VimwikiToggleListItem*
     Toggle checkbox of a list item on/off.

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -234,8 +234,8 @@ command! -buffer Vimwiki2HTMLBrowse
       \ call vimwiki#base#system_open_link(vimwiki#html#Wiki2HTML(
       \         expand(vimwiki#vars#get_wikilocal('path_html')),
       \         expand('%')))
-command! -buffer VimwikiAll2HTML
-      \ call vimwiki#html#WikiAll2HTML(expand(vimwiki#vars#get_wikilocal('path_html')))
+command! -buffer -bang VimwikiAll2HTML
+      \ call vimwiki#html#WikiAll2HTML(expand(vimwiki#vars#get_wikilocal('path_html')), <bang>0)
 
 command! -buffer VimwikiTOC call vimwiki#base#table_of_contents(1)
 


### PR DESCRIPTION
This simple change allows the user to supply a `!` to the `:VimwikiAll2HTML` command which forces vimwiki to recompile wikis to HTML even if they are not marked as out of date.

This is useful in the case where someone updates either the CSS file or the HTML template file (in which case the actual wiki files will not be marked out-of-date) and wants to recompile all of their wikis.
