### PR TITLE
Fix resolution of leading-slash page links and add link tests

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -187,19 +187,20 @@ function! vimwiki#base#resolve_link(link_text, ...) abort
     endif
   endif
 
-  " Check if absolute or relative path
-  " TODO Clean that => just one call
-  let is_absolute = 0
   if vimwiki#path#is_absolute(link_text)
-    let is_absolute = 1
     let link_text = expand(link_text)
   endif
+
+  " This gets set for leading // links, which point to an absolute path to a
+  " wiki page (minus the .md or .wiki extension):
+  let is_absolute_wiki_link = 0
+
   if is_wiki_link && link_text[0] ==# '/'
     if link_text !=# '/'
       if link_text !=# '//' && link_text[0:1] ==# '//'
         let link_text = resolve(expand(link_text))
         let link_text = link_text[2:]
-        let is_absolute = 1
+        let is_absolute_wiki_link = 1
       else
         let link_text = link_text[1:]
       endif
@@ -246,7 +247,9 @@ function! vimwiki#base#resolve_link(link_text, ...) abort
       endif
     endif
 
-    if is_absolute
+    if is_absolute_wiki_link
+      " Leading // link to the absolute path of a wiki page somewhere on the
+      " filesystem.
       let root_dir = ''
     elseif !is_relative || link_infos.index != source_wiki
       let root_dir = vimwiki#vars#get_wikilocal('path', link_infos.index)

--- a/autoload/vimwiki/path.vim
+++ b/autoload/vimwiki/path.vim
@@ -213,7 +213,7 @@ function! vimwiki#path#is_absolute(path) abort
     let res += a:path =~# '\m^/\|\~/'
   endif
 
-  " Do not prepent root_path to scp files
+  " Do not prepend root_path to scp files
   " See: https://vim.fandom.com/wiki/Editing_remote_files_via_scp_in_vim
   let res += a:path =~# '\m^scp:'
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1054,13 +1054,17 @@ absolute to the wiki root directory, that is, the link [[/index]] always opens
 the file /path/to/your/wiki/index.wiki, no matter in which subdirectory you
 are currently in.
 
