### PR TITLE
VimwikiGoto: Support wiki pages with spaces

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3924,6 +3924,7 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * PR #1128: VimwikiGoto: Support wiki pages with spaces
     * Feature: Add option to use link Description in default syntax if 
       caption is present. |generated_links_caption|
     * PR #1106: Fix trailing closing brace and comma typo

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -320,7 +320,7 @@ command! -buffer -nargs=* VimwikiSearch call vimwiki#base#search(<q-args>)
 command! -buffer -nargs=* VWS call vimwiki#base#search(<q-args>)
 
 command! -buffer -nargs=* -complete=customlist,vimwiki#base#complete_links_escaped
-      \ VimwikiGoto call vimwiki#base#goto(<f-args>)
+      \ VimwikiGoto call vimwiki#base#goto(<q-args>)
 
 command! -buffer -range VimwikiCheckLinks call vimwiki#base#check_links(<range>, <line1>, <line2>)
 

--- a/test/file_goto.vader
+++ b/test/file_goto.vader
@@ -10,6 +10,11 @@ Execute (VimwikiGoto buzz_bozz && Assert):
   VimwikiGoto buzz_bozz
   AssertEqual $HOME . '/testmarkdown/buzz_bozz.md', expand('%')
 
+Execute (VimwikiGoto buzz bozz && Assert):
+  VimwikiIndex 4
+  VimwikiGoto buzz bozz
+  AssertEqual $HOME . '/testwiki space/buzz bozz.wiki', expand('%')
+
 Do (VimwikiGoto <CR> buzz_bozz && Assert):
   :VimwikiIndex 2\<CR>
   :VimwikiGoto\<CR>

--- a/test/vimrc
+++ b/test/vimrc
@@ -50,9 +50,19 @@
   let vimwiki_mediawiki.ext = '.mw'
   let vimwiki_mediawiki.name = 'MediaWikiSyntax'
 
-  " Register the 3 wikis
-  let g:vimwiki_list = [vimwiki_default, vimwiki_markdown, vimwiki_mediawiki]
-  let g:vimwiki_list_vimrc = [vimwiki_default, vimwiki_markdown, vimwiki_mediawiki]
+  " Declare default syntax with spaces
+  let vimwiki_default_space = {}
+  let vimwiki_default_space.path = $HOME . '/testwiki space'
+  let vimwiki_default_space.path_html = $HOME . '/html/testwiki space'
+  let vimwiki_default_space.template_path = $HOME . '/testwiki space/templates/'
+  let vimwiki_default_space.syntax = 'default'
+  let vimwiki_default_space.ext = '.wiki'
+  let vimwiki_default_space.name = 'DefaultSyntax'
+  let vimwiki_default_space.base_url = 'https://example.com/'
+
+  " Register the 4 wikis
+  let g:vimwiki_list = [vimwiki_default, vimwiki_markdown, vimwiki_mediawiki, vimwiki_default_space]
+  let g:vimwiki_list_vimrc = [vimwiki_default, vimwiki_markdown, vimwiki_mediawiki, vimwiki_default_space]
 
   " Test VimwikiColorize and ,wc
   let g:vimwiki_color_dic = {


### PR DESCRIPTION
This PR updates `:VimwikiGoto` to support opening wiki pages with spaces in the name.