### PR TITLE
Allow user to override <TAB> and <S-TAB> keys.

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3607,10 +3607,10 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * PR #932: Add g:vimwiki_tab_key and g:vimwiki_shift_tab_key
     * PR #919: Fix duplicate helptag
     * PR #907: Cycle bullets
     * PR #900: conceallevel is now setted locally for vimwiki buffers
-    * Support g:vimwiki_tab_key and g:vimwiki_shift_tab_key
 
 2.5 (2020-05-26)~
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3595,6 +3595,7 @@ Contributors and their Github usernames in roughly chronological order:
     - flex (@bratekarate)
     - Marius Lopez (@PtitCaius)
     - Edward Bassett (@ebassett)
+    - Gary A. Howard (@Traap)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3609,6 +3610,7 @@ New:~
     * PR #919: Fix duplicate helptag
     * PR #907: Cycle bullets
     * PR #900: conceallevel is now setted locally for vimwiki buffers
+    * Support g:vimwiki_tab_key and g:vimwiki_shift_tab_key
 
 2.5 (2020-05-26)~
 

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -330,16 +330,12 @@ command! -buffer VimwikiCatUrl call vimwiki#html#CatUrl(expand('%:p'))
 " ------------------------------------------------
 
 " Allow the use to redefine <TAB> and <S-TAB>.
-if exists('g:vimwiki_tab_key')
-  let s:vimwiki_tab_key = g:vimwiki_tab_key
-else
-  let s:vimwiki_tab_key = '<TAB>' 
+if !exists('g:vimwiki_tab_key')
+  let g:vimwiki_tab_key = '<TAB>' 
 endif
 
-if exists('g:vimwiki_shift_tab_key')
-  let s:vimwiki_shift_tab_key = g:vimwiki_shift_tab_key
-else
-  let s:vimwiki_shift_tab_key = '<S-TAB>' 
+if !exists('g:vimwiki_shift_tab_key')
+  let g:vimwiki_shift_tab_key = '<S-TAB>' 
 endif
 
 " mouse mappings
@@ -406,8 +402,8 @@ if str2nr(vimwiki#vars#get_global('key_mappings').links)
   call vimwiki#u#map_key('n', '<D-CR>', '<Plug>VimwikiTabnewLink')
   call vimwiki#u#map_key('n', '<C-S-CR>', '<Plug>VimwikiTabnewLink', 1)
   call vimwiki#u#map_key('n', '<BS>', '<Plug>VimwikiGoBackLink')
-  call vimwiki#u#map_key('n', s:vimwiki_tab_key, '<Plug>VimwikiNextLink')
-  call vimwiki#u#map_key('n', s:vimwiki_shift_tab_key, '<Plug>VimwikiPrevLink')
+  call vimwiki#u#map_key('n', g:vimwiki_tab_key, '<Plug>VimwikiNextLink')
+  call vimwiki#u#map_key('n', g:vimwiki_shift_tab_key, '<Plug>VimwikiPrevLink')
   call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'n', '<Plug>VimwikiGoto')
   call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'d', '<Plug>VimwikiDeleteFile')
   call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'r', '<Plug>VimwikiRenameFile')
@@ -560,8 +556,8 @@ endfunction
 
 " insert mode table mappings
 if str2nr(vimwiki#vars#get_global('key_mappings').table_mappings)
-  inoremap <expr><buffer> s:vimwiki_tab_key vimwiki#tbl#kbd_tab()
-  inoremap <expr><buffer> s:vimwiki_shift_tab_key vimwiki#tbl#kbd_shift_tab()
+  exe 'inoremap <expr><buffer> '.g:vimwiki_tab_key.' vimwiki#tbl#kbd_tab()'
+  exe 'inoremap <expr><buffer> '.g:vimwiki_shift_tab_key.' vimwiki#tbl#kbd_shift_tab()'
 endif
 
 " <Plug> table formatting definitions

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -329,6 +329,19 @@ command! -buffer VimwikiCatUrl call vimwiki#html#CatUrl(expand('%:p'))
 " Keybindings
 " ------------------------------------------------
 
+" Allow the use to redefine <TAB> and <S-TAB>.
+if exists('g:vimwiki_tab_key')
+  let s:vimwiki_tab_key = g:vimwiki_tab_key
+else
+  let s:vimwiki_tab_key = '<TAB>' 
+endif
+
+if exists('g:vimwiki_shift_tab_key')
+  let s:vimwiki_shift_tab_key = g:vimwiki_shift_tab_key
+else
+  let s:vimwiki_shift_tab_key = '<S-TAB>' 
+endif
+
 " mouse mappings
 if str2nr(vimwiki#vars#get_global('key_mappings').mouse)
   nmap <buffer> <S-LeftMouse> <NOP>
@@ -393,8 +406,8 @@ if str2nr(vimwiki#vars#get_global('key_mappings').links)
   call vimwiki#u#map_key('n', '<D-CR>', '<Plug>VimwikiTabnewLink')
   call vimwiki#u#map_key('n', '<C-S-CR>', '<Plug>VimwikiTabnewLink', 1)
   call vimwiki#u#map_key('n', '<BS>', '<Plug>VimwikiGoBackLink')
-  call vimwiki#u#map_key('n', '<TAB>', '<Plug>VimwikiNextLink')
-  call vimwiki#u#map_key('n', '<S-TAB>', '<Plug>VimwikiPrevLink')
+  call vimwiki#u#map_key('n', s:vimwiki_tab_key, '<Plug>VimwikiNextLink')
+  call vimwiki#u#map_key('n', s:vimwiki_shift_tab_key, '<Plug>VimwikiPrevLink')
   call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'n', '<Plug>VimwikiGoto')
   call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'d', '<Plug>VimwikiDeleteFile')
   call vimwiki#u#map_key('n', vimwiki#vars#get_global('map_prefix').'r', '<Plug>VimwikiRenameFile')
@@ -547,8 +560,8 @@ endfunction
 
 " insert mode table mappings
 if str2nr(vimwiki#vars#get_global('key_mappings').table_mappings)
-  inoremap <expr><buffer> <Tab> vimwiki#tbl#kbd_tab()
-  inoremap <expr><buffer> <S-Tab> vimwiki#tbl#kbd_shift_tab()
+  inoremap <expr><buffer> s:vimwiki_tab_key vimwiki#tbl#kbd_tab()
+  inoremap <expr><buffer> s:vimwiki_shift_tab_key vimwiki#tbl#kbd_shift_tab()
 endif
 
 " <Plug> table formatting definitions


### PR DESCRIPTION
Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

This pull request allows a vimwiki user to redefine the TAB and S-TAB keys.  The lines below are added to vimrc to override the default <TAB> and <S-TAB> behavior.
``  
let g:vimwiki_tab_key = '<F7>'
``
``
let g:vimwiki_shift_tab_key = '<F8>'
``

ftplugin/vimwiki.vim assigns these values to script variables when they exist, otherwise, TAB and S-TAB remain the defaults.

key mappings and insert mode mappings use g:vimwiki_tab_key and g:vimwiki_shift_tab_key to achieve the desired result. 

