### PR TITLE
Feature: Optionally disable todo propagation to parents/children (Issue #954)

### DIFF
--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -800,6 +800,10 @@ function! s:set_state_plus_children(item, new_rate, ...) abort
     call s:set_state(a:item, a:new_rate)
   endif
 
+  if vimwiki#vars#get_wikilocal('listsyms_propagate') == 0
+    return
+  endif
+
   let all_children_are_done = 1
   let all_children_are_rejected = 1
 
@@ -867,7 +871,7 @@ endfunction
 "updates the symbol of a checkboxed item according to the symbols of its
 "children
 function! s:update_state(item) abort
-  if a:item.type == 0 || a:item.cb ==? ''
+  if a:item.type == 0 || a:item.cb ==? '' || vimwiki#vars#get_wikilocal('listsyms_propagate') == 0
     return
   endif
 

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -606,7 +606,7 @@ function! s:normalize_wikilocal_settings() abort
       endif
     endfor
 
-    " Nomarlize
+    " Normalize
     """"""""""""""""""""""""""""""""
     let wiki_settings['path'] = s:normalize_path(wiki_settings['path'])
 
@@ -1288,8 +1288,8 @@ endfunction
 
 " Get variable anywhere
 " Returns: [value, location] where loc=global|wikilocal|syntaxlocal|bufferlocal|none
-" Called: cmd <- VimvikiVar
-" TODO get more preformant approach when this file has been well refactored:
+" Called: cmd <- VimwikiVar
+" TODO get more performant approach when this file has been well refactored:
 " -- calls only the necessary functions and not syntaxlocal anytime
 function! s:get_anywhere(key, ...) abort
   " Alias common info
@@ -1534,7 +1534,7 @@ function! vimwiki#vars#get_syntaxlocal(key, ...) abort
     let syntax = vimwiki#vars#get_wikilocal('syntax')
   endif
 
-  " Create syntax varaible dict if not exists (lazy)
+  " Create syntax variable dict if not exists (lazy)
   if !exists('g:vimwiki_syntaxlocal_vars') || !has_key(g:vimwiki_syntaxlocal_vars, syntax)
     call vimwiki#vars#populate_syntax_vars(syntax)
   endif
@@ -1599,7 +1599,7 @@ function! vimwiki#vars#set_global(key, value) abort
 endfunction
 
 
-" Return: wiki local named varaible
+" Return: wiki local named variable
 " Param: (1): variable name (alias key, <string>)
 " Param: (2): wiki number (<int>). When absent, the wiki of the currently active buffer is
 " used

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -506,6 +506,7 @@ function! s:get_default_wikilocal() abort
         \ 'list_margin': {'type': type(0), 'default': -1, 'min': -1},
         \ 'listsym_rejected': {'type': type(''), 'default': vimwiki#vars#get_global('listsym_rejected')},
         \ 'listsyms': {'type': type(''), 'default': vimwiki#vars#get_global('listsyms')},
+        \ 'listsyms_propagate': {'type': type(0), 'default': 1},
         \ 'markdown_link_ext': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'maxhi': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'name': {'type': type(''), 'default': ''},

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1880,9 +1880,10 @@ parent items: >
    * [ ] Add highlighting to list item boxes.
    * [ ] Add [ ] to the next list item created using o, O or <CR>.
 
-Parent items should change when their child items change. If not, use
-|vimwiki_glr|. The symbol between [ ] depends on the percentage of toggled
-child items (see also |vimwiki-listsyms|): >
+Parent items should change when their child items change unless disabled via
+|vimwiki-option-listsyms_propagate|. If not, use |vimwiki_glr|. The symbol
+between [ ] depends on the percentage of toggled child items (see also
+|vimwiki-listsyms|): >
     [ ] -- 0%
     [.] -- 1-33%
     [o] -- 34-66%
@@ -2672,6 +2673,16 @@ The character used here must not be part of |vimwiki-listsyms|.
 You can set it to a more fancy symbol like this:
 >
    let g:vimwiki_list = [{'path': '~/path/', 'listsym_rejected' = '✗'}]
+
+
+*vimwiki-option-listsyms_propagate*
+------------------------------------------------------------------------------
+Key                 Default value     Values~
+listsyms_propagate  1                 0, 1
+
+Description~
+Set this option to 0 to disable propagation of todo list item status to
+parents and children.
 
 
 *vimwiki-option-auto_tags*
@@ -3831,6 +3842,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Benney Au (@chinwobble)
     - David Sierra DiazGranados (@davidsierradz)
     - Daniel Moura (@dmouraneto)
+    - Tomáš Janoušek (@liskin)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3842,6 +3854,8 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * Feature: #954: Add option |vimwiki-option-listsyms_propagate| to disable
+      todo propagation to parents/children
     * Issue #1009: |foldmethod| syntax works for markdown (|g:vimwiki_folding|)
       Also the VimwikiHeader1Folding (1..60 regions support end-of-file `/\%$`
       as end maker

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1883,7 +1883,7 @@ parent items: >
 Parent items should change when their child items change unless disabled via
 |vimwiki-option-listsyms_propagate|. If not, use |vimwiki_glr|. The symbol
 between [ ] depends on the percentage of toggled child items (see also
-|vimwiki-listsyms|): >
+|vimwiki-option-listsyms|): >
     [ ] -- 0%
     [.] -- 1-33%
     [o] -- 34-66%
@@ -2643,7 +2643,7 @@ If set to 1 (true), cycle through |bullet_types| when changing list element
 identation
 
 
-*vimwiki-listsyms*
+*vimwiki-option-listsyms*
 ------------------------------------------------------------------------------
 Key               Default value~
 listsyms          ' .oOX'
@@ -2660,7 +2660,7 @@ You can set it to some more fancy symbols like this:
    let g:vimwiki_list = [{'path': '~/path/', 'listsyms' = '✗○◐●✓'}]
 
 
-*vimwiki-listsym_rejected*
+*vimwiki-option-listsym_rejected*
 ------------------------------------------------------------------------------
 
 Character that is used to show that an item of a todo list will not be done.
@@ -2668,7 +2668,7 @@ Default value is '-'. This overwrites the global |g:vimwiki_listsym_rejected| on
 per wiki base.
 
 
-The character used here must not be part of |vimwiki-listsyms|.
+The character used here must not be part of |vimwiki-option-listsyms|.
 
 You can set it to a more fancy symbol like this:
 >
@@ -2990,7 +2990,7 @@ Default: 'Vimwiki'
 
 String of at least two symbols to show the progression of todo list items.
 Default value is ' .oOX'. You can also set this on a per-wiki level with
-|vimwiki-listsyms|.
+|vimwiki-option-listsyms|.
 
 The first char is for 0% done items.
 The last is for 100% done items.
@@ -3005,7 +3005,7 @@ You can set it to some more fancy symbols like this:
 
 Character that is used to show that an item of a todo list will not be done.
 Default value is '-'. You can also set this on a per-wiki level with
-|vimwiki-listsym_rejected|.
+|vimwiki-option-listsym_rejected|.
 
 
 The character used here must not be part of |g:vimwiki_listsyms|.
@@ -3854,8 +3854,8 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
-    * Feature: #954: Add option |vimwiki-option-listsyms_propagate| to disable
-      todo propagation to parents/children
+    * Feature: #954 #1041: Add option |vimwiki-option-listsyms_propagate| to
+      disable todo propagation to parents/children
     * Issue #1009: |foldmethod| syntax works for markdown (|g:vimwiki_folding|)
       Also the VimwikiHeader1Folding (1..60 regions support end-of-file `/\%$`
       as end maker
@@ -4069,8 +4069,8 @@ New:~
     * Add the option |g:vimwiki_listsym_rejected| to set the character used
       for won't-do list items.
     * The effect of |g:vimwiki_listsyms| and |g:vimwiki_listsym_rejected| can
-      be set on a per wiki level, see |vimwiki-listsyms| and
-      |vimwili-listsym_rejected|
+      be set on a per wiki level, see |vimwiki-option-listsyms| and
+      |vimwili-option-listsym_rejected|
     * gln and glp change the "done" status of a checkbox, see |vimwiki_gln|.
     * |:VimwikiSplitLink| and |:VimwikiVSplitLink| can now reuse an existing
       split window and not move the cursor.

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -11,7 +11,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release, otherwise -1 for dev-branch
-let s:plugin_vers = str2float("-1")
+let s:plugin_vers = str2float('-1')
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')

--- a/test/list_update_nopropagate.vader
+++ b/test/list_update_nopropagate.vader
@@ -1,0 +1,87 @@
+# Task list update, propagation disabled
+
+Given vimwiki (Sample nested list, vimwiki syntax):
+  * [ ] Top Level
+    * [ ] Child 1
+    * [ ] Child 2
+    * [ ] Child 3
+
+Execute (Set syntax to default):
+  set sw=2
+  call SetSyntax('default')
+  call vimwiki#vars#set_wikilocal('listsyms_propagate', 0)
+
+Do (Toggle top-level):
+  \<C-Space>
+
+Expect vimwiki (Only top updated):
+  * [X] Top Level
+    * [ ] Child 1
+    * [ ] Child 2
+    * [ ] Child 3
+
+Do (Toggle child 1):
+  j
+  \<C-Space>
+
+Expect vimwiki (Only child 1 updated):
+  * [ ] Top Level
+    * [X] Child 1
+    * [ ] Child 2
+    * [ ] Child 3
+
+Do (Toggle all children):
+  j
+  \<C-Space>
+  j
+  \<C-Space>
+  j
+  \<C-Space>
+
+Expect vimwiki (Only children updated):
+  * [ ] Top Level
+    * [X] Child 1
+    * [X] Child 2
+    * [X] Child 3
+
+Given vimwiki (Deeply nested list, vimwiki syntax):
+  * [ ] Top Level
+    * [ ] Child 1
+      * [X] Child 2
+
+Do (Indent child 2):
+  jj
+  a\<C-D>
+
+Expect vimwiki (Child 2 indent changed, checkmarks unchanged):
+  * [ ] Top Level
+    * [ ] Child 1
+    * [X] Child 2
+
+Do (Add child 3):
+  jj
+  o
+  Child 3
+
+Expect vimwiki (Child 3 added, checkmarks unchanged):
+  * [ ] Top Level
+    * [ ] Child 1
+      * [X] Child 2
+      * [ ] Child 3
+
+Do (Add and indent child 3):
+  jj
+  o
+  \<C-T>
+  Child 3
+
+Expect vimwiki (Child 3 added, checkmarks unchanged):
+  * [ ] Top Level
+    * [ ] Child 1
+      * [X] Child 2
+        * [ ] Child 3
+
+Execute (Clean):
+  set sw&
+
+# vim: sw=2:foldlevel=30:foldmethod=indent:

--- a/test/map.vader
+++ b/test/map.vader
@@ -7,6 +7,7 @@
 ##################
 
 Execute (VimwikiIndex):
+  call SetSyntax('markdown')
   VimwikiIndex 2
   AssertEqual 1, vimwiki#vars#get_bufferlocal('wiki_nr')
   AssertEqual 'vimwiki', &filetype


### PR DESCRIPTION
taskwiki integrates vimwiki with taskwarrior, and in doing so changes the
semantics of checkboxes a bit:

    * [ ] Install Taskwiki   |   pending task
    * [X] Install Taskwiki   |   completed task
    * [D] Install Taskwiki   |   deleted task
    * [S] Install Taskwiki   |   started task
    * [W] Install Taskwiki   |   waiting task

It's still desirable for vimwiki to automatically insert `* [ ]` on
`i_<CR>`, `o` and `O` and to syntax highlight all these five as checkboxes,
so I have this in my .vimrc:

    let g:vimwiki_listsym_rejected = 'D'
    let g:vimwiki_listsyms = ' WSX'

but it results in undesirable behaviour with task hierarchies: when I
add a new subtask (using `i_<CR>`, `o` or `O`) or mark a subtask done,
the parent's checkbox is updated to reflect its overall completion, to
one of ` `, `W`, `S` or `X`, depending on subtasks completion. This
makes little sense in taskwiki. One usually doesn't want to touch the
"parent" task in taskwarrior until the "subtasks" are done. Setting

    let g:vimwiki_listsym_rejected = 'W'
    let g:vimwiki_listsyms = ' SX'

results in slightly less illogical behaviour, but it still assumes that
(1) all subtasks are visible (not necessarily true in taskwiki) and
(2) that it's a parent/subtask relationship, not a dependency relationship
(not true in taskwarrior, questionable in taskwiki).

This commit adds an option to disable this behaviour.

---

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.