### PR TITLE
Rename three commands, deprecate their old names

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -2379,6 +2379,11 @@ function! vimwiki#base#search(search_pattern) abort
   endtry
 endfunction
 
+function! vimwiki#base#deprecate(old, new) abort
+  echohl WarningMsg
+  echo a:old 'is deprecated and will be removed in future versions, use' a:new 'instead.'
+  echohl None
+endfunction
 
 " -------------------------------------------------------------------------
 " Load syntax-specific Wiki functionality

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -387,13 +387,13 @@ MAP                MODE
 
                                                           *vimwiki_<Leader>wd*
 <Leader>wd         n    Delete wiki page you are in.
-                        Maps to |:VimwikiDeleteLink|.
-                        Remap command: `<Plug>VimwikiDeleteLink`
+                        Maps to |:VimwikiDeleteFile|.
+                        Remap command: `<Plug>VimwikiDeleteFile`
 
                                                           *vimwiki_<Leader>wr*
 <Leader>wr         n    Rename wiki page you are in.
-                        Maps to |:VimwikiRenameLink|.
-                        Remap command: `<Plug>VimwikiRenameLink`
+                        Maps to |:VimwikiRenameFile|.
+                        Remap command: `<Plug>VimwikiRenameFile`
 
                                                                    *vimwiki_=*
 =                  n    Add header level. Create if needed.
@@ -793,10 +793,10 @@ Vimwiki file.
     Supports |cmdline-completion| for link name. If name is not specified, a
     prompt will be shown.
 
-*:VimwikiDeleteLink*
+*:VimwikiDeleteFile*
     Delete the wiki page you are in.
 
-*:VimwikiRenameLink*
+*:VimwikiRenameFile*
     Rename the wiki page you are in.
 
 *:VimwikiNextTask*
@@ -3506,7 +3506,7 @@ https://github.com/vimwiki-backup/vimwiki/issues.
 2.5 (in progress)~
 
 New:~
-    * PR #787: |:VimwikiRenameLink| works for all directories: even
+    * PR #787: |:VimwikiRenameFile| works for all directories: even
       wiki_root/diary/2019-12-11.md if current file is wiki_root/dir1/file.md.
     * Issue #764: fenced code blocks are properly supported for markdown
       syntax i.e. more than 3 backticks, adds tilde support.
@@ -3576,6 +3576,11 @@ New:~
     * PR #857: Make default template responsive
     * PR #879: Generate links when diary & wiki dir are the same
 
+Changed:~
+    * Issue #796: Rename |:VimwikiGenerateTags| to |:VimwikiGenerateTagLinks|
+    * Issue #638: Rename |:VimwikiDeleteLink| to |:VimwikiDeleteFile|
+    * Issue #638: Rename |:VimwikiRenameLink| to |:VimwikiRenameFile|
+
 Removed:~
     * PR #698: Remove awa check triggering silent file edits.
     * Options g:vimwiki_use_mouse and g:vimwiki_table_mappings. These are
@@ -3585,7 +3590,6 @@ Removed:~
 
 Fixed:~
     * Issue #90: VimwikiRenameLink doesn't update links in diary.
-    * Issue #796: Rename |:VimwikiGenerateTags| to |:VimwikiGenerateTagLinks|
     * Issue #790: Allow tags before a header with markdown syntax.
     * Issue #779: Vimwiki tags file meets ctags standard.
     * Issue #781: Compatablity fixes for older versions of Vim.

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -242,8 +242,14 @@ command! -buffer VimwikiTOC call vimwiki#base#table_of_contents(1)
 command! -buffer VimwikiNextTask call vimwiki#base#find_next_task()
 command! -buffer VimwikiNextLink call vimwiki#base#find_next_link()
 command! -buffer VimwikiPrevLink call vimwiki#base#find_prev_link()
