### PR TITLE
Cycle bullets

### DIFF
--- a/syntax/vimwiki_markdown.vim
+++ b/syntax/vimwiki_markdown.vim
@@ -73,8 +73,9 @@ let s:markdown_syntax.rxHR = '\(^---*$\|^___*$\|^\*\*\**$\)'
 let s:markdown_syntax.rxTableSep = '|'
 
 " Lists
-let s:markdown_syntax.bullet_types = ['-', '*', '+']
+let s:markdown_syntax.bullet_types = ['*', '-', '+']
 let s:markdown_syntax.recurring_bullets = 0
+let s:markdown_syntax.cycle_bullets = 1
 let s:markdown_syntax.number_types = ['1.']
 let s:markdown_syntax.list_markers = ['-', '*', '+', '1.']
 let s:markdown_syntax.rxListDefine = '::\%(\s\|$\)'

--- a/test/independent_runs/map.vader
+++ b/test/independent_runs/map.vader
@@ -402,6 +402,55 @@ Expect (list -> *):
       1. Much
   * You
 
+Given (Bulleted list):
+  * I
+    - Relly
+  * Love
+    - Very
+      + Much
+  * You
+
+Execute (file .md):
+  file toto.md
+  edit!
+  AssertEqual 'vimwiki', &ft
+  set sw=2
+
+Do (2gll):
+  gLl
+
+Expect (Increase):
+    - I
+      + Relly
+  * Love
+    - Very
+      + Much
+  * You
+
+Do (3glh):
+  gLh
+
+Expect (Decrease):
+  * I
+    - Relly
+  * Love
+    - Very
+      + Much
+  * You
+
+Given (Bulleted list 2):
+  * Love
+    - Very
+      - Much
+
+Do (Go):
+  Go
+
+Expect (New item):
+  * Love
+    - Very
+      - Much
+      - 
 
 # 3 Text Object {{{1
 ####################


### PR DESCRIPTION
When the syntax local cnfig `cycle_bullets` is set (currently only
markdown has it by default) the indent functions will cycle through the
characters defined in `bullet_types` based on the level of indentation.

Signed-off-by: Robert Günzler <r@gnzler.io>

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
