### PR TITLE
Do not modify spaces to link descriptions

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -2736,14 +2736,14 @@ function! s:normalize_link_syntax_v() abort
   endif
 
   " Transform link:
-  " Replace description (used for markdown)
-  let link = s:safesubstitute(link, '__LinkDescription__', visual_selection, '')
   " Replace file extension
   let file_extension = vimwiki#vars#get_wikilocal('ext', vimwiki#vars#get_bufferlocal('wiki_nr'))
   let link = s:safesubstitute(link, '__FileExtension__', file_extension , '')
   " Replace space characters
   let sc = vimwiki#vars#get_wikilocal('links_space_char')
   let link = substitute(link, '\s', sc, 'g')
+  " Replace description (used for markdown)
+  let link = s:safesubstitute(link, '__LinkDescription__', visual_selection, '')
   " Remove newlines
   let link = substitute(link, '\n', '', '')
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3974,7 +3974,7 @@ Changed:~
     * VimwikiCheckLinks work on current wiki or on range
     * PR #1057: Change how resolve subdir work
       Change how shell escaping work when using CustomWiki2HTML
-    * PR #TBD: Spaces in link descriptions are no longer replaced with
+    * PR #1132: Spaces in link descriptions are no longer replaced with
       links_space_char
 
 Removed:~

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3913,6 +3913,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Matthew Toohey (@mtoohey31)
     - Brennen Bearnes
     - Stefan Schuhbäck (@stefanSchuhbaeck)
+    - Vinny Furia (@vinnyfuria)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3973,6 +3974,8 @@ Changed:~
     * VimwikiCheckLinks work on current wiki or on range
     * PR #1057: Change how resolve subdir work
       Change how shell escaping work when using CustomWiki2HTML
+    * PR #TBD: Spaces in link descriptions are no longer replaced with
+      links_space_char
 
 Removed:~
 


### PR DESCRIPTION
When links_space_char is configure to replace spaces, the spaces should only replace the `__LinkUrl__` and not replace the `__LinkDescription__`

This is a different fix then described in https://github.com/vimwiki/vimwiki/issues/1038 but fixes the described problem.

All vadar tests pass; vint returns no errors

**Note:** on some vim versions I'm seeing 1/4 tests passing in `search.vader`; but that is the case in the `dev` branch as well.

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [X] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
