### PR TITLE
Bugfix: file extension for markdown is syntax wide

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1023,8 +1023,8 @@ function! s:update_wiki_links(wiki_nr, dir, old_url, new_url) abort
     let old_url_r = '\%(\.[/\\]\)\?' . old_url_r
     " Compute old url regex with filename between \zs and \ze
     let old_url_r = vimwiki#base#apply_template(
-          \ vimwiki#vars#get_syntaxlocal('WikiLinkMatchUrlTemplate',
-             \ vimwiki#vars#get_wikilocal('syntax', a:wiki_nr)), old_url_r, '', '')
+          \ vimwiki#vars#get_syntaxlocal('WikiLinkMatchUrlTemplate', vimwiki#vars#get_wikilocal('syntax', a:wiki_nr))
+            \, old_url_r, '', '', vimwiki#vars#get_wikilocal('ext', a:wiki_nr))
 
     return old_url_r
   endfunction
@@ -2110,10 +2110,11 @@ endfunction
 
 "   Construct a regular expression matching from template (with special
 "   characters properly escaped), by substituting rxUrl for __LinkUrl__, rxDesc
-"   for __LinkDescription__, and rxStyle for __LinkStyle__.  The three
-"   arguments rxUrl, rxDesc, and rxStyle are copied verbatim, without any
-"   special character escapes or substitutions.
-function! vimwiki#base#apply_template(template, rxUrl, rxDesc, rxStyle) abort
+"   for __LinkDescription__, rxStyle for __LinkStyle__ and rxExtension for
+"   __FileExtention__.  The four arguments rxUrl, rxDesc, rxStyle and
+"   rxExtension are copied verbatim, without any special character escapes or
+"   substitutions.
+function! vimwiki#base#apply_template(template, rxUrl, rxDesc, rxStyle, rxExtension) abort
   let lnk = a:template
   if a:rxUrl !=? ''
     let lnk = s:safesubstitute(lnk, '__LinkUrl__', a:rxUrl, 'g')
@@ -2123,6 +2124,9 @@ function! vimwiki#base#apply_template(template, rxUrl, rxDesc, rxStyle) abort
   endif
   if a:rxStyle !=? ''
     let lnk = s:safesubstitute(lnk, '__LinkStyle__', a:rxStyle, 'g')
+  endif
+  if a:rxExtension !=? ''
+    let lnk = s:safesubstitute(lnk, '__FileExtention__', a:rxExtension, 'g')
   endif
   return lnk
 endfunction

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -787,20 +787,20 @@ function! s:populate_extra_markdown_vars() abort
   let mkd_syntax.rxWeblink1Suffix = ')'
   let mkd_syntax.rxWeblink1EscapeCharsSuffix = '\(\\\)\@<!\()\)'
   let mkd_syntax.rxWeblink1Separator = ']('
-  let mkd_syntax.rxWeblink1Ext = ''
+  let rxWeblink1Ext = ''
   if vimwiki#vars#get_global('markdown_link_ext')
-    let mkd_syntax.rxWeblink1Ext = vimwiki#vars#get_wikilocal('ext')
+    let rxWeblink1Ext = '__FileExtention__'
   endif
   " [DESCRIPTION](URL)
   let mkd_syntax.Weblink1Template = mkd_syntax.rxWeblink1Prefix . '__LinkDescription__'.
-        \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'. mkd_syntax.rxWeblink1Ext.
+        \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'. rxWeblink1Ext.
         \ mkd_syntax.rxWeblink1Suffix
   " [DESCRIPTION](ANCHOR)
   let mkd_syntax.Weblink2Template = mkd_syntax.rxWeblink1Prefix . '__LinkDescription__'.
         \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'. mkd_syntax.rxWeblink1Suffix
   " [DESCRIPTION](FILE#ANCHOR)
   let mkd_syntax.Weblink3Template = mkd_syntax.rxWeblink1Prefix . '__LinkDescription__'.
-        \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'. mkd_syntax.rxWeblink1Ext.
+        \ mkd_syntax.rxWeblink1Separator. '__LinkUrl__'. rxWeblink1Ext.
         \ '#__LinkAnchor__'. mkd_syntax.rxWeblink1Suffix
 
   let valid_chars = '[^\\\]]'
@@ -815,18 +815,18 @@ function! s:populate_extra_markdown_vars() abort
         \ mkd_syntax.rx_wikilink_md_prefix .
         \ '.*' .
         \ rx_wikilink_md_separator .
