### PR TITLE
Vimwiki2HTML: remove string concat from variable substitution

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -1831,25 +1831,25 @@ function! s:convert_file_to_lines_template(wikifile, current_html_file) abort
   let html_lines = s:get_html_template(converted['template_name'])
 
   " processing template variables (refactor to a function)
-  call map(html_lines, 'substitute(v:val, "%title%", "'. converted['title'] .'", "g")')
-  call map(html_lines, 'substitute(v:val, "%date%", "'. converted['date'] .'", "g")')
+  call map(html_lines, 'substitute(v:val, "%title%", converted["title"], "g")')
+  call map(html_lines, 'substitute(v:val, "%date%", converted["date"], "g")')
   call map(html_lines, 'substitute(v:val, "%root_path%", "'.
         \ s:root_path(vimwiki#vars#get_bufferlocal('subdir')) .'", "g")')
-  call map(html_lines, 'substitute(v:val, "%wiki_path%", "'. converted['wiki_path'] .'", "g")')
+  call map(html_lines, 'substitute(v:val, "%wiki_path%", converted["wiki_path"], "g")')
 
   let css_name = expand(vimwiki#vars#get_wikilocal('css_name'))
   let css_name = substitute(css_name, '\', '/', 'g')
-  call map(html_lines, 'substitute(v:val, "%css%", "'. css_name .'", "g")')
+  call map(html_lines, 'substitute(v:val, "%css%", css_name, "g")')
 
   let rss_name = expand(vimwiki#vars#get_wikilocal('rss_name'))
   let rss_name = substitute(rss_name, '\', '/', 'g')
-  call map(html_lines, 'substitute(v:val, "%rss%", "'. rss_name .'", "g")')
+  call map(html_lines, 'substitute(v:val, "%rss%", rss_name, "g")')
 
   let enc = &fileencoding
   if enc ==? ''
     let enc = &encoding
   endif
-  call map(html_lines, 'substitute(v:val, "%encoding%", "'. enc .'", "g")')
+  call map(html_lines, 'substitute(v:val, "%encoding%", enc, "g")')
 
   let html_lines = s:html_insert_contents(html_lines, converted['html']) " %contents%
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3955,6 +3955,7 @@ Changed:~
 Removed:~
 
 Fixed:~
+    * Allow title values with quotes
     * Enable strikethrough for Neovim
     * Issue #1029: Fix: error loading plugin when lang uses comma instead of
       dot as decimal separator

--- a/test/html_convert_default.vader
+++ b/test/html_convert_default.vader
@@ -1,4 +1,4 @@
-# Conertion: Wiki -> Html
+# Conversion: Wiki -> Html
 
 #################################################
 Given vimwiki (Comments):
@@ -42,10 +42,6 @@ Expect (Comments Removed):
   </body>
   </html>
 
-
-Execute(Delete):
-  call DeleteFile('$HOME/testwiki/test_html_table.wiki')
-  call DeleteFile('$HOME/html/default/test_html_table.html')
 
 #################################################
 Given vimwiki (Table no heading {{{1):
@@ -100,10 +96,6 @@ Expect (Table no heading):
 
   </body>
   </html>
-
-Execute(Delete):
-  call DeleteFile('$HOME/testwiki/test_html_table.wiki')
-  call DeleteFile('$HOME/html/default/test_html_table.html')
 
 
 Given vimwiki (Table with heading {{{1):
@@ -164,10 +156,6 @@ Expect (Table with heading):
   </body>
   </html>
 
-
-Execute(Delete):
-  call DeleteFile('$HOME/testwiki/test_html_table.wiki')
-  call DeleteFile('$HOME/html/default/test_html_table.html')
 
 #################################################
 Execute (Log):

--- a/test/html_convert_title.vader
+++ b/test/html_convert_title.vader
@@ -1,0 +1,10 @@
+# Test that %title values carry through when HTML is rendered
+
+Given vimwiki (Title value):
+  %title this is a title with some quotes in it: ' "
+
+  Some content.
+
+Execute(Check for title tag):
+  call ConvertWiki2Html()
+  Assert 0 != search('<title>this is a title with some quotes in it: '' "</title>')


### PR DESCRIPTION
Problem: I noticed that running :Vimwiki2HTML for a file with a `"` in the `%title` line would error out.  For example, a title like:

```vimwiki
%title this will die: "
```

Causes:

```
Error detected while processing function vimwiki#html#Wiki2HTML[1]..<SNR>177_convert_file[15]..<SNR>177_convert_file_to_lines_template:
line    8:
E116: Invalid arguments for function substitute(v:val, "%title%", "this will die: "", "g")
```

Solution: It seems like the string concatenation here was unnecessary. At least on my vim 8.1, the evaluated code seems to have access to the correct variables.

I'm sure there are bigger problems with the HTML generation here, but this allows my ~2000 pages with titles to render without throwing errors.

Also adds a brief test and removes some unnecessary DeleteFile() calls from html_convert_default.vader.

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues. (Didn't find anything.)
- [X] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
