### PR TITLE
fix: not throwing error when loading for some languages

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3830,6 +3830,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Jerome Gay (@jeromg)
     - Benney Au (@chinwobble)
     - David Sierra DiazGranados (@davidsierradz)
+    - Daniel Moura (@dmouraneto)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3878,6 +3879,8 @@ Changed:~
 Removed:~
 
 Fixed:~
+    * Issue #1029: Fix: error loading plugin when lang uses comma instead of
+      dot as decimal separator
     * Issue #886: :VimwikiGenerateLinks not working on Windows
     * Issue #55: Newlines in blockquotes are not honored
     * Issue #55: BlockQuote restarts list numbering

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -11,7 +11,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release, otherwise -1 for dev-branch
-let s:plugin_vers = -1
+let s:plugin_vers = str2float("-1")
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')


### PR DESCRIPTION
Fixes #1029 
Some languages uses comma instead of dot for decimal separator.
When loading vimwiki the following error was occuring
E806: using Float as a String
This is probably a bug in vim, as a workaround when using float can be
str2float.
Similar issue in another project
https://github.com/nathanaelkane/vim-indent-guides/issues/10