### PR TITLE
Revert "Fix Renaming issue in Windows"

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -62,19 +62,12 @@ function! vimwiki#base#subdir(path, filename) abort
     let filename = a:filename
   endif
   let idx = 0
-  let pathelement = split(path, '[/\\]') 
-  let fileelement = split(filename, '[/\\]')
-  let minlen = min([len(pathelement), len(fileelement)])
-  let p = fileelement[:]
   "FIXME this can terminate in the middle of a path component!
-  while pathelement[idx] ==? fileelement[idx]
-    let p = p[1:]
+  while path[idx] ==? filename[idx]
     let idx = idx + 1
-    if idx == minlen
-      break
-    endif
   endwhile
 
+  let p = split(strpart(filename, idx), '[/\\]')
   let res = join(p[:-2], '/')
   if len(res) > 0
     let res = res.'/'


### PR DESCRIPTION
Reverts vimwiki/vimwiki#1051. My Pull Request is not finished. I have deleted commit that change `doc/vimwiki.txt`. It means the `doc/vimwiki.txt` is **not updatted**. And Also the commit name is wrong. The pull request **only fix Reaming Page in WIndows not fix renaming in two dot extension**. Two dot extension file is **bad** and it is **not standard**.