### PR TITLE
fix base#find_files so that it works for filenames with whitespaces

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -498,11 +498,11 @@ function! vimwiki#base#find_files(wiki_nr, directories_only) abort
   else
     let pattern = '**/*'.ext
   endif
-  let files = split(globpath(root_directory, pattern))
+  let files = split(globpath(root_directory, pattern), '\n')
 
   " filter excluded files before returning
   for pattern in vimwiki#vars#get_wikilocal('exclude_files')
-    let efiles = split(globpath(root_directory, pattern))
+    let efiles = split(globpath(root_directory, pattern), '\n')
     let files = filter(files, 'index(efiles, v:val) == -1')
   endfor
 

--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1435,7 +1435,7 @@ function! s:use_custom_wiki2html() abort
 endfunction
 
 
-function! vimwiki#html#CustomWiki2HTML(path, wikifile, force) abort
+function! vimwiki#html#CustomWiki2HTML(path, wikifile, force, main_path) abort
   call vimwiki#path#mkdir(a:path)
   let output = system(vimwiki#vars#get_wikilocal('custom_wiki2html'). ' '.
       \ a:force. ' '.
@@ -1443,7 +1443,7 @@ function! vimwiki#html#CustomWiki2HTML(path, wikifile, force) abort
       \ strpart(vimwiki#vars#get_wikilocal('ext'), 1). ' '.
       \ shellescape(a:path). ' '.
       \ shellescape(a:wikifile). ' '.
-      \ shellescape(s:default_CSS_full_name(a:path)). ' '.
+      \ shellescape(s:default_CSS_full_name(a:main_path)). ' '.
       \ (len(vimwiki#vars#get_wikilocal('template_path')) > 1 ?
       \     shellescape(expand(vimwiki#vars#get_wikilocal('template_path'))) : '-'). ' '.
       \ (len(vimwiki#vars#get_wikilocal('template_default')) > 0 ?
@@ -1465,7 +1465,7 @@ function! s:convert_file(path_html, wikifile) abort
   let done = 0
 
   let wikifile = fnamemodify(a:wikifile, ':p')
-
+  let main_path_html = expand(a:path_html)
   let path_html = expand(a:path_html).vimwiki#vars#get_bufferlocal('subdir')
   let htmlfile = fnamemodify(wikifile, ':t:r').'.html'
 
@@ -1476,7 +1476,7 @@ function! s:convert_file(path_html, wikifile) abort
 
   if s:use_custom_wiki2html()
     let force = 1
-    call vimwiki#html#CustomWiki2HTML(path_html, wikifile, force)
+    call vimwiki#html#CustomWiki2HTML(path_html, wikifile, force, main_path_html)
     let done = 1
   endif
 


### PR DESCRIPTION
Steps for submitting a pull request:

- [ ] **ALL** pull requests should be made against the `dev` branch!
- [ ] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
#237
- [ ] Provide a description of the proposed changes.
  - Fix base#find_files so that it honors whitespaces in file names. The problematic code could only be found on the `dev` branch. The fix for #237 on `dev` does not work if a whitespace is in the filename. As long as this feature is not on `master`, this PR makes it work on the `dev` branch. 
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
