### PR TITLE
Bug fix for %plainhtml feature

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1218,16 +1218,14 @@ function! s:parse_line(line, state) abort
   let state.header_ids = a:state.header_ids
 
   let res_lines = []
-
-  let line = s:safe_html_line(a:line)
-
   let processed = 0
+  let line = a:line
 
   if !processed
     " allows insertion of plain text to the final html conversion
     " for example:
     " %plainhtml <div class="mycustomdiv">
-    " inserts that line to the final html file (without %plainhtml prefix)
+    " inserts the line above to the final html file (without %plainhtml prefix)
     let trigger = '%plainhtml'
     if line =~# '^\s*' . trigger
       let lines = []
@@ -1258,6 +1256,8 @@ function! s:parse_line(line, state) abort
       call extend(res_lines, lines)
     endif
   endif
+
+  let line = s:safe_html_line(a:line)
 
   " pres
   if !processed


### PR DESCRIPTION
Hello,

This pull request fixes a bug in another pull request that I submitted a while ago (https://github.com/vimwiki/vimwiki/pull/778)

The issue was that `s:safe_html_line(a:line)` was called before testing for plain html lines, which caused plain html lines to be converted incorrectly.

Without this fix, a line like this:
`%plainhtml <p> example </p> `

will be converted to this:
`&lt;p&gt; example &lt;/p&gt;` *wrong!*

With this fix, the line will be converted to this:
`<p> example </p>` *correct!*

Thanks for accepting the previous PR and providing the Vader tests! I had this fixed for a while now, but as my first PR went quiet, I did not update it.  I'll try to study the Vader files and provide better testing for future PRs. From what I understand, the current Vader tests are passing, but it keeps throwing this red error during the tests: `Vader error: Vim(if):E684: list index out of range: 0 (in function <SNR>21_setup_buffer_win_enter[7]..vimwiki#u#ft_is_vw, line 1)`

I also tried to squash the merged upstream changes with this fix but it did not end up well on my part, maybe I did something wrong. Let me know if there is an issue.