### PR TITLE
Functions to remove all todo items that are done

### DIFF
--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -1157,7 +1157,8 @@ function! vimwiki#lst#remove_done(first_line, last_line)
 
   let parent_items_of_lines = []
   let cur_ln = first_item.lnum
-  while cur_ln > 0 && cur_ln <= last_item.lnum
+  let end_ln = last_item.lnum
+  while cur_ln > 0 && cur_ln <= end_ln
     let cur_item = s:get_item(cur_ln)
     if s:is_done(cur_item)
       let cur_parent_item = s:get_parent(cur_item)
@@ -1165,6 +1166,8 @@ function! vimwiki#lst#remove_done(first_line, last_line)
         call insert(parent_items_of_lines, cur_parent_item)
       endif
       exe cur_ln.'delete _'
+      let cur_ln -= 1
+      let end_ln -= 1
     endif
     let cur_ln = s:get_next_line(cur_ln)
   endwhile

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -1146,8 +1146,8 @@ function! vimwiki#lst#remove_done_in_current_list(recursive)
 endfunction
 
 
-" Remove lines containing task that are done
-function! vimwiki#lst#remove_done(first_line, last_line)
+" Remove selected lines if they contain a task that is done
+function! vimwiki#lst#remove_done_in_range(first_line, last_line)
   let first_item = s:get_corresponding_item(a:first_line)
   let last_item = s:get_corresponding_item(a:last_line)
 
@@ -1174,6 +1174,25 @@ function! vimwiki#lst#remove_done(first_line, last_line)
   for parent_item in parent_items_of_lines
     call s:update_state(parent_item)
   endfor
+endfunction
+
+
+" wrapper function to distinguish between function used with a range or not
+" vim 8.0.1089 and newer and corresponding neovim versions allow to use <range> to distinguish if
+" the function has been called with a range. For older versions we use remove_done_in_range if
+" first and last line are identical, which means there was either no range or the range was within
+" one line.
+function! vimwiki#lst#remove_done(recursive, range, first_line, last_line)
+  if a:range ==# '<range>'
+    let range = a:first_line != a:last_line
+  else
+    let range = a:range > 0
+  endif
+  if range
+    call vimwiki#lst#remove_done_in_range(a:first_line, a:last_line)
+  else
+    call vimwiki#lst#remove_done_in_current_list(a:recursive)
+  endif
 endfunction
 
 

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -1106,12 +1106,14 @@ endfunction
 " Iterate over given todo list and remove all task that are done
 " If recursive is true, child items will be checked too
 function! s:remove_done_in_list(item, recursive)
+  " Clause non-null item type
   if a:item.type == 0
     return
   endif
+  
+  " Recurse self on list item
   let first_item = s:get_first_item_in_list(a:item, 0)
   let total_lines_removed = 0
-
   let cur_item = first_item
   while 1
     let next_item = s:get_next_list_item(cur_item, 0)
@@ -1132,6 +1134,7 @@ function! s:remove_done_in_list(item, recursive)
     endif
   endwhile
 
+  " Update state of parent item (percentage of done)
   call s:update_state(s:get_parent(first_item))
   return total_lines_removed
 endfunction
@@ -1151,10 +1154,12 @@ function! vimwiki#lst#remove_done_in_range(first_line, last_line)
   let first_item = s:get_corresponding_item(a:first_line)
   let last_item = s:get_corresponding_item(a:last_line)
 
+  " Clause non-null first and last type item
   if first_item.type == 0 || last_item.type == 0
     return
   endif
 
+  " For each line, delete done tasks
   let parent_items_of_lines = []
   let cur_ln = first_item.lnum
   let end_ln = last_item.lnum
@@ -1171,6 +1176,8 @@ function! vimwiki#lst#remove_done_in_range(first_line, last_line)
     endif
     let cur_ln = s:get_next_line(cur_ln)
   endwhile
+  
+  " Update all parent state (percentage of done)
   for parent_item in parent_items_of_lines
     call s:update_state(parent_item)
   endfor

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -1711,3 +1711,31 @@ function! vimwiki#lst#fold_level(lnum) abort
   return '='
 endfunction
 
+
+" Remove all lines containing task that are done
+function! vimwiki#lst#remove_done(first_line, last_line)
+  let first_item = s:get_corresponding_item(a:first_line)
+  let last_item = s:get_corresponding_item(a:last_line)
+
+  if first_item.type == 0 || last_item.type == 0
+    return
+  endif
+
+  let parent_items_of_lines = []
+  let cur_ln = first_item.lnum
+  while 1
+    if cur_ln <= 0 || cur_ln > last_item.lnum | break | endif
+    let cur_item = s:get_item(cur_ln)
+    if cur_item.type != 0 && s:get_rate(cur_item) == 100
+      let cur_parent_item = s:get_parent(cur_item)
+      if index(parent_items_of_lines, cur_parent_item) == -1
+        call insert(parent_items_of_lines, cur_parent_item)
+      endif
+      exe cur_ln.'delete _'
+    endif
+    let cur_ln = s:get_next_line(cur_ln)
+  endwhile
+  for parent_item in parent_items_of_lines
+    call s:update_state(parent_item)
+  endfor
+endfunction

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -798,6 +798,11 @@ Vimwiki file.
 
 *:VimwikiRenameFile*
     Rename the wiki page you are in.
