### PR TITLE
Add error handling to VimwikiSearch

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -839,8 +839,8 @@ Vimwiki file.
     To display previous match use |:lprevious| command.
 
     Hint: this feature is simply a wrapper around |:lvimgrep|. For a
-    description of how the pattern can look like, see |:vimgrep|. For example,
-    to do a case insensitive search, use >
+    complete description of the search pattern format, see |:vimgrep|.
+    For example, to perform a case insensitive search, use >
     :VWS /\cpattern/
 
 *:VimwikiBacklinks*
@@ -3464,6 +3464,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Shaedil (@Shaedil)
     - Robin Lowe (@defau1t)
     - Abhinav Gupta (@abhinav)
+    - Dave Gauer (@ratfactor)
 
 
 ==============================================================================
@@ -3544,6 +3545,7 @@ Removed:~
       point.
 
 Fixed:~
+    * Issue #420: Add error handling to VimwikiSearch
     * PR #744: Fix typo in vimwiki_list_manipulation
     * Issue #715: s:clean_url is compatible with vim pre 7.4.1546 (sticky type
       checking)

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -258,11 +258,8 @@ command! -buffer VimwikiGenerateLinks call vimwiki#base#generate_links(1)
 command! -buffer -nargs=0 VimwikiBacklinks call vimwiki#base#backlinks()
 command! -buffer -nargs=0 VWB call vimwiki#base#backlinks()
 