-        \ '\zs__LinkUrl__\ze\%(#.*\)\?\%('.vimwiki#vars#get_wikilocal('ext').'\)\?'.
+        \ '\zs__LinkUrl__\ze\%(#.*\)\?\%(__FileExtention__\)\?'.
         \ mkd_syntax.rx_wikilink_md_suffix .
         \ '\|' .
         \ mkd_syntax.rx_wikilink_md_prefix .
-        \ '\zs__LinkUrl__\ze\%(#.*\)\?\%('.vimwiki#vars#get_wikilocal('ext').'\)\?'.
+        \ '\zs__LinkUrl__\ze\%(#.*\)\?\%(__FileExtention__\)\?'.
         \ rx_wikilink_md_separator .
         \ mkd_syntax.rx_wikilink_md_suffix .
         \ '\|' .
         \ mkd_syntax.rxWeblink1Prefix.
         \ '.*' .
         \ mkd_syntax.rxWeblink1Separator.
-        \ '\zs__LinkUrl__\ze\%(#.*\)\?\%('.vimwiki#vars#get_wikilocal('ext').'\)\?'.
+        \ '\zs__LinkUrl__\ze\%(#.*\)\?\%(__FileExtention__\)\?'.
         \ mkd_syntax.rxWeblink1EscapeCharsSuffix
 
   " 1. [DESCRIPTION](URL)

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -51,33 +51,33 @@ function! s:highlight_existing_links() abort
   " match [[URL]]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_global('WikiLinkTemplate1')),
-        \ safe_links, vimwiki#vars#get_global('rxWikiLinkDescr'), '')
+        \ safe_links, vimwiki#vars#get_global('rxWikiLinkDescr'), '', '')
   call s:add_target_syntax_ON(target, 'VimwikiLink')
   " match [[URL|DESCRIPTION]]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_global('WikiLinkTemplate2')),
-        \ safe_links, vimwiki#vars#get_global('rxWikiLinkDescr'), '')
+        \ safe_links, vimwiki#vars#get_global('rxWikiLinkDescr'), '', '')
   call s:add_target_syntax_ON(target, 'VimwikiLink')
 
   " match {{URL}}
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_global('WikiInclTemplate1')),
-        \ safe_links, vimwiki#vars#get_global('rxWikiInclArgs'), '')
+        \ safe_links, vimwiki#vars#get_global('rxWikiInclArgs'), '', '')
   call s:add_target_syntax_ON(target, 'VimwikiLink')
   " match {{URL|...}}
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_global('WikiInclTemplate2')),
-        \ safe_links, vimwiki#vars#get_global('rxWikiInclArgs'), '')
+        \ safe_links, vimwiki#vars#get_global('rxWikiInclArgs'), '', '')
   call s:add_target_syntax_ON(target, 'VimwikiLink')
   " match [[DIRURL]]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_global('WikiLinkTemplate1')),
-        \ safe_dirs, vimwiki#vars#get_global('rxWikiLinkDescr'), '')
+        \ safe_dirs, vimwiki#vars#get_global('rxWikiLinkDescr'), '', '')
   call s:add_target_syntax_ON(target, 'VimwikiLink')
   " match [[DIRURL|DESCRIPTION]]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_global('WikiLinkTemplate2')),
-        \ safe_dirs, vimwiki#vars#get_global('rxWikiLinkDescr'), '')
+        \ safe_dirs, vimwiki#vars#get_global('rxWikiLinkDescr'), '', '')
   call s:add_target_syntax_ON(target, 'VimwikiLink')
 endfunction
 
@@ -114,26 +114,26 @@ let s:rxSchemes = '\%('.
 let s:target = vimwiki#base#apply_template(
       \ vimwiki#u#escape(vimwiki#vars#get_global('WikiLinkTemplate1')),
       \ s:rxSchemes.vimwiki#vars#get_global('rxWikiLinkUrl'),
-      \ vimwiki#vars#get_global('rxWikiLinkDescr'), '')
+      \ vimwiki#vars#get_global('rxWikiLinkDescr'), '', '')
 call s:add_target_syntax_ON(s:target, 'VimwikiLink')
 " b) match [[nonwiki-scheme-URL|DESCRIPTION]]
 let s:target = vimwiki#base#apply_template(
       \ vimwiki#u#escape(vimwiki#vars#get_global('WikiLinkTemplate2')),
       \ s:rxSchemes.vimwiki#vars#get_global('rxWikiLinkUrl'),
-      \ vimwiki#vars#get_global('rxWikiLinkDescr'), '')
+      \ vimwiki#vars#get_global('rxWikiLinkDescr'), '', '')
 call s:add_target_syntax_ON(s:target, 'VimwikiLink')
 
 " a) match {{nonwiki-scheme-URL}}
 let s:target = vimwiki#base#apply_template(
       \ vimwiki#u#escape(vimwiki#vars#get_global('WikiInclTemplate1')),
       \ s:rxSchemes.vimwiki#vars#get_global('rxWikiInclUrl'),
