### PR TITLE
Add wikilocal option showing description in generated links

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -507,6 +507,7 @@ function! s:get_default_wikilocal() abort
         \ 'bullet_types': {'type': type([]), 'default': []},
         \ 'cycle_bullets': {'type': type(0), 'default': 0},
         \ 'html_filename_parameterization': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
+        \ 'generated_links_caption': {'type': type(0), 'default': 0 },
         \ 'index': {'type': type(''), 'default': 'index', 'min_length': 1},
         \ 'links_space_char': {'type': type(''), 'default': ' ', 'min_length': 1},
         \ 'list_ignore_newline': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
@@ -1285,8 +1286,10 @@ function! s:normalize_syntax_settings(syntax) abort
   "   command generate link form file name (generate_link)
   if a:syntax ==# 'markdown'
     let syntax_dic.Link1 = syntax_dic.Weblink1Template
+    let syntax_dic.Link2 = syntax_dic.Weblink1Template
   else
     let syntax_dic.Link1 = vimwiki#vars#get_global('WikiLinkTemplate1')
+    let syntax_dic.Link2 = vimwiki#vars#get_global('WikiLinkTemplate2')
   endif
 endfunction
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -2672,6 +2672,18 @@ If set to 1 (true), cycle through |bullet_types| when changing list element
 identation
 
 
+*vimwiki-option-generated_links_caption*
+------------------------------------------------------------------------------
+Key                         Default value~
+generated_links_caption     0
+
+Default syntax only. If set to 1 (true), use the [[URL|DESCRIPTIOM]]  when
+calling |:VimwikiGenerateLinks|. DESCRIPTION will be the first header in the
+corresbonding file found in the first n lines, where n is set by
+|g:vimwiki_max_scan_for_caption| (Default 5). If no caption is found fallback
+to [[URL]] only.
+
+
 *vimwiki-option-listsyms*
 ------------------------------------------------------------------------------
 Key               Default value~
@@ -3900,6 +3912,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Fergus Collins (@C-Fergus)
     - Matthew Toohey (@mtoohey31)
     - Brennen Bearnes
+    - Stefan Schuhbäck (@stefanSchuhbaeck)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3911,6 +3924,8 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * Feature: Add option to use link Description in default syntax if 
+      caption is present. |generated_links_caption|
     * PR #1106: Fix trailing closing brace and comma typo
     * Feature: VimwikiColorize maps in visual and normal mode `<leader>wc`
     * Feature: PR #686: add a flag lists_return to disable mappings 

--- a/test/link_generation.vader
+++ b/test/link_generation.vader
@@ -1,6 +1,6 @@
 # Automatic link generation
 # Related to:
-#   - wiki file discovery 
+#   - wiki file discovery
 #   - buffer list insertion (see: vimwiki#base#update_listing_in_buffer)
 
 
@@ -9,11 +9,11 @@ Execute (Reset sw to default (due to batch)):
 
 # 1 VimwikiGenerateLinks {{{1
 ##########################
-# Wiki Syntax {{{2
+# Wiki Syntax (no caption, default) {{{2
 #################
 
 Execute (Log):
-  Log 'Wiki Syntax'
+  Log 'Wiki Syntax (no caption, default)'
   call ReloadVimwiki()
   AssertEqual '-1_margin', vimwiki#vars#get_wikilocal('list_margin') . '_margin'
 
@@ -52,6 +52,49 @@ Expect (The links with a header (bis)):
 Execute (Clean Test.wiki):
   call DeleteFile('$HOME/testwiki/Test.wiki')
 
+# Wiki Syntax (with caption)  {{{2
+#################
+
+Execute (Log):
+  Log 'Wiki Syntax (with caption)'
+  let vimwiki_default.generated_links_caption = 1
+  call ReloadVimwiki()
+  AssertEqual '-1_margin', vimwiki#vars#get_wikilocal('list_margin') . '_margin'
+
+Given (Void):
+
+Execute (VimwikiGenerateLinks):
+  edit $HOME/testwiki/Test.wiki
+  VimwikiGenerateLinks
+
+Expect (The links with a header):
+
+
+  = Generated Links =
+          - [[buzz_bozz|Buzz Bozz]]
+          - [[index|Test Wiki]]
+          - [[link_syntax]]
+          - [[link_syntax/nested]]
+
+Execute (VimwikiGenerateLinks x 2):
+  edit $HOME/testwiki/Test.wiki
+  VimwikiGenerateLinks
+  call append('$', 'Last Line')
+  VimwikiGenerateLinks
+
+Expect (The links with a header (bis)):
+
+
+  = Generated Links =
+          - [[buzz_bozz|Buzz Bozz]]
+          - [[index|Test Wiki]]
+          - [[link_syntax]]
+          - [[link_syntax/nested]]
+
+  Last Line
+
+Execute (Clean Test.wiki):
+  call DeleteFile('$HOME/testwiki/Test.wiki')
 
 # Markdown Syntax {{{2
 #################


### PR DESCRIPTION
Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.

For the default syntax the generated links list does not provide the link description (or caption). For the markdown syntax this caption is provided by the first caption found in the corresponding file. My filenames are not as descriptive so it would be nice to use do the same for the default syntax.
```
  = Generated Links =
          - [[buzz_bozz]]
          - [[indexi]]
          - [[link_syntax]]
          - [[link_syntax/nested]]
```
vs.
```
  = Generated Links =
          - [[buzz_bozz|Buzz Bozz]]
          - [[index|Test Wiki]]
          - [[link_syntax]]   <--- does not contain a header so keep the default link syntax
          - [[link_syntax/nested]]  <--- (same here)
```
Not breaking the default behavior I added a wiki local option `generated_links_caption` to toggle the behavior. 

To activate add the following tho `.vimrc` 

```
let g:vimwiki_list = [{
            \ 'path': '$HOME/vimwiki',
            \ 'template_path': '$HOME/.vim/pack/vendor/start/vimwiki/autoload/vimwiki',
            \ 'auto_tags': 1,
            \ 'generated_links_caption': 1,  
            \ 'ext': '.wiki'}]
```

- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
