### PR TITLE
Default to wiki number 0 if diary is called outside a wiki buffer

### DIFF
--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -37,6 +37,17 @@ endfunction
 
 function! vimwiki#diary#diary_date_link(...) abort
   " Return: <String> date
+
+  let wiki_nr = vimwiki#vars#get_bufferlocal('wiki_nr')
+  if wiki_nr < 0  " this happens when called outside a wiki buffer
+    let wiki_nr = 0
+  endif
+
+  if wiki_nr >= vimwiki#vars#number_of_wikis()
+    call vimwiki#u#error('Wiki '.wiki_nr.' is not registered in g:vimwiki_list!')
+    return
+  endif
+
   if a:0
     let l:timestamp = a:1
   else
@@ -56,10 +67,10 @@ function! vimwiki#diary#diary_date_link(...) abort
         \ 'friday': 5, 'saturday': 6,
         \ 'sunday': 0}
 
-  let l:frequency = vimwiki#vars#get_wikilocal('diary_frequency')
+  let l:frequency = vimwiki#vars#get_wikilocal('diary_frequency', wiki_nr)
 
   if l:frequency ==? 'weekly'
-    let l:start_week_day = vimwiki#vars#get_wikilocal('diary_start_week_day')
+    let l:start_week_day = vimwiki#vars#get_wikilocal('diary_start_week_day', wiki_nr)
     let l:weekday_num = str2nr(strftime('%w', l:timestamp))
     let l:days_to_end_of_week = (7-l:weekday_number[l:start_week_day]+weekday_num) % 7
     let l:computed_timestamp = l:timestamp


### PR DESCRIPTION
If a diary page is opened from outside a wiki buffer the diary frequency
and start of week options are not respected as the wiki number is not
yet set for the local buffer.

Fix this by defaulting the wiki number to 0, which is what is done in
vimwiki#diary#make_note() for the diary_rel_path option that suffers
from the same problem.

Example on how to trigger the problem:

    let g:vimwiki_list = [{'path': '~/.vimwiki', 'diary_frequency': 'weekly', 'diary_start_week_day': 'monday'}]

    $ vim -c VimwikiMakeDiaryNote

Fixes: a3be479d5a5fc290 ("Add a diary frequency option (#884)")
Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>

Steps for submitting a pull request:

- [ ] **ALL** pull requests should be made against the `dev` branch!
- [ ] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
- [ ] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