-      \ vimwiki#vars#get_global('rxWikiInclArgs'), '')
+      \ vimwiki#vars#get_global('rxWikiInclArgs'), '', '')
 call s:add_target_syntax_ON(s:target, 'VimwikiLink')
 " b) match {{nonwiki-scheme-URL}[{...}]}
 let s:target = vimwiki#base#apply_template(
       \ vimwiki#u#escape(vimwiki#vars#get_global('WikiInclTemplate2')),
       \ s:rxSchemes.vimwiki#vars#get_global('rxWikiInclUrl'),
-      \ vimwiki#vars#get_global('rxWikiInclArgs'), '')
+      \ vimwiki#vars#get_global('rxWikiInclArgs'), '', '')
 call s:add_target_syntax_ON(s:target, 'VimwikiLink')
 
 

--- a/syntax/vimwiki_markdown_custom.vim
+++ b/syntax/vimwiki_markdown_custom.vim
@@ -52,34 +52,34 @@ function! s:highlight_existing_links() abort
   " match [URL][]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_syntaxlocal('WikiLink1Template1')),
-        \ safe_links, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '')
+        \ safe_links, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '', '')
   call s:add_target_syntax_ON(s:wrap_wikilink1_rx(target), 'VimwikiWikiLink1')
   " match [DESCRIPTION][URL]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_syntaxlocal('WikiLink1Template2')),
-        \ safe_links, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '')
+        \ safe_links, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '', '')
   call s:add_target_syntax_ON(s:wrap_wikilink1_rx(target), 'VimwikiWikiLink1')
 
   " match [DIRURL][]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_syntaxlocal('WikiLink1Template1')),
-        \ safe_dirs, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '')
+        \ safe_dirs, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '', '')
   call s:add_target_syntax_ON(s:wrap_wikilink1_rx(target), 'VimwikiWikiLink1')
   " match [DESCRIPTION][DIRURL]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_syntaxlocal('WikiLink1Template2')),
-        \ safe_dirs, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '')
+        \ safe_dirs, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '', '')
   call s:add_target_syntax_ON(s:wrap_wikilink1_rx(target), 'VimwikiWikiLink1')
 
   " match [MKDREF][]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_syntaxlocal('WikiLink1Template1')),
-        \ safe_reflinks, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '')
+        \ safe_reflinks, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '', '')
   call s:add_target_syntax_ON(s:wrap_wikilink1_rx(target), 'VimwikiWikiLink1')
   " match [DESCRIPTION][MKDREF]
   let target = vimwiki#base#apply_template(
         \ vimwiki#u#escape(vimwiki#vars#get_syntaxlocal('WikiLink1Template2')),
-        \ safe_reflinks, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '')
+        \ safe_reflinks, vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '', '')
   call s:add_target_syntax_ON(s:wrap_wikilink1_rx(target), 'VimwikiWikiLink1')
 endfunction
 
@@ -113,13 +113,13 @@ let s:rxSchemes = '\%('.
 let s:target = vimwiki#base#apply_template(
       \ vimwiki#u#escape(vimwiki#vars#get_syntaxlocal('WikiLink1Template1')),
       \ s:rxSchemes . vimwiki#vars#get_syntaxlocal('rxWikiLink1Url'),
-      \ vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '')
+      \ vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '', '')
 call s:add_target_syntax_ON(s:wrap_wikilink1_rx(s:target), 'VimwikiWikiLink1')
 " b) match [DESCRIPTION][nonwiki-scheme-URL]
 let s:target = vimwiki#base#apply_template(
       \ vimwiki#u#escape(vimwiki#vars#get_syntaxlocal('WikiLink1Template2')),
       \ s:rxSchemes . vimwiki#vars#get_syntaxlocal('rxWikiLink1Url'),
-      \ vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '')
+      \ vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '', '')
 call s:add_target_syntax_ON(s:wrap_wikilink1_rx(s:target), 'VimwikiWikiLink1')
 
 


### PR DESCRIPTION
`populate_extra_markdown_vars()` contained uses of the file-extension via
`vimwiki#vars#get_wikilocal`. Since the first is syntax-wide and the second is
wikilocal and no wiki is specified or open at the moment of the call, the file
extension of the first markdown wiki will be used for all markdown wikis.

This PR fixes this via use of the existing template infrastructure.

This bug becomes critical when merging #889 or fixing #894.