### PR TITLE
Allow overwriting insert mode maps

### DIFF
--- a/autoload/vimwiki/u.vim
+++ b/autoload/vimwiki/u.vim
@@ -212,7 +212,7 @@ endfunc
 function! vimwiki#u#map_key(mode, key, plug, ...) abort
   if a:0 && a:1 == 2
     " global mappings
-    if !hasmapto(a:plug) && maparg(a:key, a:mode) ==# ''
+    if !hasmapto(a:plug, a:mode) && maparg(a:key, a:mode) ==# ''
       exe a:mode . 'map ' . a:key . ' ' . a:plug
     endif
   elseif a:0 && a:1 == 1
@@ -220,7 +220,7 @@ function! vimwiki#u#map_key(mode, key, plug, ...) abort
       exe a:mode . 'map <buffer> ' . a:key . ' ' . a:plug
   else
     " vimwiki buffer mappings
-    if !hasmapto(a:plug)
+    if !hasmapto(a:plug, a:mode)
       exe a:mode . 'map <buffer> ' . a:key . ' ' . a:plug
     endif
   endif

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3900,6 +3900,7 @@ Fixed:~
     * PR #919: Fix duplicate helptag
     * PR #959: Fix :VimwikiNextTask
     * PR #986: Fix typo in help file
+    * PR #1030: Allow overwriting insert mode mappings
 
 
 2.5 (2020-05-26)~


### PR DESCRIPTION
According to `:h hasmapto()` if we don't pass the mode as an argument then only normal, visual and operator-pending modes are checked.

Lets pass the mode explicitly to allow overwriting insert mode mappings.

I think this will fix: #1021 

Original PR that introduced `vimwiki#u#map_key()`: #686 

With this minimal `.vimrc | init.vim`:

```viml
call plug#begin('~/.config/nvim/plugged')
Plug 'vimwiki/vimwiki', { 'branch': 'dev' }
call plug#end()
let g:vimwiki_list = [
      \ {'path': '~/notes/',
      \ 'syntax': 'markdown', 'ext': '.md'}]
imap <F13> <Plug>VimwikiIncreaseLvlSingleItem
inoremap <C-T> <Esc>
```

Notice I want to remap `<C-T>` in insert mode. We should only need to remap `<Plug>VimwikiIncreaseLvlSingleItem` to another key (`<F13>` in this case) and vimwiki should not apply this: `call vimwiki#u#map_key('i', '<C-T>', '<Plug>VimwikiIncreaseLvlSingleItem')` from `ftplugin/vimwiki.vim`.

Without this patch this is not happening, `:verbose imap <C-T>`:

![image](https://user-images.githubusercontent.com/9190258/95624909-3990b600-0a3d-11eb-9fe7-488ab4362d8a.png)

With the patch:

![image](https://user-images.githubusercontent.com/9190258/95625003-63e27380-0a3d-11eb-9d94-d17f487e4d29.png)

I searched all vimwiki codebase and noticed all `vimwiki#u#map_key` calls always have the mode as first argument, so I think this is a safe fix. Writing a test is above my knowledge/time.

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
