### PR TITLE
Make default template responsive

### DIFF
--- a/autoload/vimwiki/default.tpl
+++ b/autoload/vimwiki/default.tpl
@@ -4,6 +4,7 @@
 <link rel="Stylesheet" type="text/css" href="%root_path%%css%">
 <title>%title%</title>
 <meta http-equiv="Content-Type" content="text/html; charset=%encoding%">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 %content%

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3486,6 +3486,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Abhinav Gupta (@abhinav)
     - Dave Gauer (@ratfactor)
     - Martin Tourneboeuf (@tinmarino)
+    - Mauro Morales (@mauromorales)
 
 
 ==============================================================================
@@ -3568,6 +3569,7 @@ New:~
     * PR #377: Add horizontal alignment to tables.
     * PR #202: Don't override or display errors for existing keymappings.
     * PR #47: Optimize table formatting for large tables.
+    * PR #857: Make default template responsive
 
 Removed:~
     * PR #698: Remove awa check triggering silent file edits.


### PR DESCRIPTION
Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [X] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

I really like the HTML template that comes by default in Vimwiki, I think i'd benefit from making the template responsive for viewing on a mobile phone and this is what this PR introduces. I'm well aware that I provide my own templates to do this change for my personal vimwiki but I consider it's valuable to provide by default.