### PR TITLE
#940: Render header inside thead element if table has header

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -790,14 +790,18 @@ function! s:close_tag_table(table, ldest, header_ids) abort
       endif
     endfor
     if head > 0
+      call add(ldest, '<thead>')
       for row in table[1 : head-1]
         if !empty(filter(row, '!empty(v:val)'))
           call s:close_tag_row(row, 1, ldest, a:header_ids)
         endif
       endfor
+      call add(ldest, '</thead>')
+      call add(ldest, '<tbody>')
       for row in table[head+1 :]
         call s:close_tag_row(row, 0, ldest, a:header_ids)
       endfor
+      call add(ldest, '</tbody>')
     else
       for row in table[1 :]
         call s:close_tag_row(row, 0, ldest, a:header_ids)

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3595,6 +3595,7 @@ Contributors and their Github usernames in roughly chronological order:
     - flex (@bratekarate)
     - Marius Lopez (@PtitCaius)
     - Edward Bassett (@ebassett)
+    - Gaurang Kher (@gaurangkher)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3606,6 +3607,8 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * Issue #940: Render table header inside thead element and rest under
+      tbody element if table header specified in wiki
     * PR #919: Fix duplicate helptag
     * PR #907: Cycle bullets
     * PR #900: conceallevel is now setted locally for vimwiki buffers


### PR DESCRIPTION
Ref:https://github.com/vimwiki/vimwiki/issues/940

Added functionality for table html conversion:
If table header has been specified in vimwiki, headers will go under thead element and rest will go under tbody element