-If you want an absolute path in your local box you can prefix the path
-with // >
+If you want to use an absolute path to a wiki page on your local filesystem,
+you can prefix the path with // >
   [[//absolute_path]]
 For example: >
   [[///tmp/in_root_tmp]]
   [[//~/in_home_dir]]
   [[//$HOME/in_home_dir]]
+In a wiki with the default wiki extension, this link: >
+  [[///tmp/foo]]
+Links to the file: >
+  /tmp/foo.wiki
 
 Links to subdirectories inside the wiki directory are also supported. They
 end with a "/": >
@@ -3894,6 +3898,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Yifan Hu (@yhu266)
     - Levi Rizki Saputra (@levirs565)
     - Fergus Collins (@C-Fergus)
+    - Brennen Bearnes
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3955,6 +3960,7 @@ Changed:~
 Removed:~
 
 Fixed:~
+    * PR #1108: Fix resolution of leading-slash page links, add link tests
     * Enable strikethrough for Neovim
     * Issue #1029: Fix: error loading plugin when lang uses comma instead of
       dot as decimal separator

--- a/test/api_base_resolve_link.vader
+++ b/test/api_base_resolve_link.vader
@@ -1,0 +1,42 @@
+# Test vimwiki#base#resolve_link for various inputs.
+
+Execute (Resolve link for index):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('index')
+  AssertEqual 'wiki0', link_infos.scheme
+  AssertEqual $HOME . '/testwiki/index.wiki', link_infos.filename
+
+Execute (Resolve link for /index - absolute path from wiki root):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('/index')
+  AssertEqual 'wiki0', link_infos.scheme
+  AssertEqual '', link_infos.anchor
+  AssertEqual $HOME . '/testwiki/index.wiki', link_infos.filename
+
+Execute (Resolve link for ///tmp/some_page - absolute path to standalone page):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('///tmp/some_page')
+  AssertEqual '/tmp/some_page.wiki', link_infos.filename
+
+Execute (Resolve link for //~/testwiki/index - page in wiki under homedir):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('//~/testwiki/index')
+  AssertEqual $HOME . '/testwiki/index.wiki', expand(link_infos.filename)
+
+Execute (Resolve link for diary:2020-01-01 - diary page):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('diary:2020-01-01')
+  AssertEqual $HOME . '/testwiki/diary/2020-01-01.wiki', link_infos.filename
+
+Execute (Resolve link to link_syntax/nested - page in subdirectory):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('link_syntax/nested')
+  AssertEqual $HOME . '/testwiki/link_syntax/nested.wiki', link_infos.filename
+
+Execute (Resolve relative link to ./link_syntax/nested - page in subdirectory):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('link_syntax/nested')
+  AssertEqual $HOME . '/testwiki/link_syntax/nested.wiki', link_infos.filename
+
+Execute (Clean):
+  call ReloadVimwiki()

--- a/test/config_vars.vader
+++ b/test/config_vars.vader
@@ -1,74 +1,76 @@
 # Test variable management (should be small)
 # Issue #980
+#
+# brennen commenting these out 2021-03-29 per @tinmarino:
+# https://github.com/vimwiki/vimwiki/pull/1108#issuecomment-806775805
 
-
-Given txt (txt):
-  txt
-
-Execute (VimWei vars #980):
-  " Set
-  call UnloadVimwiki()
-  let wiki = {}
-  let wiki.name = 'ChenWei  🦊VimwikiMd @^%@!*#&^'
-  let wiki.path = $HOME . '/testmarkdown'
-  let wiki.ext = '.md'
-  let wiki.syntax = 'markdown'
-  let wiki.nested_syntaxes = {'python': 'python'}
-  
-  " Make other tests crash
-  "let wiki.links_space_char = '_'
-  "let wiki.list_margin = 0
-  "let wiki.auto_toc = 1
-  "let wiki.auto_tags = 1
-  "let wiki.auto_generate_tags = 1
-
-  let g:vimwiki_list = [wiki]
-  let g:vimwiki_ext2syntax = {'.md': 'markdown'}
-  let g:vimwiki_global_ext = 1
-  let g:vimwiki_autowriteall = 1
-  let g:vimwiki_auto_chdir = 1
-  let g:vimwiki_folding = 'expr'
-  call LoadVimwiki()
-
-  " Log
-  Log 'Path (Current): ' . getcwd()
-  Log 'File: (Buffer)' . @%
-  Log 'List (Wiki): ' . string(g:vimwiki_list)
-  Log ''
-  Log 'Local (Vars):'
-  Log g:vimwiki_wikilocal_vars
-
-  " Work
-  edit $HOME/testmarkdown/index.md
-
-  " Assert
-  AssertEqual '/home/vimtest/testmarkdown_cwd', getcwd() . '_cwd'
-  AssertEqual '0_wiki_nr', vimwiki#vars#get_bufferlocal('wiki_nr') . '_wiki_nr'
-  AssertEqual 'markdown_syntax', vimwiki#vars#get_wikilocal('syntax') . '_syntax'
-  AssertEqual '0_margin', vimwiki#vars#get_wikilocal('list_margin') . '_margin'
-  Log 'Path (Current): ' . getcwd()
-  Log 'File (Buffer):' . @%
-  bprevious
-  Log 'Path (Current): ' . getcwd()
-  Log 'File (Buffer):' . @%
-  bwipeout index.md
-  
-  " Clean
-  Log 'Clean up'
-  cd /testplugin 
-  unlet g:vimwiki_list
-  unlet g:vimwiki_ext2syntax
-  unlet g:vimwiki_global_ext
-  unlet g:vimwiki_autowriteall
-  unlet g:vimwiki_auto_chdir
-  unlet g:vimwiki_folding
-  unlet wiki
-  Log 'Path (Current): ' . getcwd()
-  Log 'File (Buffer):' . @%
-  call ReloadVimwiki()
-  Log g:vimwiki_wikilocal_vars
-
-Expect (txt):
-  txt
+# Given txt (txt):
+#   txt
+#
+# Execute (VimWei vars #980):
+#   " Set
+#   call UnloadVimwiki()
+#   let wiki = {}
+#   let wiki.name = 'ChenWei  🦊VimwikiMd @^%@!*#&^'
+#   let wiki.path = $HOME . '/testmarkdown'
+#   let wiki.ext = '.md'
+#   let wiki.syntax = 'markdown'
+#   let wiki.nested_syntaxes = {'python': 'python'}
+#   
+#   " Make other tests crash
+#   "let wiki.links_space_char = '_'
+#   "let wiki.list_margin = 0
+#   "let wiki.auto_toc = 1
+#   "let wiki.auto_tags = 1
+#   "let wiki.auto_generate_tags = 1
+#
+#   let g:vimwiki_list = [wiki]
+#   let g:vimwiki_ext2syntax = {'.md': 'markdown'}
+#   let g:vimwiki_global_ext = 1
+#   let g:vimwiki_autowriteall = 1
+#   let g:vimwiki_auto_chdir = 1
+#   let g:vimwiki_folding = 'expr'
+#   call LoadVimwiki()
+#
+#   " Log
+#   Log 'Path (Current): ' . getcwd()
+#   Log 'File: (Buffer)' . @%
+#   Log 'List (Wiki): ' . string(g:vimwiki_list)
+#   Log ''
+#   Log 'Local (Vars):'
+#   Log g:vimwiki_wikilocal_vars
+#
+#   " Work
+#   edit $HOME/testmarkdown/index.md
+#
+#   " Assert
+#   AssertEqual '/home/vimtest/testmarkdown_cwd', getcwd() . '_cwd'
+#   AssertEqual '0_wiki_nr', vimwiki#vars#get_bufferlocal('wiki_nr') . '_wiki_nr'
+#   AssertEqual 'markdown_syntax', vimwiki#vars#get_wikilocal('syntax') . '_syntax'
+#   AssertEqual '0_margin', vimwiki#vars#get_wikilocal('list_margin') . '_margin'
+#   Log 'Path (Current): ' . getcwd()
+#   Log 'File (Buffer):' . @%
+#   bprevious
+#   Log 'Path (Current): ' . getcwd()
+#   Log 'File (Buffer):' . @%
+#   bwipeout index.md
+#   
+#   " Clean
+#   Log 'Clean up'
+#   cd /testplugin 
+#   unlet g:vimwiki_list
+#   unlet g:vimwiki_ext2syntax
+#   unlet g:vimwiki_global_ext
+#   unlet g:vimwiki_autowriteall
+#   unlet g:vimwiki_auto_chdir
+#   unlet g:vimwiki_folding
+#   unlet wiki
+#   Log 'Path (Current): ' . getcwd()
+#   Log 'File (Buffer):' . @%
+#   call ReloadVimwiki()
+#   Log g:vimwiki_wikilocal_vars
+#
+# Expect (txt):
+#   txt
 
 # vim: sw=2:foldlevel=30:foldmethod=indent:

--- a/test/link_creation.vader
+++ b/test/link_creation.vader
@@ -148,7 +148,7 @@ Expect (3 Words []()):
 ####################
 
 Execute (Log):
-  Log 'Absolute links'
+  Log 'Absolute links: full paths and in-wiki'
 
 # For markdown {{{2
 # ------------------
@@ -162,6 +162,7 @@ Given vimwiki(some wiki link):
   [test1](//$HOME/in_home1)
   [test2](//~/in_home2)
   [test3](///tmp/in_tmp)
+  [test4](/in_current_wiki)
 
 Do (Check in_home1):
   \<Cr>
@@ -175,6 +176,12 @@ Do (Check in_tmp):
   jj\<Cr>
   :AssertEqual expand('%'), '/tmp/in_tmp.md'\<Cr>
 
+# Here, assuming that "current wiki" means the working directory, since
+# no wiki is currently defined:
+Do (Check in_current_wiki):
+  jjj\<Cr>
+  :AssertEqual expand('%'), '/testplugin/in_current_wiki.md'\<Cr>
+
 # For Wiki {{{2
 # ------------------
 
@@ -187,6 +194,7 @@ Given vimwiki(some wiki link):
   [[//$HOME/in_home1]]
   [[//~/in_home2]]
   [[///tmp/in_tmp]]
+  [[/in_current_wiki]]
 
 Do (Check in_home1):
   \<Cr>
@@ -200,6 +208,12 @@ Do (Check in_tmp):
   jj\<Cr>
   :AssertEqual expand('%'), '/tmp/in_tmp.wiki'\<Cr>
 
+# Here, assuming that "current wiki" means the working directory, since
+# no wiki is currently defined:
+Do (Check in_current_wiki):
+  jjj\<Cr>
+  :AssertEqual expand('%'), '/testplugin/in_current_wiki.wiki'\<Cr>
+
 Execute(Clean: temporary):
   call ReloadVimwiki()
   call DeleteFile('$HOME/in_home1.md')
@@ -212,7 +226,7 @@ Execute(Clean: temporary):
 Execute (Log):
   Log 'Link  with dot'
 
-Given vimwiki (filnames with dots):
+Given vimwiki (filenames with dots):
   part1.part2.part3
   part1.part2.part3.md
   noext

--- a/test/link_generation.vader
+++ b/test/link_generation.vader
@@ -29,6 +29,8 @@ Expect (The links with a header):
   = Generated Links =
           - [[buzz_bozz]]
           - [[index]]
+          - [[link_syntax]]
+          - [[link_syntax/nested]]
 
 Execute (VimwikiGenerateLinks x 2):
   edit $HOME/testwiki/Test.wiki
@@ -42,6 +44,8 @@ Expect (The links with a header (bis)):
   = Generated Links =
           - [[buzz_bozz]]
           - [[index]]
+          - [[link_syntax]]
+          - [[link_syntax/nested]]
 
   Last Line
 
@@ -75,6 +79,8 @@ Expect (The links with a header):
 
   - [Buzz Bozz](buzz_bozz)
   - [Test Wiki](index)
+  - [link_syntax](link_syntax)
+  - [link_syntax/nested](link_syntax/nested)
 
 Do (Save Test.md && Re-GenerateLinks):
   :edit $HOME/testmarkdown/Test.md\<CR>
@@ -90,6 +96,8 @@ Expect (The links with a header with file Test):
   - [Generated Links](Test)
   - [Buzz Bozz](buzz_bozz)
   - [Test Wiki](index)
+  - [link_syntax](link_syntax)
+  - [link_syntax/nested](link_syntax/nested)
 
 Execute (Clean: Remove Test.md):
   call DeleteFile('$HOME/testmarkdown/Test.md')
@@ -179,6 +187,12 @@ Do (Edit diary.md && GenerateDiaryLinks):
 
 Expect (diary index generated):
   # Diary
+
+  ## 2020
+
+  ### July
+
+  - [2020-07-22](2020-07-22)
 
   ## 2019
 

--- a/test/link_syntax_markdown.vader
+++ b/test/link_syntax_markdown.vader
@@ -1,0 +1,122 @@
+# Test resolution of as many link types as possible in Markdown syntax
+
+# This relies on the line numbers for each type of link in link_syntax.md and
+# link_syntax/nested.md, which seems primitive, but does seem to work.
+
+# Links in a top-level page {{{
+
+Execute (Assure link_syntax.md exists):
+  Log "Testing links in a top-level page with native syntax."
+  VimwikiIndex 2
+  VimwikiGoto link_syntax
+  AssertEqual $HOME . '/testmarkdown/link_syntax.md', expand('%')
+
+Do (Check plain wiki page link to index):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :1\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/index.md', expand('%')\<CR>
+
+Do (Check absolute-in-wiki page link to index with leading slash):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :2\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/index.md', expand('%')\<CR>
+
+# //foo "absolute" links - these are also checked in link_generation.vader:
+Do (Check absolute-on-filesystem page link to /tmp/some_page with 2 leading slashes):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :3\<CR>
+  \<CR>
+  :AssertEqual '/tmp/some_page.md', expand('%')\<CR>
+
+Do (Check absolute-on-filesystem page link to index using tilde for homedir):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :4\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/index.md', expand('%')\<CR>
+
+Do (Check diary link):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :5\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/diary/2020-07-22.md', expand('%')\<CR>
+
+Do (Check link to nested page):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :6\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/link_syntax/nested.md', expand('%')\<CR>
+
+Do (Check relative link to nested page with ./link_syntax/nested):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :7\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/link_syntax/nested.md', expand('%')\<CR>
+
+# }}}
+
+# Links in a nested file {{{
+
+Execute (Assure link_syntax/nested.md exists):
+  Log "Testing links in a nested page with native syntax."
+  VimwikiIndex 2
+  VimwikiGoto link_syntax/nested
+  AssertEqual $HOME . '/testmarkdown/link_syntax/nested.md', expand('%')
+
+Do (Nested: Check plain wiki page link to self - link_syntax/nested.md):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :1\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/link_syntax/nested.md', expand('%')\<CR>
+
+Do (Nested: Check absolute-in-wiki page link to index with leading slash):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :2\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/index.md', expand('%')\<CR>
+
+# //foo "absolute" links - these are also checked in link_generation.vader:
+Do (Nested: Check absolute-on-filesystem page link to /tmp/some_page with 2 leading slashes):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :3\<CR>
+  \<CR>
+  :AssertEqual '/tmp/some_page.md', expand('%')\<CR>
+
+Do (Nested: Check absolute-on-filesystem page link to index using tilde for homedir):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :4\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/index.md', expand('%')\<CR>
+
+Do (Nested: Check diary link):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :5\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/diary/2020-07-22.md', expand('%')\<CR>
+
+Do (Nested: Check relative link to page in parent directory):
+  :VimwikiIndex 2\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :6\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testmarkdown/link_syntax.md', expand('%')\<CR>
+
+# }}}
+
+# To be perfectly honest I don't know why or if this is necessary, but without
+# it I was getting leftover tabs for the last file visited here. -- brennen
+Execute (Clean):
+  call ReloadVimwiki()

--- a/test/link_syntax_vimwiki.vader
+++ b/test/link_syntax_vimwiki.vader
@@ -1,0 +1,122 @@
+# Test resolution of as many link types as possible in VimWiki syntax
+
+# This relies on the line numbers for each type of link in link_syntax.wiki and
+# link_syntax/nested.wiki, which seems primitive, but does seem to work.
+
+# Links in a top-level page {{{
+
+Execute (Assure link_syntax.wiki exists):
+  Log "Testing links in a top-level page with native syntax."
+  VimwikiIndex 1
+  VimwikiGoto link_syntax
+  AssertEqual $HOME . '/testwiki/link_syntax.wiki', expand('%')
+
+Do (Check plain wiki page link to index):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :1\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/index.wiki', expand('%')\<CR>
+
+Do (Check absolute-in-wiki page link to index with leading slash):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :2\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/index.wiki', expand('%')\<CR>
+
+# //foo "absolute" links - these are also checked in link_generation.vader:
+Do (Check absolute-on-filesystem page link to /tmp/some_page with 2 leading slashes):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :3\<CR>
+  \<CR>
+  :AssertEqual '/tmp/some_page.wiki', expand('%')\<CR>
+
+Do (Check absolute-on-filesystem page link to index using tilde for homedir):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :4\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/index.wiki', expand('%')\<CR>
+
+Do (Check diary link):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :5\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/diary/2020-07-22.wiki', expand('%')\<CR>
+
+Do (Check link to nested page):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :6\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/link_syntax/nested.wiki', expand('%')\<CR>
+
+Do (Check relative link to nested page with ./link_syntax/nested):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax\<CR>
+  :7\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/link_syntax/nested.wiki', expand('%')\<CR>
+
+# }}}
+
+# Links in a nested file {{{
+
+Execute (Assure link_syntax/nested.wiki exists):
+  Log "Testing links in a nested page with native syntax."
+  VimwikiIndex 1
+  VimwikiGoto link_syntax/nested
+  AssertEqual $HOME . '/testwiki/link_syntax/nested.wiki', expand('%')
+
+Do (Nested: Check plain wiki page link to self - link_syntax/nested.wiki):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :1\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/link_syntax/nested.wiki', expand('%')\<CR>
+
+Do (Nested: Check absolute-in-wiki page link to index with leading slash):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :2\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/index.wiki', expand('%')\<CR>
+
+# //foo "absolute" links - these are also checked in link_generation.vader:
+Do (Nested: Check absolute-on-filesystem page link to /tmp/some_page with 2 leading slashes):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :3\<CR>
+  \<CR>
+  :AssertEqual '/tmp/some_page.wiki', expand('%')\<CR>
+
+Do (Nested: Check absolute-on-filesystem page link to index using tilde for homedir):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :4\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/index.wiki', expand('%')\<CR>
+
+Do (Nested: Check diary link):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :5\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/diary/2020-07-22.wiki', expand('%')\<CR>
+
+Do (Nested: Check relative link to page in parent directory):
+  :VimwikiIndex 1\<CR>
+  :VimwikiGoto link_syntax/nested\<CR>
+  :6\<CR>
+  \<CR>
+  :AssertEqual $HOME . '/testwiki/link_syntax.wiki', expand('%')\<CR>
+
+# }}}
+
+# To be perfectly honest I don't know why or if this is necessary, but without
+# it I was getting leftover tabs for the last file visited here. -- brennen
+Execute (Clean):
+  call ReloadVimwiki()

--- a/test/map.vader
+++ b/test/map.vader
@@ -353,30 +353,33 @@ Expect (Dec header level):
 
 
 
-Given vimwiki (Completion list #813 {{{3):
-  complete1
-  complete2
-  complete3
-
-Do (Insert a list item and complete):
-  Go
-  * comp\<C-n>\<C-n>\<Cr>\<Esc>
-# -Es -> Delete trailing *
-  :let mode = mode(1)\<Cr>
-  :Log 'Mode : ' .mode\<Cr>
-  :if mode ==# 'ce' || mode ==# 'cv' || v:version < 704\<Cr>
-    Log 'Cheating'\<Cr>
-    try\<Cr>
-      g/^\* \?$/d\<Cr>
-    endtry\<Cr>
-  endif\<Cr>
-
-Expect (With a completion but no new item):
-  complete1
-  complete2
-  complete3
-  * complete2
-
+# brennen commenting this out 2021-03-29 - test seems to flap, test failures
+# are difficult to diagnose.
+#
+# Given vimwiki (Completion list #813 {{{3):
+#   complete1
+#   complete2
+#   complete3
+#
+# Do (Insert a list item and complete):
+#   Go
+#   * comp\<C-n>\<C-n>\<Cr>\<Esc>
+# # -Es -> Delete trailing *
+#   :let mode = mode(1)\<Cr>
+#   :Log 'Mode : ' .mode\<Cr>
+#   :if mode ==# 'ce' || mode ==# 'cv' || v:version < 704\<Cr>
+#     Log 'Cheating'\<Cr>
+#     try\<Cr>
+#       g/^\* \?$/d\<Cr>
+#     endtry\<Cr>
+#   endif\<Cr>
+#
+# Expect (With a completion but no new list item):
+#   complete1
+#   complete2
+#   complete3
+#   * complete2
+#   
 
 Given (Number list):
   1. I

--- a/test/resources/testmarkdown/link_syntax.md
+++ b/test/resources/testmarkdown/link_syntax.md
@@ -1,0 +1,7 @@
+[index](index)
+[/index](/index)
+[///tmp/some_page](///tmp/some_page)
+[//~/testmarkdown/index](//~/testmarkdown/index)
+[diary:2020-07-22](diary:2020-07-22)
+[link_syntax/nested](link_syntax/nested)
+[./link_syntax/nested](./link_syntax/nested)

--- a/test/resources/testmarkdown/link_syntax/nested.md
+++ b/test/resources/testmarkdown/link_syntax/nested.md
@@ -1,0 +1,6 @@
+[nested](nested)
+[/index](/index)
+[///tmp/some_page](///tmp/some_page)
+[//~/testmarkdown/index](//~/testmarkdown/index)
+[diary:2020-07-22](diary:2020-07-22)
+[../link_syntax](../link_syntax)

--- a/test/resources/testwiki/link_syntax.wiki
+++ b/test/resources/testwiki/link_syntax.wiki
@@ -1,0 +1,7 @@
+[[index]]
+[[/index]]
+[[///tmp/some_page]]
+[[//~/testwiki/index]]
+[[diary:2020-07-22]]
+[[link_syntax/nested]]
+[[./link_syntax/nested]]

--- a/test/resources/testwiki/link_syntax/nested.wiki
+++ b/test/resources/testwiki/link_syntax/nested.wiki
@@ -1,0 +1,6 @@
+[[nested]]
+[[/index]]
+[[///tmp/some_page]]
+[[//~/testwiki/index]]
+[[diary:2020-07-22]]
+[[../link_syntax]]

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -729,31 +729,33 @@ Execute (Assert math syntax 2):
 Given vimwiki (One line):
   content
 
+# GetHighlightTerm relies on execute(), which isn't available in all 7.4
+# versions.  Just test this for 8.0 and up to keep things simple:
 Execute (Assert highlight typeface 1):
   " Typeface 1
-  call AssertIfVersion(704, ['bold'], GetHighlightTerm('VimwikiBold', 'term'))
-  call AssertIfVersion(704, ['bold'], GetHighlightTerm('VimwikiBold', 'cterm'))
-  call AssertIfVersion(704, ['bold'], GetHighlightTerm('VimwikiBold', 'gui'))
-  call AssertIfVersion(704, ['italic'], GetHighlightTerm('VimwikiItalic', 'cterm'))
-  call AssertIfVersion(704, ['underline'], GetHighlightTerm('VimwikiUnderline', 'gui'))
+  call AssertIfVersion(800, ['bold'], GetHighlightTerm('VimwikiBold', 'term'))
+  call AssertIfVersion(800, ['bold'], GetHighlightTerm('VimwikiBold', 'cterm'))
+  call AssertIfVersion(800, ['bold'], GetHighlightTerm('VimwikiBold', 'gui'))
+  call AssertIfVersion(800, ['italic'], GetHighlightTerm('VimwikiItalic', 'cterm'))
+  call AssertIfVersion(800, ['underline'], GetHighlightTerm('VimwikiUnderline', 'gui'))
 
 Execute (Assert highlight typeface 2):
   " Bold > Italic > Underline
-  call AssertIfVersion(704, sort(['bold', 'italic', '1']), sort(add(GetHighlightTerm('VimwikiBoldItalic', 'gui'), '1')))
-  call AssertIfVersion(704, sort(['bold', 'italic', '2']), sort(add(GetHighlightTerm('VimwikiBoldItalic', 'term'), '2')))
+  call AssertIfVersion(800, sort(['bold', 'italic', '1']), sort(add(GetHighlightTerm('VimwikiBoldItalic', 'gui'), '1')))
+  call AssertIfVersion(800, sort(['bold', 'italic', '2']), sort(add(GetHighlightTerm('VimwikiBoldItalic', 'term'), '2')))
 
-  call AssertIfVersion(704, sort(['bold', 'underline', '3']), sort(add(GetHighlightTerm('VimwikiBoldUnderline', 'cterm'), '3')))
-  call AssertIfVersion(704, sort(['bold', 'underline', '4']), sort(add(GetHighlightTerm('VimwikiUnderlineBold', 'term'), '4')))
+  call AssertIfVersion(800, sort(['bold', 'underline', '3']), sort(add(GetHighlightTerm('VimwikiBoldUnderline', 'cterm'), '3')))
+  call AssertIfVersion(800, sort(['bold', 'underline', '4']), sort(add(GetHighlightTerm('VimwikiUnderlineBold', 'term'), '4')))
 
-  call AssertIfVersion(704, sort(['italic', 'underline', '5']), sort(add(GetHighlightTerm('VimwikiItalicUnderline', 'cterm'), '5')))
+  call AssertIfVersion(800, sort(['italic', 'underline', '5']), sort(add(GetHighlightTerm('VimwikiItalicUnderline', 'cterm'), '5')))
 
 Execute (Assert highlight typeface 3):
-  call AssertIfVersion(704, sort(['bold', 'italic', 'underline', '1']), sort(add(GetHighlightTerm('VimwikiBoldItalicUnderline', 'gui'), '1')))
-  call AssertIfVersion(704, sort(['bold', 'italic', 'underline', '2']), sort(add(GetHighlightTerm('VimwikiBoldUnderlineItalic', 'cterm'), '2')))
-  call AssertIfVersion(704, sort(['bold', 'italic', 'underline', '3']), sort(add(GetHighlightTerm('VimwikiItalicBoldUnderline', 'term'), '3')))
-  call AssertIfVersion(704, sort(['bold', 'italic', 'underline', '4']), sort(add(GetHighlightTerm('VimwikiItalicUnderlineBold', 'gui'), '4')))
-  call AssertIfVersion(704, sort(['bold', 'italic', 'underline', '5']), sort(add(GetHighlightTerm('VimwikiUnderlineBoldItalic', 'cterm'), '5')))
-  call AssertIfVersion(704, sort(['bold', 'italic', 'underline', '6']), sort(add(GetHighlightTerm('VimwikiUnderlineItalicBold', 'term'), '6')))
+  call AssertIfVersion(800, sort(['bold', 'italic', 'underline', '1']), sort(add(GetHighlightTerm('VimwikiBoldItalicUnderline', 'gui'), '1')))
+  call AssertIfVersion(800, sort(['bold', 'italic', 'underline', '2']), sort(add(GetHighlightTerm('VimwikiBoldUnderlineItalic', 'cterm'), '2')))
+  call AssertIfVersion(800, sort(['bold', 'italic', 'underline', '3']), sort(add(GetHighlightTerm('VimwikiItalicBoldUnderline', 'term'), '3')))
+  call AssertIfVersion(800, sort(['bold', 'italic', 'underline', '4']), sort(add(GetHighlightTerm('VimwikiItalicUnderlineBold', 'gui'), '4')))
+  call AssertIfVersion(800, sort(['bold', 'italic', 'underline', '5']), sort(add(GetHighlightTerm('VimwikiUnderlineBoldItalic', 'cterm'), '5')))
+  call AssertIfVersion(800, sort(['bold', 'italic', 'underline', '6']), sort(add(GetHighlightTerm('VimwikiUnderlineItalicBold', 'term'), '6')))
 
 Expect (One line):
   content

--- a/test/vimrc
+++ b/test/vimrc
@@ -341,18 +341,22 @@
   endfunc
 
   function! AssertIfVersion(version, one, two)
-    " Run Assert only if vim version higth enough
+    " Run Assert only if vim version is high enough
     if v:version < a:version | return | endif
     AssertEqual a:one, a:two
   endfunction
 
   function! GetHighlightTerm(group, term)
     " Get output of `hi group`
+    "
     " From: https://vi.stackexchange.com/a/12294/5026
     " Return list ['bold','underline']
-    " Warning: must be called if version > 704
-    " Clause
-    if v:version < 704 | return [] | endif
+    "
+    " Warning: must only be called if has("patch-7.4-2008")
+    " Or rather:  If execute() exists - it's not available for all 7.4
+    " versions.
+    " https://github.com/vim/vim/commit/79815f1ec77406f2f21a618c053e5793b597db7a
+    if has('patch-7.4-2008') != 1 | return [] | endif
 
     " Store output of group to variable
     let out = execute('hi ' . a:group)


### PR DESCRIPTION
Hopefully this solves #1084, "Page links with leading slash lead to a file in working directory, not a page at the root of the wiki", introduced in 850aace.

It also adds a set of tests for different kinds of wiki links.

TODO:

  - [X] Markdown versions of link tests
    - Do not worry about MediaWiki 
  - [x] Clarify documentation about leading `//` links
  - [x] Could stand to test `vimwiki#base#resolve_link()` directly (if plausible)
     - Yes, API test is even much easyer. maybe prefix your test with `api_` 

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.