+*:VimwikiRemoveDone*
+    In selection: Remove Todo-list-items marked as done.
+
+*:VimwikiRemoveDoneInList*
+    In current Todo-List: Remove Todo-list-items marked as done.
 
 *:VimwikiNextTask*
     Jump to the next unfinished task in the current wiki page.

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -802,9 +802,9 @@ Vimwiki file.
 *:VimwikiRemoveDone*
     With range: Remove all lines that have a checked |vimwiki-todo-lists| checkbox
 
-    Otherwiese:
+    Otherwise:
     Remove all lines in the current todo-list that have a checked box. This is
-    applyed to the list in which the cursor is in, as well as all sublists.
+    applied to the list in which the cursor is in, as well as all its sublists.
     The status of parents is updated accordingly.
     If you want to remove only items of the current nesting level, (re)define
     a command that calls the same function with `0` as first argument: >

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -798,12 +798,19 @@ Vimwiki file.
 
 *:VimwikiRenameFile*
     Rename the wiki page you are in.
+
 *:VimwikiRemoveDone*
-    In selection: Remove Todo-list-items marked as done.
+    With range: Remove all lines that have a checked |vimwiki-todo-lists| checkbox
 
-*:VimwikiRemoveDoneInList*
-    In current Todo-List: Remove Todo-list-items marked as done.
-
+    Otherwiese:
+    Remove all lines in the current todo-list that have a checked box. This is
+    applyed to the list in which the cursor is in, as well as all sublists.
+    The status of parents is updated accordingly.
+    If you want to remove only items of the current nesting level, (re)define
+    a command that calls the same function with `0` as first argument: >
+        :command! -buffer -range VimwikiRemoveDone call 
+           \ vimwiki#lst#remove_done(0, "<range>", <line1>, <line2>)
+<
 *:VimwikiNextTask*
     Jump to the next unfinished task in the current wiki page.
 

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -293,6 +293,7 @@ command! -buffer VimwikiRenumberList call vimwiki#lst#adjust_numbered_list()
 command! -buffer VimwikiRenumberAllLists call vimwiki#lst#adjust_whole_buffer()
 command! -buffer VimwikiListToggle call vimwiki#lst#toggle_list_item()
 command! -buffer -range VimwikiRemoveDone call vimwiki#lst#remove_done(<line1>, <line2>)
+command! -buffer VimwikiRemoveDoneInList call vimwiki#lst#remove_done_in_list()
 
 " table commands
 command! -buffer -nargs=* VimwikiTable call vimwiki#tbl#create(<f-args>)

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -292,8 +292,7 @@ command! -buffer VimwikiRemoveCBInList call vimwiki#lst#remove_cb_in_list()
 command! -buffer VimwikiRenumberList call vimwiki#lst#adjust_numbered_list()
 command! -buffer VimwikiRenumberAllLists call vimwiki#lst#adjust_whole_buffer()
 command! -buffer VimwikiListToggle call vimwiki#lst#toggle_list_item()
-command! -buffer -range VimwikiRemoveDone call vimwiki#lst#remove_done(<line1>, <line2>)
-command! -buffer VimwikiRemoveDoneInList call vimwiki#lst#remove_done_in_current_list(1)
+command! -buffer -range VimwikiRemoveDone call vimwiki#lst#remove_done(1, "<range>", <line1>, <line2>)
 
 " table commands
 command! -buffer -nargs=* VimwikiTable call vimwiki#tbl#create(<f-args>)

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -293,7 +293,7 @@ command! -buffer VimwikiRenumberList call vimwiki#lst#adjust_numbered_list()
 command! -buffer VimwikiRenumberAllLists call vimwiki#lst#adjust_whole_buffer()
 command! -buffer VimwikiListToggle call vimwiki#lst#toggle_list_item()
 command! -buffer -range VimwikiRemoveDone call vimwiki#lst#remove_done(<line1>, <line2>)
