### PR TITLE
Preciser description for VimwikiGenerateLinks

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -890,7 +890,7 @@ Vimwiki file.
 
 
 *:VimwikiGenerateLinks* [pattern]
-    Insert the links of all available wiki files into the current buffer.
+    Insert a list of links to all available wiki files into the current buffer.
     If an optional 'pattern' is given as argument, the files will be searched
     in the wiki root folder according to the 'pattern' as |globpath|
 


### PR DESCRIPTION
Preciser and easier understandable description for VimwikiGenerateLinks.

Stumbled over this when reviewing f4c983b.