### PR TITLE
enable changing insert mode table mappings

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -612,7 +612,14 @@ TABLE MAPPINGS, INSERT MODE                           *vimwiki-table-mappings*
 
                                                        *vimwiki_i_<Tab>_table*
 <Tab>                   Go to the next table cell, create a new row if on the
-                        last cell.
+                        last cell. Adjusts the whole column width according
+                        to the largest cell.
+                        Remap command: `<Plug>VimwikiTableNextCell`
+
+                                                       *vimwiki_i_<Tab>_table*
+<S-Tab>                 Go to the previous table cell. Adjusts the whole
+                        column width according to the largest cell.
+                        Remap command: `<Plug>VimwikiTablePrevCell`
 
 LIST MAPPINGS, INSERT MODE                             *vimwiki-list-mappings*
                                                               *vimwiki_i_<CR>*
@@ -3844,6 +3851,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Daniel Moura (@dmouraneto)
     - Tomáš Janoušek (@liskin)
     - Rajesh Sharem (@deepredsky)
+    - Amit Beka (@amitbeka)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3855,6 +3863,7 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * Feature: enable re-mapping insert mode table mappings
     * Feature: #954 #1041: Add option |vimwiki-option-listsyms_propagate| to
       disable todo propagation to parents/children
     * Issue #1009: |foldmethod| syntax works for markdown (|g:vimwiki_folding|)

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -595,9 +595,13 @@ function! s:CR(normal, just_mrkr) abort
 endfunction
 
 " insert mode table mappings
+inoremap <silent><buffer><expr> <Plug>VimwikiTableNextCell
+    \ vimwiki#tbl#kbd_tab()
+inoremap <silent><buffer><expr> <Plug>VimwikiTablePrevCell
+    \ vimwiki#tbl#kbd_shift_tab()
 if str2nr(vimwiki#vars#get_global('key_mappings').table_mappings)
-  inoremap <expr><buffer> <Tab> vimwiki#tbl#kbd_tab()
-  inoremap <expr><buffer> <S-Tab> vimwiki#tbl#kbd_shift_tab()
+  call vimwiki#u#map_key('i', '<Tab>', '<Plug>VimwikiTableNextCell')
+  call vimwiki#u#map_key('i', '<S-Tab>', '<Plug>VimwikiTablePrevCell')
 endif
 
 " <Plug> table formatting definitions


### PR DESCRIPTION
Mapping `<Tab>` and `<S-Tab>` at insert mode sometimes collide with
other plugins which utilize these for completions (e.g. coc example
mapping).

Since for many users the case for completion is more frequent than table
editing, this patch enables changing these mappings using the options
`g:vimwiki_tbl_next_cell` and `g:vimwiki_tbl_prev_cell`.

This patch makes it easier of those using multiple plugins and have no
desire or knowledge in debugging the collision.
It complements #1030 by providing a more direct and documented method
for setting custom keymappings.

Signed-off-by: Amit Beka <--->

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [X] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
