### PR TITLE
Fix: VimwikiGoBackLink does not go back to links on the same page #691 (more stable pull request)

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -104,6 +104,12 @@ function! vimwiki#base#find_wiki(path)
 endfunction
 
 
+" helper: check if a link a well formed wiki link
+function! s:is_wiki_link(link_infos)
+  return a:link_infos.scheme =~# '\mwiki\d\+' || a:link_infos.scheme ==# 'diary'
+endfunction
+
+
 " THE central function of Vimwiki. Extract infos about the target from a link.
 " If the second parameter is present, which should be an absolute file path, it
 " is assumed that the link appears in that file. Without it, the current file
@@ -147,7 +153,7 @@ function! vimwiki#base#resolve_link(link_text, ...)
     let link_text = matchstr(link_text, '^'.vimwiki#vars#get_global('rxSchemes').':\zs.*\ze')
   endif
 
-  let is_wiki_link = link_infos.scheme =~# '\mwiki\d\+' || link_infos.scheme ==# 'diary'
+  let is_wiki_link = s:is_wiki_link(link_infos)
 
   " extract anchor
   if is_wiki_link
@@ -328,7 +334,7 @@ function! vimwiki#base#open_link(cmd, link, ...)
     return
   endif
 
-  let is_wiki_link = link_infos.scheme =~# '\mwiki\d\+' || link_infos.scheme =~# 'diary'
+  let is_wiki_link = s:is_wiki_link(link_infos)
 
   let update_prev_link = is_wiki_link &&
         \ !vimwiki#path#is_equal(link_infos.filename, vimwiki#path#current_wiki_file())

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -336,12 +336,9 @@ function! vimwiki#base#open_link(cmd, link, ...)
 
   let is_wiki_link = s:is_wiki_link(link_infos)
 
-  let update_prev_link = is_wiki_link &&
-        \ !vimwiki#path#is_equal(link_infos.filename, vimwiki#path#current_wiki_file())
-
   let vimwiki_prev_link = []
   " update previous link for wiki pages
-  if update_prev_link
+  if is_wiki_link
     if a:0
       let vimwiki_prev_link = [a:1, []]
     elseif &ft ==# 'vimwiki'
@@ -352,7 +349,7 @@ function! vimwiki#base#open_link(cmd, link, ...)
   " open/edit
   if is_wiki_link
     call vimwiki#base#edit_file(a:cmd, link_infos.filename, link_infos.anchor,
-          \ vimwiki_prev_link, update_prev_link)
+          \ vimwiki_prev_link, is_wiki_link)
   else
     call vimwiki#base#system_open_link(link_infos.filename)
   endif
@@ -861,7 +858,9 @@ function! vimwiki#base#edit_file(command, filename, anchor, ...)
   " a:1 -- previous vimwiki link to save
   " a:2 -- should we update previous link
   if a:0 && a:2 && len(a:1) > 0
-    call vimwiki#vars#set_bufferlocal('prev_link', a:1)
+    let prev_links = vimwiki#vars#get_bufferlocal('prev_links')
+    call insert(prev_links, a:1)
+    call vimwiki#vars#set_bufferlocal('prev_links', prev_links)
   endif
 endfunction
 
@@ -1040,7 +1039,7 @@ function! s:get_wiki_buffers()
       " this may find buffers that are not part of the current wiki, but that
       " doesn't hurt
       if bname =~# vimwiki#vars#get_wikilocal('ext')."$"
