### PR TITLE
Update MathJax local loading instructions

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1398,7 +1398,7 @@ have two alternative options:
 Choose a folder on your hard drive and save MathJax in it. Then add to your
 HTML template the following line:
 
-<script type="text/javascript" src="<mathjax_folder>/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="<mathjax_folder>/es5/tex-chtml.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
 where <mathjax_folder> is the folder on your HD, as a relative path to the
 template folder. For instance, a sensible folder structure could be:


### PR DESCRIPTION
The MathJax.js file doesn't exist anymore in the MathJax repository andthe script that should be loaded is tex-chtml.js. This update the helpfile to reflect this change.

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues. (_I didn't see any_)
- [X] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

I didn't run the tests because it was a trivial test in documentation.
I'm not sure whether I should update the Changelog or not for the same reason.

Also, as it is explained [here](https://github.com/mathjax/MathJax#hosting-your-own-copy-of-the-mathjax-components), the people from MathJax advice the user to directly link with the `es5/` directory, so I am not sure what the Vimwiki doc should advice.

Thank you for reading and thank for your great work on Vimwiki.
