### PR TITLE
Fix off-by-one error in get_next_line and get_prev_line

### DIFF
--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -419,10 +419,12 @@ function! s:get_next_line(lnum, ...)
     while cur_ln <= line('$') && getline(cur_ln) !~# vimwiki#vars#get_syntaxlocal('rxPreEnd')
       let cur_ln += 1
     endwhile
-    let next_line = cur_ln
+    let next_line = cur_ln + 1
   else
-    let next_line = nextnonblank(a:lnum+1)
+    let next_line = a:lnum + 1
   endif
+
+  let next_line = nextnonblank(next_line)
 
   if a:0 > 0 && getline(next_line) =~# vimwiki#vars#get_syntaxlocal('rxHeader')
     let next_line = s:get_next_line(next_line, 1)
@@ -440,18 +442,18 @@ endfunction
 "Returns: lnum-1 in most cases, but skips blank lines and preformatted text
 "0 in case of nonvalid line and a header, because a header ends every list
 function! s:get_prev_line(lnum)
-  let prev_line = prevnonblank(a:lnum-1)
+  let cur_ln = a:lnum - 1
 
-  if getline(prev_line) =~# vimwiki#vars#get_syntaxlocal('rxPreEnd')
-    let cur_ln = a:lnum - 1
+  if getline(cur_ln) =~# vimwiki#vars#get_syntaxlocal('rxPreEnd')
     while 1
       if cur_ln == 0 || getline(cur_ln) =~# vimwiki#vars#get_syntaxlocal('rxPreStart')
         break
       endif
       let cur_ln -= 1
     endwhile
-    let prev_line = cur_ln
   endif
+
+  let prev_line = prevnonblank(cur_ln)
 
   if prev_line < 0 || prev_line > line('$') ||
         \ getline(prev_line) =~# vimwiki#vars#get_syntaxlocal('rxHeader')

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3471,6 +3471,8 @@ https://github.com/vimwiki-backup/vimwiki/issues.
 2.5 (in progress)~
 
 New:~
+    * PR #735: Make list-toggling work properly even when code blocks are
+      embedded within the list in Markdown mode.
     * PR #711: Allow forcing VimwikiAll2HTML with !
     * PR #702: Make remapping documentation more accessible to newer vim users
     * PR #673: Add :VimwikiGoto key mapping.

--- a/test/list_update.vader
+++ b/test/list_update.vader
@@ -1,0 +1,191 @@
+Include: vader_includes/vader_setup.vader
+
+Given vimwiki (Sample nested list, vimwiki syntax):
+  * [ ] Top Level
+    * [ ] Child 1
+    * [ ] Child 2
+
+    * [ ] Post space
+
+    {{{code
+    * [ ] print "hello, world"
+    }}}
+
+    {{{morecode
+    print "hello again"
+    }}}
+
+    * [ ] Post code
+      * [ ] Sub-child
+
+      * [ ] Sub-sub-child
+
+Execute (Set syntax to default):
+  call SetSyntax('default')
+
+Do (Toggle top-level):
+  \<C-Space>
+
+Expect (All tree toggled):
+  * [X] Top Level
+    * [X] Child 1
+    * [X] Child 2
+
+    * [X] Post space
+
+    {{{code
+    * [ ] print "hello, world"
+    }}}
+
+    {{{morecode
+    print "hello again"
+    }}}
+
+    * [X] Post code
+      * [X] Sub-child
+
+      * [X] Sub-sub-child
+
+Do (Toggle child):
+  j
+  \<C-Space>
+
+Expect (Child toggled, top updated):
+  * [.] Top Level
+    * [X] Child 1
+    * [ ] Child 2
+
+    * [ ] Post space
+
+    {{{code
+    * [ ] print "hello, world"
+    }}}
+
+    {{{morecode
+    print "hello again"
+    }}}
+
+    * [ ] Post code
+      * [ ] Sub-child
+
+      * [ ] Sub-sub-child
+
+Do (Toggle sub-child):
+  G
+  \<C-Space>
+
+Expect (Sub-child toggled, parents updated):
+  * [.] Top Level
+    * [ ] Child 1
+    * [ ] Child 2
+
+    * [ ] Post space
+
+    {{{code
+    * [ ] print "hello, world"
+    }}}
+
+    {{{morecode
+    print "hello again"
+    }}}
+
+    * [o] Post code
+      * [ ] Sub-child
+
+      * [X] Sub-sub-child
+
+Given markdown (Sample nested list, markdown syntax):
+  * [ ] Top Level
+    * [ ] Child 1
+    * [ ] Child 2
+
+    * [ ] Post space
+
+    ```code
+    * [ ] print "hello, world"
+    ```
+
+    ```morecode
+    print "hello again"
+    ```
+
+    * [ ] Post code
+      * [ ] Sub-child
+
+      * [ ] Sub-sub-child
+
+Execute (Set syntax to markdown):
+  call SetSyntax('markdown')
+
+Do (Toggle top-level):
+  \<C-Space>
+
+Expect (All tree toggled):
+  * [X] Top Level
+    * [X] Child 1
+    * [X] Child 2
+
+    * [X] Post space
+
+    ```code
+    * [ ] print "hello, world"
+    ```
+
+    ```morecode
+    print "hello again"
+    ```
+
+    * [X] Post code
+      * [X] Sub-child
+
+      * [X] Sub-sub-child
+
+Do (Toggle child):
+  j
+  \<C-Space>
+
+Expect (Child toggled, top updated):
+  * [.] Top Level
+    * [X] Child 1
+    * [ ] Child 2
+
+    * [ ] Post space
+
+    ```code
+    * [ ] print "hello, world"
+    ```
+
+    ```morecode
+    print "hello again"
+    ```
+
+    * [ ] Post code
+      * [ ] Sub-child
+
+      * [ ] Sub-sub-child
+
+Do (Toggle sub-child):
+  G
+  \<C-Space>
+
+Expect (Sub-child toggled, parents updated):
+  * [.] Top Level
+    * [ ] Child 1
+    * [ ] Child 2
+
+    * [ ] Post space
+
+    ```code
+    * [ ] print "hello, world"
+    ```
+
+    ```morecode
+    print "hello again"
+    ```
+
+    * [o] Post code
+      * [ ] Sub-child
+
+      * [X] Sub-sub-child
+
+Include: vader_includes/vader_teardown.vader


### PR DESCRIPTION
I believe this fixes #407.

The problem as far as I can tell is that in the following example:

```
1 * [ ] Test
2     + [ ] Foo
3     ```c
4     printf("Hello, World\n")
5     ```
6     + [ ] Bar
7     + [ ] Baz
```

If `get_next_line` was used to get the next item after Foo it would correctly find
the `rxPreStart` symbol (```` ``` ````) and skip over it. Then it would loop until it
encountered the `rxPreEnd` symbol (the same ```` ``` ````) and there it would stop.

So far everything is working as expected, except that it would return the
*current* line (the one with the closing ```` ``` ````) instead of the next one. Therefore
the next call to get_next_line would start on the *same* line. Since for
markdown rxPreStart and rxPreEnd are the same sequence it now thinks this this
the start of a new block and keeps reading until it finds ```` ``` ```` again (or the end
of file).

The bug wasn't apparent with vimwiki markup because it uses it uses a different
sequence to begin and end code blocks, so the subsequent call to get_next_line
simply ignored the end-of-block sequence instead of erroneously believing it was the beginning of a new block.