-command! -buffer VimwikiRemoveDoneInList call vimwiki#lst#remove_done_in_list()
+command! -buffer VimwikiRemoveDoneInList call vimwiki#lst#remove_done_in_current_list(0)
 
 " table commands
 command! -buffer -nargs=* VimwikiTable call vimwiki#tbl#create(<f-args>)

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -293,7 +293,7 @@ command! -buffer VimwikiRenumberList call vimwiki#lst#adjust_numbered_list()
 command! -buffer VimwikiRenumberAllLists call vimwiki#lst#adjust_whole_buffer()
 command! -buffer VimwikiListToggle call vimwiki#lst#toggle_list_item()
 command! -buffer -range VimwikiRemoveDone call vimwiki#lst#remove_done(<line1>, <line2>)
-command! -buffer VimwikiRemoveDoneInList call vimwiki#lst#remove_done_in_current_list(0)
+command! -buffer VimwikiRemoveDoneInList call vimwiki#lst#remove_done_in_current_list(1)
 
 " table commands
 command! -buffer -nargs=* VimwikiTable call vimwiki#tbl#create(<f-args>)

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -292,6 +292,7 @@ command! -buffer VimwikiRemoveCBInList call vimwiki#lst#remove_cb_in_list()
 command! -buffer VimwikiRenumberList call vimwiki#lst#adjust_numbered_list()
 command! -buffer VimwikiRenumberAllLists call vimwiki#lst#adjust_whole_buffer()
 command! -buffer VimwikiListToggle call vimwiki#lst#toggle_list_item()
+command! -buffer -range VimwikiRemoveDone call vimwiki#lst#remove_done(<line1>, <line2>)
 
 " table commands
 command! -buffer -nargs=* VimwikiTable call vimwiki#tbl#create(<f-args>)

--- a/test/list_clean.vader
+++ b/test/list_clean.vader
@@ -36,7 +36,7 @@ Given vimwiki (simple list):
   * [ ] Todo 2
 
 Do (clean done with recursion, command):
-  :VimwikiRemoveDoneInList\<Enter>
+  :VimwikiRemoveDone\<Enter>
 
 Expect (two removed):
   * [ ] Todo 1

--- a/test/list_clean.vader
+++ b/test/list_clean.vader
@@ -172,5 +172,28 @@ Expect (only first is removed):
   * [ ] Todo Post space
   * [X] Done Post space
 
+Given vimwiki (list):
+  * [X] Done 1
+  * [ ] Todo 1
+
+  Line in between.
+
+  * [X] Done 2
+  * [X] Done 3
+  * [ ] Todo 2
+  * [X] Done 4
+
+Do (clean done, with range):
+  :1,6VimwikiRemoveDone\<Enter>
+
+Expect (only first is removed):
+  * [ ] Todo 1
+
+  Line in between.
+
+  * [X] Done 3
+  * [ ] Todo 2
+  * [X] Done 4
+
 
 Include: vader_includes/vader_teardown.vader

--- a/test/list_clean.vader
+++ b/test/list_clean.vader
@@ -10,7 +10,7 @@ Execute (Set syntax to default):
   call SetSyntax('default')
 
 Do (clean done, without recursion):
-  :VimwikiRemoveDoneInList\<Enter>
+  :call vimwiki#lst#remove_done_in_current_list(0)\<Enter>
 
 Expect (two removed):
   * [ ] Todo 1
@@ -22,8 +22,21 @@ Given vimwiki (simple list):
   * [X] Done 2
   * [ ] Todo 2
 
-Do (clean done with recursion):
+Do (clean done with recursion, function):
   :call vimwiki#lst#remove_done_in_current_list(1)\<Enter>
+
+Expect (two removed):
+  * [ ] Todo 1
+  * [ ] Todo 2
+
+Given vimwiki (simple list):
+  * [X] Done 1
+  * [ ] Todo 1
+  * [X] Done 2
+  * [ ] Todo 2
+
+Do (clean done with recursion, command):
+  :VimwikiRemoveDoneInList\<Enter>
 
 Expect (two removed):
   * [ ] Todo 1
@@ -39,7 +52,7 @@ Given vimwiki (with sub items):
   * [ ] Todo 2
 
 Do (clean done, without recursion):
-  :VimwikiRemoveDoneInList\<Enter>
+  :call vimwiki#lst#remove_done_in_current_list(0)\<Enter>
 
 Expect (first removed):
   * [ ] Todo 1
@@ -86,7 +99,7 @@ Given vimwiki (nested list with space and code):
       * Without cb
 
 Do (clean done, without recursion):
-  :VimwikiRemoveDoneInList\<Enter>
+  :call vimwiki#lst#remove_done_in_current_list(0)\<Enter>
 
 Expect (removed):
   * [ ] Todo 1

