### PR TITLE
Fix: VimwikiGoBackLink does not go back to links on the same page #691

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -104,6 +104,12 @@ function! vimwiki#base#find_wiki(path)
 endfunction
 
 
+" helper: check if a link a well formed wiki link
+function! s:is_wiki_link(link_infos)
+  return a:link_infos.scheme =~# '\mwiki\d\+' || a:link_infos.scheme ==# 'diary'
+endfunction
+
+
 " THE central function of Vimwiki. Extract infos about the target from a link.
 " If the second parameter is present, which should be an absolute file path, it
 " is assumed that the link appears in that file. Without it, the current file
@@ -147,7 +153,7 @@ function! vimwiki#base#resolve_link(link_text, ...)
     let link_text = matchstr(link_text, '^'.vimwiki#vars#get_global('rxSchemes').':\zs.*\ze')
   endif
 
-  let is_wiki_link = link_infos.scheme =~# '\mwiki\d\+' || link_infos.scheme ==# 'diary'
+  let is_wiki_link = s:is_wiki_link(link_infos)
 
   " extract anchor
   if is_wiki_link
@@ -328,7 +334,7 @@ function! vimwiki#base#open_link(cmd, link, ...)
     return
   endif
 
-  let is_wiki_link = link_infos.scheme =~# '\mwiki\d\+' || link_infos.scheme =~# 'diary'
+  let is_wiki_link = s:is_wiki_link(link_infos)
 
   let update_prev_link = is_wiki_link &&
         \ !vimwiki#path#is_equal(link_infos.filename, vimwiki#path#current_wiki_file())

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -336,12 +336,9 @@ function! vimwiki#base#open_link(cmd, link, ...)
 
   let is_wiki_link = s:is_wiki_link(link_infos)
 
-  let update_prev_link = is_wiki_link &&
-        \ !vimwiki#path#is_equal(link_infos.filename, vimwiki#path#current_wiki_file())
-
   let vimwiki_prev_link = []
   " update previous link for wiki pages
-  if update_prev_link
+  if is_wiki_link
     if a:0
       let vimwiki_prev_link = [a:1, []]
     elseif &ft ==# 'vimwiki'
@@ -352,7 +349,7 @@ function! vimwiki#base#open_link(cmd, link, ...)
   " open/edit
   if is_wiki_link
     call vimwiki#base#edit_file(a:cmd, link_infos.filename, link_infos.anchor,
-          \ vimwiki_prev_link, update_prev_link)
+          \ vimwiki_prev_link, is_wiki_link)
   else
     call vimwiki#base#system_open_link(link_infos.filename)
   endif
@@ -861,7 +858,9 @@ function! vimwiki#base#edit_file(command, filename, anchor, ...)
   " a:1 -- previous vimwiki link to save
   " a:2 -- should we update previous link
   if a:0 && a:2 && len(a:1) > 0
-    call vimwiki#vars#set_bufferlocal('prev_link', a:1)
+    let prev_links = vimwiki#vars#get_bufferlocal('prev_links')
+    call insert(prev_links, a:1)
+    call vimwiki#vars#set_bufferlocal('prev_links', prev_links)
   endif
 endfunction
 
@@ -1040,7 +1039,7 @@ function! s:get_wiki_buffers()
       " this may find buffers that are not part of the current wiki, but that
       " doesn't hurt
       if bname =~# vimwiki#vars#get_wikilocal('ext')."$"
-        let bitem = [bname, vimwiki#vars#get_bufferlocal('prev_link', bcount)]
+        let bitem = [bname, vimwiki#vars#get_bufferlocal('prev_links', bcount)]
         call add(blist, bitem)
       endif
     endif
@@ -1053,7 +1052,7 @@ endfunction
 function! s:open_wiki_buffer(item)
   call vimwiki#base#edit_file(':e', a:item[0], '')
   if !empty(a:item[1])
-    call vimwiki#vars#set_bufferlocal('prev_link', a:item[1], a:item[0])
+    call vimwiki#vars#set_bufferlocal('prev_links', a:item[1], a:item[0])
   endif
 endfunction
 
@@ -1347,7 +1346,15 @@ endfunction
 
 
 function! vimwiki#base#go_back_link()
-  let prev_link = vimwiki#vars#get_bufferlocal('prev_link')
+  " try pop previous link from buffer list
+  let prev_links = vimwiki#vars#get_bufferlocal('prev_links')
+  if !empty(prev_links)
+    let prev_link = remove(prev_links, 0)
+    call vimwiki#vars#set_bufferlocal('prev_links', prev_links)
+  else
+    let prev_link = []
+  endif
+
   if !empty(prev_link)
     " go back to saved wiki link
     call vimwiki#base#edit_file(':e ', prev_link[0], '')
@@ -1479,7 +1486,7 @@ function! vimwiki#base#rename_link()
 
   let &buftype="nofile"
 
-  let cur_buffer = [expand('%:p'), vimwiki#vars#get_bufferlocal('prev_link')]
+  let cur_buffer = [expand('%:p'), vimwiki#vars#get_bufferlocal('prev_links')]
 
   let blist = s:get_wiki_buffers()
 

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -175,9 +175,6 @@ function! vimwiki#base#resolve_link(link_text, ...)
 
   " check if absolute or relative path
   if is_wiki_link && link_text[0] == '/'
-    if link_text != '/'
-      let link_text = link_text[1:]
-    endif
     let is_relative = 0
   elseif !is_wiki_link && vimwiki#path#is_absolute(link_text)
     let is_relative = 0
@@ -220,11 +217,15 @@ function! vimwiki#base#resolve_link(link_text, ...)
       endif
     endif
 
-    if !is_relative || link_infos.index != source_wiki
+    if link_infos.index != source_wiki
       let root_dir = vimwiki#vars#get_wikilocal('path', link_infos.index)
     endif
 
-    let link_infos.filename = root_dir . link_text
+    if is_relative
+      let link_infos.filename = root_dir . link_text
+    else
+      let link_infos.filename = link_text
+    endif
 
     if vimwiki#path#is_link_to_dir(link_text)
       if vimwiki#vars#get_global('dir_link') != ''

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -905,8 +905,8 @@ function! vimwiki#vars#get_bufferlocal(key, ...)
   elseif a:key ==# 'existing_wikidirs'
     call setbufvar(buffer, 'vimwiki_existing_wikidirs',
         \ vimwiki#base#get_wiki_directories(vimwiki#vars#get_bufferlocal('wiki_nr')))
-  elseif a:key ==# 'prev_link'
-    call setbufvar(buffer, 'vimwiki_prev_link', [])
+  elseif a:key ==# 'prev_links'
+    call setbufvar(buffer, 'vimwiki_prev_links', [])
   elseif a:key ==# 'markdown_refs'
     call setbufvar(buffer, 'vimwiki_markdown_refs', vimwiki#markdown_base#scan_reflinks())
   else


### PR DESCRIPTION
Fixing issue #691

1/ `prev_link` -> `prev_links` which is not a link anymore but a list of links. So each buffer can have multiple prev_link
2/ Remove the check is_same_file before going back from link : `!vimwiki#path#is_equal(link_infos.filename, vimwiki#path#current_wiki_file())`

Stating #ranebrown: It does sound like storing multiple links would be required.