### PR TITLE
Allow VimwikiToggleListItem mapping to be replaced

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3843,6 +3843,7 @@ Contributors and their Github usernames in roughly chronological order:
     - David Sierra DiazGranados (@davidsierradz)
     - Daniel Moura (@dmouraneto)
     - Tomáš Janoušek (@liskin)
+    - Rajesh Sharem (@deepredsky)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3888,6 +3889,7 @@ New:~
     * PR #934: RSS feed generation for diary with :VimwikiRss.
 
 Changed:~
+    * PR #1047: Allow to replace default mapping of VimwikiToggleListItem
     * VimwikiCheckLinks work on current wiki or on range
 
 Removed:~

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -509,7 +509,7 @@ if str2nr(vimwiki#vars#get_global('key_mappings').lists)
   if has('unix')
     call vimwiki#u#map_key('n', '<C-@>', '<Plug>VimwikiToggleListItem')
     call vimwiki#u#map_key('v', '<C-@>', '<Plug>VimwikiToggleListItem')
-  endi
+  endif
   call vimwiki#u#map_key('n', 'glx', '<Plug>VimwikiToggleRejectedListItem')
   call vimwiki#u#map_key('v', 'glx', '<Plug>VimwikiToggleRejectedListItem', 1)
   call vimwiki#u#map_key('n', 'gln', '<Plug>VimwikiIncrementListItem')

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -505,11 +505,11 @@ nnoremap <silent><buffer> <Plug>VimwikiListO
 if str2nr(vimwiki#vars#get_global('key_mappings').lists)
   call vimwiki#u#map_key('n', 'gnt', '<Plug>VimwikiNextTask')
   call vimwiki#u#map_key('n', '<C-Space>', '<Plug>VimwikiToggleListItem')
-  call vimwiki#u#map_key('v', '<C-Space>', '<Plug>VimwikiToggleListItem', 1)
+  call vimwiki#u#map_key('v', '<C-Space>', '<Plug>VimwikiToggleListItem')
   if has('unix')
-    call vimwiki#u#map_key('n', '<C-@>', '<Plug>VimwikiToggleListItem', 1)
-    call vimwiki#u#map_key('v', '<C-@>', '<Plug>VimwikiToggleListItem', 1)
-  endif
+    call vimwiki#u#map_key('n', '<C-@>', '<Plug>VimwikiToggleListItem')
+    call vimwiki#u#map_key('v', '<C-@>', '<Plug>VimwikiToggleListItem')
+  endi
   call vimwiki#u#map_key('n', 'glx', '<Plug>VimwikiToggleRejectedListItem')
   call vimwiki#u#map_key('v', 'glx', '<Plug>VimwikiToggleRejectedListItem', 1)
   call vimwiki#u#map_key('n', 'gln', '<Plug>VimwikiIncrementListItem')


### PR DESCRIPTION
Currently VimwikiToggleListItem mapping cannot be removed but only new mapping
to it can be added. This commit will allow to add custom binding to this
function and release default mapping of `<C-space>` and `<C-@>`, which was how it
was before https://github.com/vimwiki/vimwiki/pull/686


Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.