--- a/test/list_clean.vader
+++ b/test/list_clean.vader
@@ -1,0 +1,142 @@
+Include: vader_includes/vader_setup.vader
+
+Given vimwiki (simple list):
+  * [X] Done 1
+  * [ ] Todo 1
+  * [X] Done 2
+  * [ ] Todo 2
+
+Execute (Set syntax to default):
+  call SetSyntax('default')
+
+Do (clean done, without recursion):
+  :VimwikiRemoveDoneInList\<Enter>
+
+Expect (two removed):
+  * [ ] Todo 1
+  * [ ] Todo 2
+
+Given vimwiki (simple list):
+  * [X] Done 1
+  * [ ] Todo 1
+  * [X] Done 2
+  * [ ] Todo 2
+
+Do (clean done with recursion):
+  :call vimwiki#lst#remove_done_in_current_list(1)\<Enter>
+
+Expect (two removed):
+  * [ ] Todo 1
+  * [ ] Todo 2
+
+Given vimwiki (with sub items):
+  * [X] Done 1
+    * [X] Subdone 1
+  * [ ] Todo 1
+  * [o] Done 2
+    * [X] Subdone1
+    * [ ] Subtodo
+  * [ ] Todo 2
+
+Do (clean done, without recursion):
+  :VimwikiRemoveDoneInList\<Enter>
+
+Expect (first removed):
+  * [ ] Todo 1
+  * [o] Done 2
+    * [X] Subdone1
+    * [ ] Subtodo
+  * [ ] Todo 2
+
+Given vimwiki (with sub items):
+  * [ ] Todo 1
+  * [o] Done 2
+    * [X] Subdone1
+    * [ ] Subtodo
+  * [ ] Todo 2
+
+Do (clean done, with recursion):
+  :call vimwiki#lst#remove_done_in_current_list(1)\<Enter>
+
+Expect (all removed):
+  * [ ] Todo 1
+  * [ ] Done 2
+    * [ ] Subtodo
+  * [ ] Todo 2
+
+Given vimwiki (nested list with space and code):
+  * [X] Done 1
+  * [ ] Todo 1
+
+  * [ ] Todo Post space
+  * [X] Done Post space
+
+  * [ ] Todo code
+     {{{code
+     * [X] print "hello, world"
+     }}}
+
+  * [ ] Post code Todo
+    * [X] Done Sub-child
+      * [X] Sub-sub-child
+      * Without cb
+  * [X] Post code Done
+    * [X] Done Sub-child
+      * [X] Sub-sub-child
+      * Without cb
+
+Do (clean done, without recursion):
+  :VimwikiRemoveDoneInList\<Enter>
+
+Expect (removed):
+  * [ ] Todo 1
+
+  * [ ] Todo Post space
+
+  * [ ] Todo code
+     {{{code
+     * [X] print "hello, world"
+     }}}
+
+  * [ ] Post code Todo
+    * [X] Done Sub-child
+      * [X] Sub-sub-child
+      * Without cb
+
+Given vimwiki (nested list with space and code):
+  * [X] Done 1
+  * [ ] Todo 1
+
+  * [ ] Todo Post space
+  * [X] Done Post space
+
+  * [ ] Todo code
+     {{{code
+     * [X] print "hello, world"
+     }}}
+
+  * [ ] Post code Todo
+    * [X] Done Sub-child
+      * [X] Sub-sub-child
+      * Without cb
+  * [X] Post code Done
+    * [X] Done Sub-child
+      * [X] Sub-sub-child
+      * Without cb
+
+Do (clean done, with recursion):
+  :call vimwiki#lst#remove_done_in_current_list(1)\<Enter>
+
+Expect (removed):
+  * [ ] Todo 1
+
+  * [ ] Todo Post space
+
+  * [ ] Todo code
+     {{{code
+     * [X] print "hello, world"
+     }}}
+
+  * [ ] Post code Todo
+
+Include: vader_includes/vader_teardown.vader

--- a/test/list_clean.vader
+++ b/test/list_clean.vader
@@ -139,4 +139,25 @@ Expect (removed):
 
   * [ ] Post code Todo
 
+Given vimwiki (two lists):
+  * [X] Done 1
+  * [ ] Todo 1
+
+  Line in between.
+
+  * [ ] Todo Post space
+  * [X] Done Post space
+
+Do (clean done, with recursion):
+  :call vimwiki#lst#remove_done_in_current_list(1)\<Enter>
+
+Expect (only first is removed):
+  * [ ] Todo 1
+
+  Line in between.
+
+  * [ ] Todo Post space
+  * [X] Done Post space
+
+
 Include: vader_includes/vader_teardown.vader


### PR DESCRIPTION
This adds functions that remove todo items that are marked as done.

* `VimwikiRemoveDone`/`vimwiki#lst#remove_done` removes them within the selected area.
* `VimwikiRemoveDoneInList`/`vimwiki#lst#remove_done_in_list` removes them in the list the cursor is in.
  * `vimwiki#lst#remove_done_in_list` has a parameter to define if it should work recursively. Default is not recursive.

Superseeding #391
Fixes #823 and others.