### PR TITLE
configure expression for Todo words

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -645,7 +645,7 @@ function! s:process_tags_typefaces(line, header_ids) abort
   " Convert line tag by tag
   let line = s:make_tag(line, s:rxItalic, 's:tag_em')
   let line = s:make_tag(line, s:rxBold, 's:tag_strong', a:header_ids)
-  let line = s:make_tag(line, vimwiki#vars#get_global('rxTodo'), 's:tag_todo')
+  let line = s:make_tag(line, vimwiki#vars#get_wikilocal('rx_todo'), 's:tag_todo')
   let line = s:make_tag(line, s:rxDelText, 's:tag_strike')
   let line = s:make_tag(line, s:rxSuperScript, 's:tag_super')
   let line = s:make_tag(line, s:rxSubScript, 's:tag_sub')

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -295,8 +295,6 @@ function! s:internal_global_settings() abort
   let g:vimwiki_global_vars.rxWikiInclSuffix1 = g:vimwiki_global_vars.rxWikiInclArgs.
         \ g:vimwiki_global_vars.rxWikiInclSuffix
 
-  let g:vimwiki_global_vars.rxTodo = '\C\<\%(TODO\|DONE\|STARTED\|FIXME\|FIXED\|XXX\)\>'
-
   " default colors when headers of different levels are highlighted differently
   " not making it yet another option; needed by ColorScheme autocommand
   let g:vimwiki_global_vars.hcolor_guifg_light = ['#aa5858', '#507030', '#1030a0', '#103040'
@@ -532,6 +530,7 @@ function! s:get_default_wikilocal() abort
         \ 'toc_header': {'type': type(''), 'default': 'Contents', 'min_length': 1},
         \ 'toc_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 6},
         \ 'toc_link_format': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
+        \ 'rx_todo': {'type': type(''), 'default': '\C\<\%(TODO\|DONE\|STARTED\|FIXME\|FIXED\|XXX\)\>'},
         \ }
 endfunction
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1018,7 +1018,8 @@ For Markdown syntax these variations are used: >
   ***bold_italic text*** or ___italic_bold text___
 
 Furthermore, there are a number of words which are highlighted extra flashy:
-TODO, DONE, STARTED, FIXME, FIXED, XXX.
+TODO, DONE, STARTED, FIXME, FIXED, XXX (customisable, see
+vimwiki-option-rx_todo).
 
 When rendered as HTML, code blocks containing only a hash prefixed 6 digit hex
 number will be colored as themselves.  For example >
@@ -2859,6 +2860,14 @@ Provides two colors to |:VimwikiColorize|: 'red' => red foreground and 'bred'
 
 
 ------------------------------------------------------------------------------
+*g:vimwiki-option-rx_todo*
+
+Regular expression used to highlight different TODO words.
+
+Default: `\C\<\%(TODO\|DONE\|STARTED\|FIXME\|FIXED\|XXX\)\>`
+
+
+------------------------------------------------------------------------------
 *vimwiki-option-color_tag_template*
 
 Not supposed to be edited already: a regex with __COLORFG__, __COLORBG__ and
@@ -3864,6 +3873,7 @@ https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
     * Feature: enable re-mapping insert mode table mappings
+    * Feature: configure expression for Todo words
     * Feature: #954 #1041: Add option |vimwiki-option-listsyms_propagate| to
       disable todo propagation to parents/children
     * Issue #1009: |foldmethod| syntax works for markdown (|g:vimwiki_folding|)

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -212,7 +212,7 @@ execute 'syn match VimwikiHeaderChar contained /\%(^\s*'.
       \ vimwiki#vars#get_syntaxlocal('header_symbol').'\+\)\|\%('.vimwiki#vars#get_syntaxlocal('header_symbol').
       \ '\+\s*$\)/'
 
-execute 'syntax match VimwikiTodo /'. vimwiki#vars#get_global('rxTodo') .'/'
+execute 'syntax match VimwikiTodo /'. vimwiki#vars#get_wikilocal('rx_todo') .'/'
 
 
 " Table:

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -327,6 +327,27 @@ Execute (Assert Syntax VimwikiTodo):
   AssertEqual SyntaxAt(5, 1), 'VimwikiTodo'
   AssertEqual SyntaxAt(6, 1), 'VimwikiTodo'
 
+Given vimwiki (custom TODO words):
+  NOW
+  LATER
+  DONE
+  TODO
+
+Execute (set custom syntax):
+  call vimwiki#vars#set_wikilocal('rx_todo', '\C\<\%(NOW\|LATER\|DONE\)\>', vimwiki#vars#get_bufferlocal('wiki_nr'))
+  call SetSyntax('markdown')
+
+Execute (Assert Syntax VimwikiTodo):
+  AssertEqual 'VimwikiTodo1', SyntaxAt(1, 1) . 1
+  AssertEqual 'VimwikiTodo2', SyntaxAt(2, 1) . 2
+  AssertEqual 'VimwikiTodo3', SyntaxAt(3, 1) . 3
+  AssertEqual '4'           , SyntaxAt(4, 1) . 4
+
+Execute (Restore VimwikiTodo):
+  call vimwiki#vars#init()
+  call SetSyntax('markdown')
+
+
 # Mardown types {{{2
 
 Given vimwiki (Typeface for markdown like italic):


### PR DESCRIPTION
Enable the user to conveniently set the refular expression used for the
`VimwikiTodo` syntax group, instead of the defaults which might be
more suitable to code.

Signed-off-by: Amit Beka <--->

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [X] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