-exe 'command! -buffer -nargs=* VimwikiSearch lvimgrep <args> '.
-      \ escape(vimwiki#vars#get_wikilocal('path').'**/*'.vimwiki#vars#get_wikilocal('ext'), ' ')
-
-exe 'command! -buffer -nargs=* VWS lvimgrep <args> '.
-      \ escape(vimwiki#vars#get_wikilocal('path').'**/*'.vimwiki#vars#get_wikilocal('ext'), ' ')
+command! -buffer -nargs=* VimwikiSearch call vimwiki#base#search(<q-args>)
+command! -buffer -nargs=* VWS call vimwiki#base#search(<q-args>)
 
 command! -buffer -nargs=* -complete=custom,vimwiki#base#complete_links_escaped
       \ VimwikiGoto call vimwiki#base#goto(<f-args>)

--- a/test/resources/testwiki space/buzz bozz.wiki
+++ b/test/resources/testwiki space/buzz bozz.wiki
@@ -1,0 +1,3 @@
+= Buzz Bozz =
+
+Cras nisl dolor, mattis condimentum neque ac, cursus tristique est. Sed vel imperdiet ipsum. Curabitur non dictum tortor. Donec massa justo, cursus at suscipit ornare, tempus a tellus. Praesent at orci mi. Praesent sed odio in leo pulvinar vulputate. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eu leo dui. Fusce vitae laoreet massa. Donec ac tempor lectus. Curabitur eget ligula vel purus efficitur congue. Fusce ut pellentesque magna, eget facilisis nunc.

--- a/test/resources/testwiki space/index.wiki
+++ b/test/resources/testwiki space/index.wiki
@@ -1,0 +1,30 @@
+= Space Path Wiki =
+
+This test wiki exists to test various features of VimWiki.
+
+VimWiki Developers: Feel free to *add* to this wiki for additional test features.
+
+Foo bar foo bar biz baz.
+
+[[buzz_bozz|Buzz Bozz]]
+
+== Lorem ipsum dolor ==
+
+Sit amet, consectetur adipiscing elit. Etiam sed efficitur lectus, sit amet consectetur purus. Vestibulum pulvinar, magna et fermentum aliquet, diam libero blandit ex, quis iaculis dui metus sit amet nulla. Mauris auctor massa magna, eu aliquam neque consequat a. Duis lorem nunc, tempus eu dignissim a, euismod sit amet ex. Duis nec condimentum libero. Nulla iaculis fringilla ante, in posuere lorem maximus vel. Nam pulvinar quis diam non ultrices. Vivamus maximus ipsum a placerat rutrum. Nam et consectetur erat, sodales hendrerit ligula.
+
+== Etiam dapibus iaculis ==
+
+Sed tincidunt vestibulum nunc, in dapibus eros dictum in. Nullam ut dolor nisi.
+
+* blandit nulla mi
+* at gravida magna
+* maximus eu
+
+=== Morbi id sodales sem ===
+
+Nulla id malesuada velit. Mauris ac nisl orci. Donec maximus ex in sapien fringilla mollis. Praesent eu felis bibendum, auctor justo eget, bibendum purus. Nullam egestas, diam et eleifend tempus, ipsum libero auctor mi, quis rutrum neque metus ac tortor. Vestibulum porttitor tempus vulputate.
+
+== Praesent tempor turpis est ==
+
+Nunc scelerisque placerat auctor. Donec vel iaculis risus, non commodo nisl. Duis pretium nisi nibh, ac faucibus metus condimentum nec. Aliquam eu euismod lorem. Aenean sit amet tellus sed massa luctus dignissim. Nam tempor sapien quis felis hendrerit fermentum. Nunc vitae vehicula enim.
+

--- a/test/resources/testwiki/buzz_bozz.wiki
+++ b/test/resources/testwiki/buzz_bozz.wiki
@@ -1,0 +1,3 @@
+= Buzz Bozz =
+
+Cras nisl dolor, mattis condimentum neque ac, cursus tristique est. Sed vel imperdiet ipsum. Curabitur non dictum tortor. Donec massa justo, cursus at suscipit ornare, tempus a tellus. Praesent at orci mi. Praesent sed odio in leo pulvinar vulputate. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed eu leo dui. Fusce vitae laoreet massa. Donec ac tempor lectus. Curabitur eget ligula vel purus efficitur congue. Fusce ut pellentesque magna, eget facilisis nunc.

--- a/test/resources/testwiki/index.wiki
+++ b/test/resources/testwiki/index.wiki
@@ -1,0 +1,35 @@
+= Test Wiki =
+
+This test wiki exists to test various features of VimWiki.
+
+VimWiki Developers: Feel free to *add* to this wiki for additional test features.
+
+Foo bar
+foo bar
+biz baz
+foo\bar
+baz{13} <--- this is for testing a literal "baz{13}"
+buzzzzz <--- this is for testing regex /buz{5}/
+
+[[buzz_bozz|Buzz Bozz]]
+
+== Lorem ipsum dolor ==
+
+Sit amet, consectetur adipiscing elit. Etiam sed efficitur lectus, sit amet consectetur purus. Vestibulum pulvinar, magna et fermentum aliquet, diam libero blandit ex, quis iaculis dui metus sit amet nulla. Mauris auctor massa magna, eu aliquam neque consequat a. Duis lorem nunc, tempus eu dignissim a, euismod sit amet ex. Duis nec condimentum libero. Nulla iaculis fringilla ante, in posuere lorem maximus vel. Nam pulvinar quis diam non ultrices. Vivamus maximus ipsum a placerat rutrum. Nam et consectetur erat, sodales hendrerit ligula.
+
+== Etiam dapibus iaculis ==
+
+Sed tincidunt vestibulum nunc, in dapibus eros dictum in. Nullam ut dolor nisi.
+
+* blandit nulla mi
+* at gravida magna
+* maximus eu
+
+=== Morbi id sodales sem ===
+
+Nulla id malesuada velit. Mauris ac nisl orci. Donec maximus ex in sapien fringilla mollis. Praesent eu felis bibendum, auctor justo eget, bibendum purus. Nullam egestas, diam et eleifend tempus, ipsum libero auctor mi, quis rutrum neque metus ac tortor. Vestibulum porttitor tempus vulputate.
+
+== Praesent tempor turpis est ==
+
+Nunc scelerisque placerat auctor. Donec vel iaculis risus, non commodo nisl. Duis pretium nisi nibh, ac faucibus metus condimentum nec. Aliquam eu euismod lorem. Aenean sit amet tellus sed massa luctus dignissim. Nam tempor sapien quis felis hendrerit fermentum. Nunc vitae vehicula enim.
+

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -35,9 +35,11 @@ runVader() {
     for v in $vers; do
         echo ""
         echo "Running version: $v"
+        vim="/vim-build/bin/$v -u test/vimrc -i NONE"
+        test_cmd="for VF in test/*.vader; do $vim \"+Vader! \$VF\"; done"
         set -o pipefail
         docker run -a stderr -e VADER_OUTPUT_FILE=/dev/stderr "${flags[@]}" \
-            "$v" -u test/vimrc -i NONE "+Vader! test/*" 2>&1 | vader_filter | vader_color
+          /bin/bash -c "$test_cmd" 2>&1 | vader_filter | vader_color
         set +o pipefail
     done
 }

--- a/test/search.vader
+++ b/test/search.vader
@@ -1,0 +1,66 @@
+Include: vader_includes/vader_setup.vader
+
+Execute (Setup search testing wrapper):
+  function! TestSearch(search_command, test_name)
+    " Note: after each search, the location list of the current window (0)
+    " will contain the search results. A non-empty list indicates success.
+    " Search for a single word (a pattern with no spaces)
+    redir => output
+    silent execute a:search_command
+    redir END
+    Assert !empty(getloclist(0)), a:test_name.": no location list result"
+    Assert match(output, '\d of \d') > -1, a:test_name.": no result message"
+
+    " Tests that VimwikiSearch is quoting the pattern correctly.
+    " If not, Vim will see anything after the first space in the pattern
+    " as a file name and attempt to open it.
+    Assert match(output, 'Cannot open file') == -1, "'open file': unquoted pattern?"
+
+    return output
+  endfunction
+
+Execute (Search test wiki):
+  " Open test wiki
+  edit test/resources/testwiki/index.wiki
+
+  " Make sure we opened the test wiki successfully by checking the
+  " title (first line) and filetype.
+  AssertEqual "= Test Wiki =", getline(1)
+  AssertEqual "vimwiki", &filetype
+
+
+  call TestSearch('VimwikiSearch foo',        'pattern with no spaces')
+  call TestSearch('VimwikiSearch foo bar',    'pattern with spaces')
+  call TestSearch('VimwikiSearch foo\bar',    'pattern with ''\''')
+  call TestSearch('VimwikiSearch baz{13}',    'pattern with literal {}')
+  call TestSearch('VimwikiSearch /\vbuz{5}/', 'proper regex')
+  call TestSearch('VWS foo bar',              'use VWS abbreviation')
+
+Execute (Search space path wiki):
+  " Open wiki with spaces in path to test fname escaping
+  edit test/resources/testwiki\ space/index.wiki
+
+  " Make sure we opened the space path wiki successfully
+  AssertEqual "= Space Path Wiki =", getline(1)
+
+  call TestSearch('VimwikiSearch foo', 'simple search in space path wiki')
+
+Execute (Search failure message):
+  " Important note: No search tests will succeed after this.
+  " The failed search will cause a Vim error to be thrown and
+  " any search with lvimgrep within Vader will result in an
+  " empty location list and empty messages queue. It is
+  " difficult to tell if the search itself is failing or if it
+  " is just an inability to view the results.
+
+  " Open test wiki again
+  edit test/resources/testwiki/index.wiki
+
+  " Now test a negative search and make sure we are returning
+  " the expected VimWiki error.
+  redir => output
+  silent VimwikiSearch not_exist
+  redir END
+  Assert match(output, 'VimwikiSearch: No match found.') > -1, "expected custom error"
+
+Include: vader_includes/vader_teardown.vader


### PR DESCRIPTION
The biggest challenge here was getting the Vader tests to work with the `lvimgrep` functionality which underlies the VimwikiSearch feature - after a lot of trial and error, the simplest and least fragile thing to do was make the `run_tests.sh` script run the Vader tests in separate Vim instances (but still a single Docker instance for the sake of efficiency) where they could not be "contaminated".

Commit message body:

 - Create function wrapper around lvimgrep for input checking, pattern
   quoting, and error handling.
 - Add Vader tests for VimwikiSearch.
 - Change syntax loading from try/catch to explicit file check (to
   prevent Vader test bug).
 - Update doc/vimwiki.txt for changes.
 - Change test script to run Vader tests separately
