### PR TITLE
Add option to configure date string format

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1803,7 +1803,7 @@ function! s:convert_file_to_lines(wikifile, current_html_file) abort
 
   let result['template_name'] = template_name
   let result['title'] = s:process_title(placeholders, fnamemodify(a:wikifile, ':t:r'))
-  let result['date'] = s:process_date(placeholders, strftime('%Y-%m-%d'))
+  let result['date'] = s:process_date(placeholders, strftime(vimwiki#vars#get_wikilocal('template_date_format')))
   let result['wiki_path'] = strpart(s:current_wiki_file, strlen(vimwiki#vars#get_wikilocal('path')))
 
   return result

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -518,6 +518,7 @@ function! s:get_default_wikilocal() abort
         \ 'template_default': {'type': type(''), 'default': 'default', 'min_length': 1},
         \ 'template_ext': {'type': type(''), 'default': '.tpl'},
         \ 'template_path': {'type': type(''), 'default': $HOME . '/vimwiki/templates/'},
+        \ 'template_date_format': {'type': type(''), 'default': '%Y-%m-%d'},
         \ 'text_ignore_newline': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'tag_format': {'type': type({}), 'default': {
         \   'pre': '^\|\s',

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3889,8 +3889,6 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
-    * Feature: Add option |vimwiki-option-template_date_format| to configure
-      alternative date string format
     * Feature: PR #686: add a flag lists_return to disable mappings 
       to <CR> and <S-CR> in insert mode
     * Feature: enable re-mapping insert mode table mappings
@@ -3927,6 +3925,8 @@ New:~
     * PR #907: Cycle bullets
     * PR #901: adds multiparagraph blockquotes using email style syntax
     * PR #934: RSS feed generation for diary with :VimwikiRss.
+    * Feature: Add option |vimwiki-option-template_date_format| to configure
+      alternative date string format
 
 Changed:~
     * PR #1047: Allow to replace default mapping of VimwikiToggleListItem

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1691,7 +1691,8 @@ See |vimwiki-option-template_path| for details.
 %date                                                           *vimwiki-date*
 
 The date of the wiki page. The value can be used in the HTML template, see
-|vimwiki-option-template_path| for details.
+|vimwiki-option-template_path| for details. To set a specific date string
+format, see |vimwiki-option-template_date_format| for details.
 
 %date 2017-07-08
 %date
@@ -2373,6 +2374,17 @@ Description~
 Setup template filename extension.
 
 See |vimwiki-option-template_path| for details.
+
+
+*vimwiki-option-template_date_format*
+------------------------------------------------------------------------------
+Key                     Default value~
+template_date_format    %Y-%m-%d
+
+Description~
+Setup date string format in templates.
+
+See |vimwiki-date| for details.
 
 
 *vimwiki-option-css_name*
@@ -3865,6 +3877,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Rajesh Sharem (@deepredsky)
     - Amit Beka (@amitbeka)
     - Yuuy Wei
+    - Yifan Hu (@yhu266)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3876,6 +3889,8 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * Feature: Add option |vimwiki-option-template_date_format| to configure
+      alternative date string format
     * Feature: PR #686: add a flag lists_return to disable mappings 
       to <CR> and <S-CR> in insert mode
     * Feature: enable re-mapping insert mode table mappings


### PR DESCRIPTION
This PR adds option `template_date_format` to configure string format of `%date%` in html templates.

---

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
