### PR TITLE
Fix not normalized path separators on Windows

### DIFF
--- a/autoload/vimwiki/path.vim
+++ b/autoload/vimwiki/path.vim
@@ -38,11 +38,12 @@ endfunction
 function! vimwiki#path#path_norm(path)
   " /-slashes
   if a:path !~# '^scp:'
-    let path = substitute(a:path, '\', '/', 'g')
+    " ensure that we are not fooled by a symbolic link
+    let path = resolve(a:path)
+    let path = substitute(path, '\', '/', 'g')
     " treat multiple consecutive slashes as one path separator
     let path = substitute(path, '/\+', '/', 'g')
-    " ensure that we are not fooled by a symbolic link
-    return resolve(path)
+    return path
   else
     return a:path
   endif

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3517,6 +3517,7 @@ Removed:~
       point.
 
 Fixed:~
+    * PR #718: Fix not normalized path separators on Windows.
     * Modify horizontal rule (thematic-breaks) syntax for markdown.
     * Disable spell check in code and math inline/blocks.
     * Properly handle markdown image links `![]()`


### PR DESCRIPTION
Currently, `vimwiki#path#path_norm` calls `resolve` after all path normalization is finished, but when a path is resolved by `resolve` on Windows, "/" in the path changes back to "\\". This leads `vimwiki#base#find_wiki` to fail to find a registered wiki in `g:vimwiki_list`.
