### PR TITLE
Adds email style quotes to signal blockquotes

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -926,14 +926,14 @@ function! s:process_tag_arrow_quote(line, arrow_quote) abort
   let lines = []
   let arrow_quote = a:arrow_quote
   let processed = 0
-  if a:line =~# '^&gt;'
+  if a:line =~# '^\s*&gt;'
     if !arrow_quote
       call add(lines, '<blockquote>')
       call add(lines, '<p>')
       let arrow_quote = 1
     endif
     let processed = 1
-    let stripped_line = substitute(a:line, '^&gt;\s*', '', '')
+    let stripped_line = substitute(a:line, '^\s*&gt;\s*', '', '')
     if stripped_line =~# '^\s*$'
       call add(lines, '</p>')
       call add(lines, '<p>')

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1441,6 +1441,14 @@ Text which starts with 4 or more spaces is a blockquote.
     could be styled by CSS in HTML. Blockquotes are usually used to quote a
     long piece of text from another source.
 
+A group of lines prefixed with > also specifies a blockquote, with the caveat
+that the > syntax allow empty lines to signal multiple parragraphs.
+
+> This also signals a block quote.
+> 
+> You can use empty lines to signal multiple paragraphs kept inside the same
+> blockquote.
+
 
 ------------------------------------------------------------------------------
 5.10. Comments                                       *vimwiki-syntax-comments*
@@ -3595,6 +3603,7 @@ Contributors and their Github usernames in roughly chronological order:
     - flex (@bratekarate)
     - Marius Lopez (@PtitCaius)
     - Edward Bassett (@ebassett)
+    - Rafael Castillo (@eltrufas)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3609,6 +3618,7 @@ New:~
     * PR #919: Fix duplicate helptag
     * PR #907: Cycle bullets
     * PR #900: conceallevel is now setted locally for vimwiki buffers
+    * PR #901: adds multiparagraph blockquotes using email style syntax
 
 2.5 (2020-05-26)~
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1442,7 +1442,7 @@ Text which starts with 4 or more spaces is a blockquote.
     long piece of text from another source.
 
 A group of lines prefixed with > also specifies a blockquote, with the caveat
-that the > syntax allow empty lines to signal multiple parragraphs.
+that the > syntax allow empty lines to signal multiple paragraphs.
 
 > This also signals a block quote.
 > 

--- a/test/html_blockquote.vader
+++ b/test/html_blockquote.vader
@@ -1,0 +1,71 @@
+Include: vader_includes/vader_setup.vader
+
+Execute (Copy Wiki's Resources):
+  Log "Start: Copy Resources"
+  call CopyResources()
+
+Given (Void):
+
+Execute (Edit TestHtml Wiki):
+  edit $HOME/testwiki/TestHtml.wiki
+  AssertEqual $HOME . '/testwiki/TestHtml.wiki', expand('%')
+  AssertEqual 'default', vimwiki#vars#get_wikilocal('syntax')
+  AssertEqual 0, vimwiki#vars#get_bufferlocal('wiki_nr')
+
+Do (Markdown with arrow blockquotes):
+  :edit $HOME/testwiki/TestHtml.wiki\<CR>
+  ggdGi first paragraph\<CR>\<CR>
+  > block\<CR>
+  > quote\<CR>\<CR>
+  last paragraph\<CR>\<Esc>
+  :write\<CR>
+
+
+Execute (Save and Convert to html):
+  edit $HOME/testwiki/TestHtml.wiki
+  Vimwiki2HTML
+
+
+Given (Void):
+
+
+Do (Get Html body):
+  :read $HOME/html/default/TestHtml.html\<CR>
+# Goto body
+  gg/<body>\<CR>
+# Copy in b
+  "bdat
+# Delete All
+  ggdG
+# Paste body
+  "bP
+# Remove last line
+  Gdd
+# Save (Not necessary)
+  :write
+
+
+
+Expect (Plain Html):
+# the whole default html file should be here as a base + the modifications 
+# from "Given"
+  <body>
+
+  <p>
+   first paragraph
+  </p>
+   
+  <blockquote>
+  <p>
+  block
+  quote
+  </p>
+  </blockquote>
+   
+  <p>
+   last paragraph
+  </p>
+
+  </body>
+
+Include: vader_includes/vader_teardown.vader


### PR DESCRIPTION
fixes #422 

Adds a new function to the html converter to detect blocks of text prefixed with '>' and treats them as  a blockquote.

---

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
