### PR TITLE
Allow hyphens instead of spaces and search case-insensitive in jump_to_anchor function

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -659,6 +659,10 @@ function! s:jump_to_anchor(anchor) abort
 
   for segment in segments
 
+    " prepare segment pattern so that it is case insensitive and also matches dashes
+    " in anchor link with spaces in heading
+    let segment = substitute(substitute(segment, '\<\(.\)', '\\c\1', 'g'), '-', '[ -]', 'g')
+
     let anchor_header = s:safesubstitute(
           \ vimwiki#vars#get_syntaxlocal('header_match'),
           \ '__Header__', segment, '')

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -659,9 +659,12 @@ function! s:jump_to_anchor(anchor) abort
 
   for segment in segments
 
-    " prepare segment pattern so that it is case insensitive and also matches dashes
+    " Craft segment pattern so that it is case insensitive and also matches dashes
     " in anchor link with spaces in heading
-    let segment = substitute(substitute(segment, '\<\(.\)', '\\c\1', 'g'), '-', '[ -]', 'g')
+    " Ignore case
+    let segment = substitute(segment, '\<\(.\)', '\\c\1', 'g')
+    " Treat - as [- or space]
+    let segment = substitute(segment , '-', '[ -]', 'g')
 
     let anchor_header = s:safesubstitute(
           \ vimwiki#vars#get_syntaxlocal('header_match'),


### PR DESCRIPTION
Steps for submitting a pull request:
**Disclaimer: Log is kind of messed up because I maintain my own fork and needed to pull the latest version in to my repo** 
 
- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

This PR allows GFM style links to be used (Issue #831). `jump_to_anchor` has been altered so that search for anchors is now case-insensitive and dashes may be included instead of whitespaces.

Code works as follows: before the anchor is transformed into the regex patterns, a `\c` is prepended before the first character of each word and spaces are replaced by `[ -]`. This way the search function also matches GFM style links.

I'm not a vimscript expert, so I don't know if this solution is the prettiest, but it is a one liner. Feel free to improve if I missed something or if it's too hacky.
