### PR TITLE
Fix conceallevel setted globally instead of locally

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3521,7 +3521,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Samir Benmendil (@Ram-Z)
     - Stefan Lehmann (@stevesteve)
     - @graywolf
-    - flex (@bratekarate)*
+    - flex (@bratekarate)
     - Marius Lopez (@PtitCaius)
 
 ==============================================================================

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3521,7 +3521,8 @@ Contributors and their Github usernames in roughly chronological order:
     - Samir Benmendil (@Ram-Z)
     - Stefan Lehmann (@stevesteve)
     - @graywolf
-    - flex (@bratekarate)
+    - flex (@bratekarate)*
+    - Marius Lopez (@PtitCaius)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3532,6 +3533,8 @@ https://github.com/vimwiki/vimwiki/issues/, all others from
 http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
+New:~
+    * PR #900: conceallevel is now setted locally for vimwiki buffers
 
 2.5 (2020-05-26)~
 

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -10,7 +10,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release, otherwise -1 for dev-branch
-let s:plugin_vers = 2.5
+let s:plugin_vers = -1
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -194,7 +194,7 @@ function! s:set_windowlocal_options() abort
   endif
 
   if vimwiki#vars#get_global('conceallevel') && exists('+conceallevel')
-    let &conceallevel = vimwiki#vars#get_global('conceallevel')
+    let &l:conceallevel = vimwiki#vars#get_global('conceallevel')
   endif
 
   if vimwiki#vars#get_global('auto_chdir')

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -10,7 +10,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release, otherwise -1 for dev-branch
-let s:plugin_vers = -1
+let s:plugin_vers = 2.5
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')


### PR DESCRIPTION
# Proposed changes
The conceallevel option is now setted locally when entering a vimwiki buffer instead of globally

- [x] add local conceallevel option
- [x] run tests
- [x] edit changelog

Closes #899