### PR TITLE
Add inline comments

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1472,6 +1472,15 @@ The default commentstring can be changed or disabled with
 |g:vimwiki_commentstring| so an alternative commentstring can be set, e.g.:
   <!-- This may be a comment too -->
 
+A multi-line comment is one that starts with %%+ and ends with +%%. This can
+traverse across multiple lines, or can be contained within part of a single
+line.
+E.g.:
+ %%+ this text
+ and this text
+ would not be
+ in html +%%
+ %%+ not included +%% is included %%+ also not included +%%
 
 ------------------------------------------------------------------------------
 5.11. Horizontal line                                      *vimwiki-syntax-hr*
@@ -3706,6 +3715,7 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * PR #967: Add multiline comment support via %%+ and +%%
     * Issue #942: Fixing wrong html link conversion in windows
     * PR #946: Add option |g:vimwiki_commentstring| to customize commentstring
     * Issue #940: Render table header inside thead element and rest under

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -348,6 +348,14 @@ if vimwiki#vars#get_global('valid_html_tags') !=? ''
 
   execute 'syntax match VimwikiComment /'.vimwiki#vars#get_syntaxlocal('rxComment').
         \ '/ contains=@Spell,VimwikiTodo'
+
+  " Only do syntax highlighting for multiline comments if they exist
+  let s:mc_start = vimwiki#vars#get_syntaxlocal('rxMultilineCommentStart')
+  let s:mc_end = vimwiki#vars#get_syntaxlocal('rxMultilineCommentEnd')
+  if !empty(s:mc_start) && !empty(s:mc_end)
+    execute 'syntax region VimwikiMultilineComment start=/'.s:mc_start.
+          \ '/ end=/'.s:mc_end.'/ contains=@NoSpell,VimwikiTodo'
+  endif
 endif
 
 " tags
@@ -425,6 +433,7 @@ hi def link VimwikiSubScriptT VimwikiSubScript
 
 hi def link VimwikiTodo Todo
 hi def link VimwikiComment Comment
+hi def link VimwikiMultilineComment Comment
 
 hi def link VimwikiPlaceholder SpecialKey
 hi def link VimwikiPlaceholderParam String
@@ -487,4 +496,3 @@ call vimwiki#base#nested_syntax('tex',
 
 
 syntax spell toplevel
-

--- a/syntax/vimwiki_default.vim
+++ b/syntax/vimwiki_default.vim
@@ -95,6 +95,8 @@ let s:default_syntax.rxPreEnd = '}}}'
 let s:default_syntax.rxMathStart = '{{\$'
 let s:default_syntax.rxMathEnd = '}}\$'
 
+let s:default_syntax.rxMultilineCommentStart = '%%+'
+let s:default_syntax.rxMultilineCommentEnd = '+%%'
 let s:default_syntax.rxComment = '^\s*%%.*$'
 let s:default_syntax.rxTags = '\%(^\|\s\)\@<=:\%([^:''[:space:]]\+:\)\+\%(\s\|$\)\@='
 

--- a/syntax/vimwiki_markdown.vim
+++ b/syntax/vimwiki_markdown.vim
@@ -89,6 +89,9 @@ let s:markdown_syntax.rxPreEnd = '\%(`\{3,}\|\~\{3,}\)'
 let s:markdown_syntax.rxMathStart = '\$\$'
 let s:markdown_syntax.rxMathEnd = '\$\$'
 
+" NOTE: There is no multi-line comment syntax for Markdown
+let s:markdown_syntax.rxMultilineCommentStart = ''
+let s:markdown_syntax.rxMultilineCommentEnd = ''
 let s:markdown_syntax.rxComment = '^\s*%%.*$\|<!--[^>]*-->'
 let s:markdown_syntax.rxTags = '\%(^\|\s\)\@<=:\%([^:[:space:]]\+:\)\+\%(\s\|$\)\@='
 

--- a/syntax/vimwiki_media.vim
+++ b/syntax/vimwiki_media.vim
@@ -70,6 +70,9 @@ let s:media_syntax.rxPreEnd = '<\/pre>'
 let s:media_syntax.rxMathStart = '{{\$'
 let s:media_syntax.rxMathEnd = '}}\$'
 
+" NOTE: There is no multi-line comment syntax for MediaWiki
+let s:media_syntax.rxMultilineCommentStart = ''
+let s:media_syntax.rxMultilineCommentEnd = ''
 let s:media_syntax.rxComment = '^\s*%%.*$'
 let s:media_syntax.rxTags = '\%(^\|\s\)\@<=:\%([^:[:space:]]\+:\)\+\%(\s\|$\)\@='
 

