### PR TITLE
enable strikethrough for Neovim

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3895,6 +3895,7 @@ Changed:~
 Removed:~
 
 Fixed:~
+    * Enable strikethrough for Neovim
     * Issue #1029: Fix: error loading plugin when lang uses comma instead of
       dot as decimal separator
     * Issue #886: :VimwikiGenerateLinks not working on Windows

--- a/syntax/vimwiki.vim
+++ b/syntax/vimwiki.vim
@@ -437,7 +437,7 @@ hi def link VimwikiTag Keyword
 
 " Deleted called strikethrough
 " See $VIMRUTIME/syntax/html.vim
-if v:version > 800 || v:version == 800 && has('patch1038')
+if v:version > 800 || (v:version == 800 && has('patch1038')) || has('nvim-0.4.3')
   hi def VimwikiDelText term=strikethrough cterm=strikethrough gui=strikethrough
 else
   hi def link VimwikiDelText Constant


### PR DESCRIPTION
Neovim has a different method of marking applied patches, using neovim
versions, since patches from Vim are not merged by chronological order.

Signed-off-by: Amit Beka <--->

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [X] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
