### PR TITLE
Fix Renaming issue in Windows and ext with two dot

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -62,12 +62,18 @@ function! vimwiki#base#subdir(path, filename) abort
     let filename = a:filename
   endif
   let idx = 0
+  let pathelement = split(path, '[/\\]') 
+  let fileelement = split(filename, '[/\\]')
+  let minlen = min([len(pathelement), len(fileelement)])
   "FIXME this can terminate in the middle of a path component!
-  while path[idx] ==? filename[idx]
+  while pathelement[idx] ==? fileelement[idx]
     let idx = idx + 1
+    if idx == minlen
+      break
+    endif
   endwhile
 
-  let p = split(strpart(filename, idx), '[/\\]')
+  let p = fileelement[idx:]
   let res = join(p[:-2], '/')
   if len(res) > 0
     let res = res.'/'

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -65,15 +65,16 @@ function! vimwiki#base#subdir(path, filename) abort
   let pathelement = split(path, '[/\\]') 
   let fileelement = split(filename, '[/\\]')
   let minlen = min([len(pathelement), len(fileelement)])
+  let p = fileelement[:]
   "FIXME this can terminate in the middle of a path component!
   while pathelement[idx] ==? fileelement[idx]
+    let p = p[1:]
     let idx = idx + 1
     if idx == minlen
       break
     endif
   endwhile
 
-  let p = fileelement[idx:]
   let res = join(p[:-2], '/')
   if len(res) > 0
     let res = res.'/'


### PR DESCRIPTION
Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [ ] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

In this Pull Request i fix two bugs:
- Rename not work in Windows. Fixed with replace `\` in path with `/`
- Updating link not work when wiki extension contain two dot (eg. `.wiki.md`). Fixed with using regex rather than using `fnamemodify`/`expand`.

I also refractor `vimwiki#base#rename_link` in order to simply the code and make it less bugs.