--- a/test/convert_default_html.vader
+++ b/test/convert_default_html.vader
@@ -4,8 +4,54 @@ Execute (Copy Wiki's Resources):
   Log "Start: Copy Resources"
   call CopyResources()
 
+#################################################
+Given vimwiki (Comments):
+  This is some text
+  %% This is a comment
+  Test%%+INLINE COMMENT+%%1
+  %%+INLINE COMMENT+%%Test2
+  Test3%%+INLINE COMMENT+%%
+  %%+ Multiline
+  comment
+  that
+  is
+  removed
+  +%%
+  Final text
+
+Do (Convert):
+  :call ConvertWiki2Html()\<Cr>
+# Keep only body
+  ggd/<body>\<Cr>
+
+Expect (Comments Removed):
+  <body>
+
+  <p>
+  This is some text
+  Test1
+  Test2
+  Test3
+  </p>
 
 
+
+
+
+
+  <p>
+  Final text
+  </p>
+
+  </body>
+  </html>
+
+
+Execute(Delete):
+  call DeleteFile('$HOME/testwiki/test_html_table.wiki')
+  call DeleteFile('$HOME/html/default/test_html_table.html')
+
+#################################################
 Given vimwiki (Table no heading {{{1):
   | header1 | header2 |
   |  val1    | val2    |
@@ -127,7 +173,6 @@ Execute(Delete):
   call DeleteFile('$HOME/testwiki/test_html_table.wiki')
   call DeleteFile('$HOME/html/default/test_html_table.html')
 
-
 #################################################
 Execute (Log):
    Log '#473: Syntax "local:" doesnt work as expected. #473'
@@ -174,11 +219,11 @@ Do (Get Html body):
 
 Expect (Local link):
   <body>
-  
+
   <p>
   <a href="../../here">Link</a>
   </p>
-  
+
   </body>
 
 
@@ -226,7 +271,7 @@ Do (Get Html body):
 
 
 Expect (Plain Html):
-# the whole default html file should be here as a base + the modifications 
+# the whole default html file should be here as a base + the modifications
 # from "Given"
   <body>
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -171,6 +171,47 @@ Execute (Assert Syntax Header):
   AssertEqual SyntaxAt(5, 10), 'VimwikiHeader5'
   AssertEqual SyntaxAt(6, 10), 'VimwikiHeader6'
 
+# 10 Comments {{{1
+###############
+
+Given vimwiki (%%):
+  %% This is a line comment
+      %% This is also a comment
+
+Execute (Set syntax default):
+  call SetSyntax('default')
+
+Execute (Assert Syntax VimwikiComment):
+  AssertEqual SyntaxAt(1, 1), 'VimwikiComment'
+  AssertEqual SyntaxAt(2, 4), 'VimwikiComment'
+
+Given vimwiki (%%+, +%%):
+  %%+ This
+  is a
+  multiline
+  comment +%%
+  %%+ This is a comment on one line +%%
+  %%+ One +%% Not a comment %%+ Two +%% Not a comment
+
+Execute (Set syntax default):
+  call SetSyntax('default')
+
+Execute (Assert Syntax VimwikiMultilineComment):
+  AssertEqual SyntaxAt(1, 1), 'VimwikiMultilineComment'
+  AssertEqual SyntaxAt(1, 8), 'VimwikiMultilineComment'
+  AssertEqual SyntaxAt(2, 1), 'VimwikiMultilineComment'
+  AssertEqual SyntaxAt(3, 1), 'VimwikiMultilineComment'
+  AssertEqual SyntaxAt(4, 1), 'VimwikiMultilineComment'
+  AssertEqual SyntaxAt(5, 1), 'VimwikiMultilineComment'
+
+  AssertEqual SyntaxAt(6, 1), 'VimwikiMultilineComment'
+  AssertEqual SyntaxAt(6, 11), 'VimwikiMultilineComment'
+  AssertEqual SyntaxAt(6, 12), ''
+  AssertEqual SyntaxAt(6, 26), ''
+  AssertEqual SyntaxAt(6, 27), 'VimwikiMultilineComment'
+  AssertEqual SyntaxAt(6, 37), 'VimwikiMultilineComment'
+  AssertEqual SyntaxAt(6, 38), ''
+  AssertEqual SyntaxAt(6, 51), ''
 
 # 10 Code {{{1
 # 10.1 Code Indent (4 spaces) {{{2


### PR DESCRIPTION
Resolves #965.
### Details

Support comments that are inline and/or multiline versus being at the start of a line.

```vimwiki
= My Wiki =

%% Line comment
- Item 1
- Item 2 %%+ Inline comment +%%
- Item 3
%%+ some comment
that continues
on multiple lines +%%
```

### Status

- [X] Add `rxMultilineComment` syntax for default vimwiki (markdown and mediawiki are empty)
    - [X] Syntax test for comments (single-line & multiline) added to `vimwiki/test/syntax.vader` and passing
- [X] Add multiline comment parsing in `s:parse_line` of `vimwiki/autoload/vimwiki/html.vim`
    - [X] Comment parsing test for comments (single-line & multiline) added to `vimwiki/test/convert_default_html.vader` and passing
- [X] Update changelog to reflect new PR #967