### PR TITLE
Restore <C-@> list item toggle on Unix systems

### DIFF
--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -509,11 +509,13 @@ nnoremap <silent><buffer> <Plug>VimwikiListO
 " Declare Map: default lists key mappings (again)
 if str2nr(vimwiki#vars#get_global('key_mappings').lists)
   call vimwiki#u#map_key('n', 'gnt', '<Plug>VimwikiNextTask')
-  call vimwiki#u#map_key('n', '<C-Space>', '<Plug>VimwikiToggleListItem')
-  call vimwiki#u#map_key('v', '<C-Space>', '<Plug>VimwikiToggleListItem')
-  if has('unix')
-    call vimwiki#u#map_key('n', '<C-@>', '<Plug>VimwikiToggleListItem')
-    call vimwiki#u#map_key('v', '<C-@>', '<Plug>VimwikiToggleListItem')
+  if !hasmapto('<Plug>VimwikiToggleListItem')
+    call vimwiki#u#map_key('n', '<C-Space>', '<Plug>VimwikiToggleListItem')
+    call vimwiki#u#map_key('v', '<C-Space>', '<Plug>VimwikiToggleListItem', 1)
+    if has('unix')
+      call vimwiki#u#map_key('n', '<C-@>', '<Plug>VimwikiToggleListItem', 1)
+      call vimwiki#u#map_key('v', '<C-@>', '<Plug>VimwikiToggleListItem', 1)
+    endif
   endif
   call vimwiki#u#map_key('n', 'glx', '<Plug>VimwikiToggleRejectedListItem')
   call vimwiki#u#map_key('v', 'glx', '<Plug>VimwikiToggleRejectedListItem', 1)


### PR DESCRIPTION
A changed aimed to allow user configuration files to be able to override
all default mappings for the VimwikiToggleListItem plug did so by
removing the optional forth argument to vimwiki#u#map_key(). This
argument if set to 1 allows the same plug to be mapped to multiple keys
in the same mode. If not present only the first mapping takes effect and
all later attempts to map the plug in the same mode result in a no-op.
Thus allowing any user configuration to set it first and then 'skipping'
the defaults.

The change however did not account for that the default on Unix systems
was to map both <C-Space> _and_ <C-@> to VimwikiToggleListItem so the
change breaks this behavior, described in issue #1061.

Fix this by restoring the forth argument to vimwiki#u#map_key() to allow
multiple mappings to the same plug/mode but wrap it in a block to first
check if the user have overridden it or not. This goes back to how his
was handled before vimwiki#u#map_key() was added in [1].

1. 4106cb7bc739a45f ("New option g:vimwiki_key_mappings to enable/disable key mappings.")

Fixes: 48baa1f4cd1bb496 ("Allow VimwikiToggleListItem mapping to be replaced (#1047)")
Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
