### PR TITLE
Keep VimwikiBacklinks compatibility with wikilink in markdown wiki

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -690,10 +690,12 @@ function! s:get_links(wikifile, idx) abort
   let syntax = vimwiki#vars#get_wikilocal('syntax', a:idx)
   if syntax ==# 'markdown'
     let rx_link = vimwiki#vars#get_syntaxlocal('rxWeblink1MatchUrl', syntax)
+    let rx_link2 = vimwiki#vars#get_syntaxlocal('wikilink', syntax)
   else
     let rx_link = vimwiki#vars#get_syntaxlocal('wikilink', syntax)
+    let rx_link2 = 0
   endif
-
+  
   let links = []
   let lnum = 0
 
@@ -705,7 +707,11 @@ function! s:get_links(wikifile, idx) abort
       let col = match(line, rx_link, 0, link_count)+1
       let link_text = matchstr(line, rx_link, 0, link_count)
       if link_text ==? ''
-        break
+        let col = match(line, rx_link2, 0, link_count)+1
+        let link_text = matchstr(line, rx_link2, 0, link_count)
+        if link_text ==? ''
+          break
+        endif
       endif
       let link_count += 1
       let target = vimwiki#base#resolve_link(link_text, a:wikifile)

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -707,6 +707,9 @@ function! s:get_links(wikifile, idx) abort
       let col = match(line, rx_link, 0, link_count)+1
       let link_text = matchstr(line, rx_link, 0, link_count)
       if link_text ==? ''
+        if rx_link2 ==? ''
+          break
+        endif
         let col = match(line, rx_link2, 0, link_count)+1
         let link_text = matchstr(line, rx_link2, 0, link_count)
         if link_text ==? ''


### PR DESCRIPTION
Since #529 the command `VimwikiBacklinks` do not recognize wiki links `[[...]]` in Markdown wikis.

This is an initial implementation that preserves both behaviours by checking it using both markdown and vim wiki styles:

vimwiki (wikilink)
```
\[\[\zs[^\\\]|]\+\ze\%(|[^\\\]]\+\)\?\]\]
```

markdown (rxWeblink1MatchUrl)
```
\[[^\\\]]\{-}\](\zs[^[:cntrl:]]\{-}\ze\(\\\)\@<!\()\)
```

A better approach may be to change the regex `rxWeblink1MatchUrl`, but this regex is a bit confusing to me. If you have a better approach, feel free to close this and open a new PR, or point me some directions so I can improve this implementation.