-command! -buffer VimwikiDeleteLink call vimwiki#base#delete_link()
-command! -buffer VimwikiRenameLink call vimwiki#base#rename_link()
+command! -buffer VimwikiDeleteFile call vimwiki#base#delete_link()
+command! -buffer VimwikiDeleteLink
+      \ call vimwiki#base#deprecate("VimwikiDeleteLink", "VimwikiDeleteFile") |
+      \ call vimwiki#base#delete_link()
+command! -buffer VimwikiRenameFile call vimwiki#base#rename_link()
+command! -buffer VimwikiRenameLink
+      \ call vimwiki#base#deprecate("VimwikiRenameLink", "VimwikiRenameFile") |
+      \ call vimwiki#base#rename_link()
 command! -buffer VimwikiFollowLink call vimwiki#base#follow_link('nosplit', 0, 1)
 command! -buffer VimwikiGoBackLink call vimwiki#base#go_back_link()
 command! -buffer -nargs=* VimwikiSplitLink call vimwiki#base#follow_link('hsplit', <f-args>)
@@ -304,6 +310,10 @@ command! -buffer -nargs=* -complete=custom,vimwiki#tags#complete_tags
       \ VimwikiSearchTags VimwikiSearch /:<args>:/
 command! -buffer -nargs=* -complete=custom,vimwiki#tags#complete_tags
       \ VimwikiGenerateTagLinks call vimwiki#tags#generate_tags(1, <f-args>)
+command! -buffer -nargs=* -complete=custom,vimwiki#tags#complete_tags
+      \ VimwikiGenerateTags
+      \ call vimwiki#base#deprecate("VimwikiGenerateTags", "VimwikiGenerateTagLinks") |
+      \ call vimwiki#tags#generate_tags(1, <f-args>)
 
 command! -buffer VimwikiPasteUrl call vimwiki#html#PasteUrl(expand('%:p'))
 command! -buffer VimwikiCatUrl call vimwiki#html#CatUrl(expand('%:p'))
@@ -357,10 +367,10 @@ nnoremap <silent><script><buffer> <Plug>VimwikiPrevLink
     \ :VimwikiPrevLink<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiGoto
     \ :VimwikiGoto<CR>
-nnoremap <silent><script><buffer> <Plug>VimwikiDeleteLink
-    \ :VimwikiDeleteLink<CR>
-nnoremap <silent><script><buffer> <Plug>VimwikiRenameLink
-    \ :VimwikiRenameLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiDeleteFile
+    \ :VimwikiDeleteFile<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiRenameFile
+    \ :VimwikiRenameFile<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiDiaryNextDay
     \ :VimwikiDiaryNextDay<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiDiaryPrevDay
@@ -380,8 +390,8 @@ if str2nr(vimwiki#vars#get_global('key_mappings').links)
   call vimwiki#u#map_key('n', '<TAB>', '<Plug>VimwikiNextLink')
   call vimwiki#u#map_key('n', '<S-TAB>', '<Plug>VimwikiPrevLink')
   call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'n', '<Plug>VimwikiGoto')
-  call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'d', '<Plug>VimwikiDeleteLink')
-  call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'r', '<Plug>VimwikiRenameLink')
+  call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'d', '<Plug>VimwikiDeleteFile')
+  call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'r', '<Plug>VimwikiRenameFile')
   call vimwiki#u#map_key('n', '<C-Down>', '<Plug>VimwikiDiaryNextDay')
   call vimwiki#u#map_key('n', '<C-Up>', '<Plug>VimwikiDiaryPrevDay')
 endif

--- a/test/command_rename_link.vader
+++ b/test/command_rename_link.vader
@@ -93,7 +93,7 @@ Do (RenameLink in_dir11 -> new_dir11):
 
   :Log 'Rename'\<CR>
   :call WriteMe()\<CR>
-  :VimwikiRenameLink\<CR>
+  :VimwikiRenameFile\<CR>
   y\<CR>
   in_dir11_new\<CR>
   :call WriteMe()\<Cr>
@@ -138,7 +138,7 @@ Do (in_dir2 -> in_dir2_new):
 
   :Log 'Rename'\<CR>
   :call WriteMe()\<CR>
-  :VimwikiRenameLink\<CR>
+  :VimwikiRenameFile\<CR>
   y\<CR>
   in_dir2_new\<CR>
   :call WriteMe()\<Cr>


### PR DESCRIPTION
As per #638:

The following commands have been renamed to better describe their
function and avoid confusion.
:VimwikiDeleteLink → :VimwikiDeletePage
:VimwikiRenameLink → :VimwikiRenamePage
:VimwikiGenerateTags → :VimwikiGenerateTagLinks (was already renamed in 3b5537f)

Calling the old commands still works but displays a warning message.