-        let bitem = [bname, vimwiki#vars#get_bufferlocal('prev_link', bcount)]
+        let bitem = [bname, vimwiki#vars#get_bufferlocal('prev_links', bcount)]
         call add(blist, bitem)
       endif
     endif
@@ -1053,7 +1052,7 @@ endfunction
 function! s:open_wiki_buffer(item)
   call vimwiki#base#edit_file(':e', a:item[0], '')
   if !empty(a:item[1])
-    call vimwiki#vars#set_bufferlocal('prev_link', a:item[1], a:item[0])
+    call vimwiki#vars#set_bufferlocal('prev_links', a:item[1], a:item[0])
   endif
 endfunction
 
@@ -1353,7 +1352,15 @@ endfunction
 
 
 function! vimwiki#base#go_back_link()
-  let prev_link = vimwiki#vars#get_bufferlocal('prev_link')
+  " try pop previous link from buffer list
+  let prev_links = vimwiki#vars#get_bufferlocal('prev_links')
+  if !empty(prev_links)
+    let prev_link = remove(prev_links, 0)
+    call vimwiki#vars#set_bufferlocal('prev_links', prev_links)
+  else
+    let prev_link = []
+  endif
+
   if !empty(prev_link)
     " go back to saved wiki link
     call vimwiki#base#edit_file(':e ', prev_link[0], '')
@@ -1485,7 +1492,7 @@ function! vimwiki#base#rename_link()
 
   let &buftype="nofile"
 
-  let cur_buffer = [expand('%:p'), vimwiki#vars#get_bufferlocal('prev_link')]
+  let cur_buffer = [expand('%:p'), vimwiki#vars#get_bufferlocal('prev_links')]
 
   let blist = s:get_wiki_buffers()
 

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -905,8 +905,8 @@ function! vimwiki#vars#get_bufferlocal(key, ...)
   elseif a:key ==# 'existing_wikidirs'
     call setbufvar(buffer, 'vimwiki_existing_wikidirs',
         \ vimwiki#base#get_wiki_directories(vimwiki#vars#get_bufferlocal('wiki_nr')))
-  elseif a:key ==# 'prev_link'
-    call setbufvar(buffer, 'vimwiki_prev_link', [])
+  elseif a:key ==# 'prev_links'
+    call setbufvar(buffer, 'vimwiki_prev_links', [])
   elseif a:key ==# 'markdown_refs'
     call setbufvar(buffer, 'vimwiki_markdown_refs', vimwiki#markdown_base#scan_reflinks())
   else

--- a/test/link_markdown_multiple_per_file.vader
+++ b/test/link_markdown_multiple_per_file.vader
@@ -1,0 +1,225 @@
+Include: vader_includes/vader_setup.vader
+
+Given vimwiki (Internal links + one link to filenew):
+  # Contents
+  
+    - [Test1](#Test1)
+    - [Test2](#Test2)
+  
+  # Test1
+  
+    - [Test1](#Test1)
+    - [Test2](#Test2)
+    - [filenew](filenew)
+  
+  # Test2
+  
+    - [Test1](#Test1)
+    - [Test2](#Test2)
+    - [filenew](filenew)
+
+Execute (Set filename wiki_test.md):
+  file wiki_test.md
+  call SetSyntax('markdown')
+
+Do (Navigate with <Tab>):
+  A more Contents\<Esc>
+  \<Tab>
+  \<Enter>
+  A more Test1\<Esc>
+  \<Tab>
+  \<Tab>
+  \<Enter>
+  A more Test2\<Esc>
+
+Expect (Content added to titles):
+  # Contents more Contents
+
+    - [Test1](#Test1)
+    - [Test2](#Test2)
+
+  # Test1 more Test1
+
+    - [Test1](#Test1)
+    - [Test2](#Test2)
+    - [filenew](filenew)
+
+  # Test2 more Test2
+
+    - [Test1](#Test1)
+    - [Test2](#Test2)
+    - [filenew](filenew)
+
+Do (Navigate with <Tab> and <Enter> and come back with <Bs>):
+  \<Tab>
+  \<Enter>
+# Cursor at Test1
+  \<Tab>
+  \<Tab>
+  \<Enter>
+# Cursor at Test2
+  \<Tab>
+  \<Tab>
+  \<Tab>
+# Cursor at Test2/filenew
+  A not yet\<Esc>
+  \<Bs>
+# Cursor at Test1/test2
+  A near Test1/test2
+  \<Esc>
+  \<Bs>
+# Cursor at Contents/test1
+  A near Contents/test1
+  \<Esc>
+
+Expect (Vimwiki links):
+  # Contents
+
+    - [Test1](#Test1) near Contents/test1
+    - [Test2](#Test2)
+
+  # Test1
+
+    - [Test1](#Test1)
+    - [Test2](#Test2) near Test1/test2
+    - [filenew](filenew)
+
+  # Test2
+
+    - [Test1](#Test1)
+    - [Test2](#Test2)
+    - [filenew](filenew) not yet
+
+Do (Navigate with <Tab> comeback with <Bs> from filenew):
+  \<Tab>
+  A first shot\<Esc>
+  0\<Tab>
+# Cursor at Contents/test1
+  \<Enter>
+  \<Tab>
+  \<Tab>
+  A first shot\<Esc>
+  0\<Tab>
+# Cursor at Test1/test2
+  \<Enter>
+  G
+# Cursor at Test2/filenew
+  A first shot\<Esc>
+  0\<Tab>
+# Cursor at Test2/filenew
+  \<Enter>
+# Cursor in filenew (a new file)
+  A anything in filenew: empirically it does not count\<Esc>
+  \<Bs>
+# Cursor at Test2/filenew
+  \<Bs>
+# Cursor at Test1/test2
+  \<Bs>
+# Cursor at Contents/test1
+  A second shot
+
+Expect (Just Contents/test1 got the second shot):
+  # Contents
+
+    - [Test1](#Test1) first shot second shot
+    - [Test2](#Test2)
+
+  # Test1
+
+    - [Test1](#Test1)
+    - [Test2](#Test2) first shot
+    - [filenew](filenew)
+
+  # Test2
+
+    - [Test1](#Test1)
+    - [Test2](#Test2)
+    - [filenew](filenew) first shot
+
+Execute (Delete filenew buffer):
+  bd! /testplugin/filenew.md
+
+Do (Navigate with <Tab> comeback with <Bs> too far):
+  \<Tab>
+# Cursor at Contents/test1
+  \<Enter>
+  \<Tab>
+  \<Tab>
+# Cursor at Test1/test2
+  \<Enter>
+  \<Tab>
+# Cursor at Test2/test1
+  \<Enter>
+  \<Tab>
+  \<Tab>
+# Cursor at Test1/test2
+  \<Enter>
+  A first test2\<Esc>
+  \<Tab>
+# Cursor at Test2/test1
+  \<Enter>
+  A first test1\<Esc>
+# Back
+  \<Bs>
+# Cursor at Test2/test1
+  A second test2/test1\<Esc>
+  \<Bs>
+# Cursor at Test1/test2
+  A second test1/test2\<Esc>
+  \<Bs>
+# Cursor at Test2/test1
+  \<Bs>
+# Cursor at Test1/test2
+  \<Bs>
+# Cursor at Contents/test1
+# Finished
+  \<Bs>
+  \<Bs>
+  \<Bs>
+  \<Bs>
+  A 1\<Esc>
+  \<Bs>
+  A 2\<Esc>
+  \<Bs>
+  A 3\<Esc>
+  \<Bs>
+  A 4\<Esc>
+
+Expect (After too many <Bs>, cursor stays at the first <Enter> spot in first file: Contents/test1):
+  # Contents
+
+    - [Test1](#Test1) 1 2 3 4
+    - [Test2](#Test2)
+
+  # Test1 first test1
+
+    - [Test1](#Test1)
+    - [Test2](#Test2) second test1/test2
+    - [filenew](filenew)
+
+  # Test2 first test2
+
+    - [Test1](#Test1) second test2/test1
+    - [Test2](#Test2)
+    - [filenew](filenew)
+
+Given vimwiki (link to self):
+  - [Bad link](Very bad.html)
+  - [My own file](wiki_test)
+  - [Test1](#Test1)
+  - [Test2](#Test2)
+
+Do (Follow link to self and append chars):
+  \<Tab>
+  \<Tab>
+  \<Enter>
+  a this_is_18_chars \<Esc>
+
+Expect (Some chars appended at self link):
+  - [Bad link](Very bad.html)
+  - [ this_is_18_chars My own file](wiki_test)
+  - [Test1](#Test1)
+  - [Test2](#Test2)
+
+
+Include: vader_includes/vader_teardown.vader


### PR DESCRIPTION
Fixing issue #691

1/ `prev_link` -> `prev_links` which is not a link anymore but a list of links. So each buffer can have multiple prev_link
2/ Remove the check is_same_file before going back from link : `!vimwiki#path#is_equal(link_infos.filename, vimwiki#path#current_wiki_file())`

Stating #ranebrown: It does sound like storing multiple links would be required.