### PR TITLE
VimwikiGoto completion works with part of filename and in nested directories

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -362,7 +362,7 @@ function! vimwiki#base#get_globlinks_escaped() abort
   let orig_pwd = getcwd()
   lcd! %:h
   " all path are relative to the current file's location
-  let globlinks = glob('*'.vimwiki#vars#get_wikilocal('ext'), 1)."\n"
+  let globlinks = glob('**/*'.vimwiki#vars#get_wikilocal('ext'), 1)."\n"
   " remove extensions
   let globlinks = substitute(globlinks, '\'.vimwiki#vars#get_wikilocal('ext').'\ze\n', '', 'g')
   " restore the original working directory

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -430,9 +430,14 @@ function! vimwiki#base#goto(...)
   let key = a:0 > 0 ? a:1 : input('Enter name: ')
   let anchor = a:0 > 1 ? a:2 : ''
 
+  " Save current file pos
+  let vimwiki_prev_link = [vimwiki#path#current_wiki_file(), getpos('.')]
+
   call vimwiki#base#edit_file(':e',
         \ vimwiki#vars#get_wikilocal('path') . key . vimwiki#vars#get_wikilocal('ext'),
-        \ anchor)
+        \ anchor,
+        \ vimwiki_prev_link,
+        \ &ft ==# 'vimwiki')
 endfunction
 
 

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -356,7 +356,8 @@ function! vimwiki#base#open_link(cmd, link, ...)
 endfunction
 
 
-function! vimwiki#base#get_globlinks_escaped() abort
+function! vimwiki#base#get_globlinks_escaped(...) abort
+  let s_arg_lead = a:0 > 0 ? a:1 : ""
   " only get links from the current dir
   " change to the directory of the current file
   let orig_pwd = getcwd()
@@ -369,12 +370,14 @@ function! vimwiki#base#get_globlinks_escaped() abort
   exe 'lcd! '.orig_pwd
   " convert to a List
   let lst = split(globlinks, '\n')
+  " Filter files whose path matches the  user's argument leader
+  " " use smart case matching
+  let r_arg = substitute(s_arg_lead, '\u', '[\0\l\0]', 'g')
+  call filter(lst, '-1 != match(v:val, r_arg)')
   " Apply fnameescape() to each item
   call map(lst, 'fnameescape(v:val)')
-  " Convert back to newline-separated list
-  let globlinks = join(lst, "\n")
-  " return all escaped links as a single newline-separated string
-  return globlinks
+  " Return list (for customlist completion)
+  return lst
 endfunction
 
 
@@ -2279,9 +2282,7 @@ endfunction
 
 
 function! vimwiki#base#complete_links_escaped(ArgLead, CmdLine, CursorPos) abort
-  " We can safely ignore args if we use -custom=complete option, Vim engine
-  " will do the job of filtering.
-  return vimwiki#base#get_globlinks_escaped()
+  return vimwiki#base#get_globlinks_escaped(a:ArgLead)
 endfunction
 
 

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -261,7 +261,7 @@ command! -buffer -nargs=0 VWB call vimwiki#base#backlinks()
 command! -buffer -nargs=* VimwikiSearch call vimwiki#base#search(<q-args>)
 command! -buffer -nargs=* VWS call vimwiki#base#search(<q-args>)
 
-command! -buffer -nargs=* -complete=custom,vimwiki#base#complete_links_escaped
+command! -buffer -nargs=* -complete=customlist,vimwiki#base#complete_links_escaped
       \ VimwikiGoto call vimwiki#base#goto(<f-args>)
 
 command! -buffer VimwikiCheckLinks call vimwiki#base#check_links()

--- a/test/command_goto.vader
+++ b/test/command_goto.vader
@@ -17,13 +17,48 @@ Do (VimwikiGoto <CR> buzz_bozz && Assert):
   buzz_bozz\<CR>
   :AssertEqual $HOME . '/testmarkdown/buzz_bozz.md', expand('%')\<CR>
 
-
 Execute (:VimwikiGoto + Completion):
   VimwikiIndex 2
   AssertEqual $HOME . '/testmarkdown/index.md', expand('%')
-  let s_complete=vimwiki#base#get_globlinks_escaped()
+  let s_complete=string(vimwiki#base#get_globlinks_escaped())
   Assert -1 != stridx(s_complete, 'buzz_bozz')
 
+Execute (Create dir1/dir2/test_goto_file.md):
+  call system("mkdir $HOME/testmarkdown/dir1")
+  call system("mkdir $HOME/testmarkdown/dir1/dir2")
+  edit $HOME/testmarkdown/dir1/dir2/test_goto_file.md
+  call WriteMe()
+
+Execute (:VimwikiGoto + Completion in directory):
+  " Return to base
+  VimwikiIndex 2
+  AssertEqual $HOME . '/testmarkdown/index.md', expand('%')
+  
+  " Complete without argment
+  let s_complete1=string(vimwiki#base#get_globlinks_escaped())
+  Assert -1 != stridx(s_complete1, 'test_goto_file')
+  
+  " Complete with file argument
+  let s_complete2=string(vimwiki#base#get_globlinks_escaped('test_goto_file'))
+  Assert -1 != stridx(s_complete2, 'test_goto_file')
+  
+  " Complete with start of file argument
+  let s_complete3=string(vimwiki#base#get_globlinks_escaped('test_got'))
+  Assert -1 != stridx(s_complete3, 'test_goto_file')
+  
+  " Complete with (nested) dir2 argument
+  let s_complete4=string(vimwiki#base#get_globlinks_escaped('dir2'))
+  Assert -1 != stridx(s_complete4, 'test_goto_file')
+
+  " Complete with bad argument
+  let l_complete5=vimwiki#base#get_globlinks_escaped('this_string_is_nowhere')
+  let s_complete5=string(l_complete5)
+  Assert -1 == stridx(s_complete5, 'test_goto_file')
+  AssertEqual 0, len(l_complete5)
+
+Execute (Clean):
+  Log "End: Clean"
+  call system("rm $HOME/testmarkdown/dir1")
 
 Include: vader_includes/vader_teardown.vader
 # vim: sw=2 ft=conf foldmethod=indent foldlevel=30 foldignore=


### PR DESCRIPTION
Feature: To enable VimwikiGoto command completion to work also:

1. With part of the filename
2. For files in directories

Note: This PR is above PR  #767 -> because I need the vader test framework
