### PR TITLE
Added new feature to insert plaintext to the final html conversion file.

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3466,6 +3466,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Robin Lowe (@defau1t)
     - Abhinav Gupta (@abhinav)
     - Dave Gauer (@ratfactor)
+    - Valtteri Vallius (@kaphula)
 
 
 ==============================================================================


### PR DESCRIPTION
Referenced issue: https://github.com/vimwiki/vimwiki/issues/774

As described in the issue, this pull request implements a feature to insert plaintext to the final html conversion file. This is useful if you want to apply custom css styling to specific parts of your vimwiki documents. 

Example usage inside vimwiki file:
```
%plainhtml <div style="text-align: center;">
My normal vimwiki paragraph that will be centered when viewed with html browser.
%plainhtml </div>
```
The feature triggers only when **%plainhtml** is the first thing on the line (excluding whitespace).

There was an issue when the **%plainhtml** was inserted on the same block with other elements such as paragraphs. The conversion script wrapped up the plaintext inside the corresponding html elements, creating incorrect nested html element structure:

```
%plainhtml </div>
My paragraph.
%plainhtml </div>
```
Was translated to:
```
<div>
<p> 
My paragraph.
</div>
</p>
```
Which is not what is wanted. The closing `</div>` should be the last element.

This was fixed by adding a list of checks that will close the conversion elements (table, para, quote...) before the plain text is inserted. If there are other items like these (or will be in the future), it might be necessary to add them to the list of checks. Now that I think about it, it might be a good idea to create a common function that does this checking for all of the conversion elements at one place.

I did not add any documentation yet since the keyword to trigger the plaintext (**%plainhtml**) may not be suitable. I learnt vimscript as I implemented this feature, so validating and testing the code further is also recommended.

