### PR TITLE
fix base#find_files so that it works for filenames with whitespaces

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -498,11 +498,11 @@ function! vimwiki#base#find_files(wiki_nr, directories_only) abort
   else
     let pattern = '**/*'.ext
   endif
-  let files = split(globpath(root_directory, pattern))
+  let files = split(globpath(root_directory, pattern), '\n')
 
   " filter excluded files before returning
   for pattern in vimwiki#vars#get_wikilocal('exclude_files')
-    let efiles = split(globpath(root_directory, pattern))
+    let efiles = split(globpath(root_directory, pattern), '\n')
     let files = filter(files, 'index(efiles, v:val) == -1')
   endfor
 


### PR DESCRIPTION
Steps for submitting a pull request:

Clone of #824, other commits accidentally found their way into the old one.

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
#237
- [x] Provide a description of the proposed changes.
  - Fix base#find_files so that it honors whitespaces in file names. The problematic code could only be found on the `dev` branch. The fix for #237 on `dev` does not work if a whitespace is in the filename. As long as this feature is not on `master`, this PR makes it work on the `dev` branch. 
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
--> probably not acclipable

