### PR TITLE
Add a flag lists_return to disable the <CR> mapping related to lists in insert mode

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -166,8 +166,8 @@ function! s:get_default_global() abort
         \ 'key_mappings': {'type': type({}), 'default':
         \   {
         \     'all_maps': 1, 'global': 1, 'headers': 1, 'text_objs': 1,
-        \     'table_format': 1, 'table_mappings': 1, 'lists': 1, 'links': 1,
-        \     'html': 1, 'mouse': 0,
+        \     'table_format': 1, 'table_mappings': 1, 'lists': 1, 'lists_return': 1,
+        \     'links': 1, 'html': 1, 'mouse': 0,
         \   }},
         \ 'links_header': {'type': type(''), 'default': 'Generated Links', 'min_length': 1},
         \ 'links_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 6},

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3609,6 +3609,9 @@ The valid key groups and their associated mappings are shown below.
     |vimwiki_glsar|, |vimwiki_gLstar|, |vimwiki_gl#|, |vimwiki_gL#|, |vimwiki_gl-|, |vimwiki_gL-|
     |vimwiki_gl1|, |vimwiki_gL1|, |vimwiki_gla|, |vimwiki_gLa|, |vimwiki_glA|, |vimwiki_gLA|
     |vimwiki_gli|, |vimwiki_gLi|, |vimwiki_glI|, |vimwiki_gLI|, |vimwiki_glx|
+`lists_return`:
+    Mappings for lists return in insert mode.
+    |vimwiki_i_<CR>|, |vimwiki_i_<S-CR>|
 `links`:
     Mappings for link creation and navigation.
     |vimwiki_<Leader>w<Leader>i|, |vimwiki_<CR>|, |vimwiki_<S-CR>|, |vimwiki_<C-CR>|
@@ -3861,6 +3864,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Tomáš Janoušek (@liskin)
     - Rajesh Sharem (@deepredsky)
     - Amit Beka (@amitbeka)
+    - Yuuy Wei
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3872,6 +3876,8 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * Feature: PR #686: add a flag lists_return to disable mappings 
+      to <CR> and <S-CR> in insert mode
     * Feature: enable re-mapping insert mode table mappings
     * Feature: configure expression for Todo words
     * Feature: #954 #1041: Add option |vimwiki-option-listsyms_propagate| to

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -535,20 +535,23 @@ if str2nr(vimwiki#vars#get_global('key_mappings').lists)
   call vimwiki#u#map_key('n', 'o', '<Plug>VimwikiListo')
   call vimwiki#u#map_key('n', 'O', '<Plug>VimwikiListO')
 
-  " Handle case of existing VimwikiReturn mappings outside the <Plug> definition
-  " Note: Avoid interfering with popup/completion menu if it's active (#813)
-  if maparg('<CR>', 'i') !~# '.*VimwikiReturn*.'
-    if has('patch-7.3.489')
-      " expand iabbrev on enter
-      inoremap <expr><silent><buffer> <CR> pumvisible() ? '<CR>' : '<C-]><Esc>:VimwikiReturn 1 5<CR>'
-    else
-      inoremap <expr><silent><buffer> <CR> pumvisible() ? '<CR>' : '<Esc>:VimwikiReturn 1 5<CR>'
+  " Set lists_return to 0, if you don't want <CR> mapped to VimwikiReturn
+  if str2nr(vimwiki#vars#get_global('key_mappings').lists_return)
+    " Handle case of existing VimwikiReturn mappings outside the <Plug> definition
+    " Note: Avoid interfering with popup/completion menu if it's active (#813)
+    if maparg('<CR>', 'i') !~# '.*VimwikiReturn*.'
+      if has('patch-7.3.489')
+        " expand iabbrev on enter
+        inoremap <expr><silent><buffer> <CR> pumvisible() ? '<CR>' : '<C-]><Esc>:VimwikiReturn 1 5<CR>'
+      else
+        inoremap <expr><silent><buffer> <CR> pumvisible() ? '<CR>' : '<Esc>:VimwikiReturn 1 5<CR>'
+      endif
+    endif
+    if  maparg('<S-CR>', 'i') !~# '.*VimwikiReturn*.'
+      inoremap <expr><silent><buffer> <S-CR> pumvisible() ? '<CR>' : '<Esc>:VimwikiReturn 2 2<CR>'
     endif
   endif
-  if  maparg('<S-CR>', 'i') !~# '.*VimwikiReturn*.'
-    inoremap <expr><silent><buffer> <S-CR> pumvisible() ? '<CR>' : '<Esc>:VimwikiReturn 2 2<CR>'
-  endif
-
+  
   " change symbol for bulleted lists
   for s:char in vimwiki#vars#get_syntaxlocal('bullet_types')
     if !hasmapto(':VimwikiChangeSymbolTo '.s:char.'<CR>')


### PR DESCRIPTION
# Problem
[Vimwiki](https://github.com/vimwiki/vimwiki) is what I want, but I got a problem when I am using it.
My input method switches unexpectedly when I hit Enter with the plug-in [vim-im-select](https://github.com/brglng/vim-im-select).
I am sure this is caused by the mapping to Enter in insert mode after reading the help doc and modifying the source code.

# solving
#686 provides us a option to disable the key mappings by group.
Unfortunately I have to disable all the mappings to lists to avoid the problem. 
But I want keep other lists key mappings in normal mode and insert mode accessible.
So I add a new flag `lists_return` to have a choice to disable the Enter key related to lists in insert mode.

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
