### PR TITLE
Allow weblinks to end with '<'

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -692,7 +692,7 @@ function! vimwiki#vars#populate_syntax_vars(syntax) abort
   " let g:vimwiki_rxWeblink = '[\["(|]\@<!'. g:vimwiki_rxWeblinkUrl .
   " \ '\%([),:;.!?]\=\%([ \t]\|$\)\)\@='
   let g:vimwiki_syntax_variables[a:syntax].rxWeblink =
-        \ '\<'. g:vimwiki_global_vars.rxWeblinkUrl . '[^[:space:]>]*'
+        \ '\<'. g:vimwiki_global_vars.rxWeblinkUrl . '[^[:space:]><]*'
   " 0a) match URL within URL
   let g:vimwiki_syntax_variables[a:syntax].rxWeblinkMatchUrl =
         \ g:vimwiki_syntax_variables[a:syntax].rxWeblink


### PR DESCRIPTION
Fixes #908 by adding one character to `rxWeblink` regex, used in `make_tag`

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [X] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
