### PR TITLE
Fix :VimwikiNextTask

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1342,7 +1342,7 @@ endfunction
 
 " Find next task (Exported)
 function! vimwiki#base#find_next_task() abort
-  let taskRegex = vimwiki#vars#get_syntaxlocal('rxListItemWithoutCB')
+  let taskRegex = vimwiki#vars#get_wikilocal('rxListItemWithoutCB')
     \ . '\+\(\[ \]\s\+\)\zs'
   call vimwiki#base#search_word(taskRegex, '')
 endfunction

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3674,6 +3674,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Edward Bassett (@ebassett)
     - Rafael Castillo (@eltrufas)
     - Reiner Herrmann (@reinerh)
+    - Ryan Winograd
 
 
 ==============================================================================
@@ -3692,6 +3693,7 @@ New:~
     * PR #900: conceallevel is now setted locally for vimwiki buffers
     * PR #901: adds multiparagraph blockquotes using email style syntax
     * PR #934: RSS feed generation for diary with :VimwikiRss.
+    * PR #959: Fix :VimwikiNextTask
 
 2.5 (2020-05-26)~
 

--- a/test/list_todo.vader
+++ b/test/list_todo.vader
@@ -200,6 +200,23 @@ Expect (4 items toogled):
   End
 
 ################################################################################
+# Todo list with text above
+
+Given vimwiki (TODO list):
+  Some other text
+
+  - [ ] Todo Item
+
+Execute (:VimwikiNextTask):
+  :execute "VimwikiNextTask" | execute 'normal yyp'
+
+Expect (Introduce new todo item):
+  Some other text
+
+  - [ ] Todo Item
+  - [ ] Todo Item
+
+################################################################################
 # Numbered Todo list
 
 Given vimwiki (Number TODO list):


### PR DESCRIPTION
Use the correct function for accessing 'rxListItemWithoutCB'.
`ac4d0a1d46` refactored access to vars and it appears this is one place
where `get_syntaxlocal` should have been renamed to `get_wikilocal` but
was accidentally skipped.

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

---------

I've been running on `dev` to take advantage of some of the latest changes there and noticed that `gnt` no longer works for me. I think I tracked down the issue and added a test to confirm the bug and related fix. That said, this is my first time contributing to this project and using vader for tests. Happy to make any tweaks to get this PR cleaned up and ready to merge!
