### PR TITLE
886 fix generate links on windows

### DIFF
--- a/autoload/vimwiki/path.vim
+++ b/autoload/vimwiki/path.vim
@@ -131,8 +131,8 @@ function! vimwiki#path#relpath(dir, file) abort
     return a:file
   endif
   " Unixify && Expand in
-  let s_dir = expand(s:unixify(a:dir))
-  let s_file = expand(s:unixify(a:file))
+  let s_dir = s:unixify(expand(a:dir))
+  let s_file = s:unixify(expand(a:file))
 
   " Split path
   let dir = split(s_dir, '/')

--- a/autoload/vimwiki/path.vim
+++ b/autoload/vimwiki/path.vim
@@ -164,7 +164,7 @@ function! vimwiki#path#relpath(dir, file) abort
     let result_path .= '/'
   endif
 
-  return s:osxify(result_path)
+  return result_path
 endfunction
 
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3828,6 +3828,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Birger Niklas (@BirgerNi)
     - Chip Senkbeil (@chipsenkbeil)
     - Jerome Gay (@jeromg)
+    - Benney Au (@chinwobble)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3876,6 +3877,7 @@ Changed:~
 Removed:~
 
 Fixed:~
+    * Issue #886: :VimwikiGenerateLinks not working on Windows
     * Issue #55: Newlines in blockquotes are not honored
     * Issue #55: BlockQuote restarts list numbering
     * Issue #979: Fix: Accessing other filetypes within vimwiki


### PR DESCRIPTION
#886 

Fix :VimWikiGenerateLinks not working on windows.
Fixes an issue where links aren't generated due to backslashes on windows.
![image](https://user-images.githubusercontent.com/18226001/92319764-05e9f700-f05f-11ea-8f13-572e427de753.png)


Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
