### PR TITLE
Allow multiple symbols for any state of a checkbox

### DIFF
--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -780,10 +780,29 @@ function! s:get_rate(item) abort
   if state == vimwiki#vars#get_global('listsym_rejected')
     return -1
   endif
-  let listsyms = map(deepcopy(vimwiki#vars#get_wikilocal('listsyms')), {_, val -> type(val) == type([]) ? index(val, state) > 0 : val == state })
+  let listsyms = vimwiki#vars#get_wikilocal('listsyms')
+
+  let found = -1
+  let idx = 0
+  for item in listsyms
+    if type(item) == type([])
+      if index(item, state) >= 0
+        let found = idx
+        break
+      endif
+    else
+      if item == state
+        let found = idx
+        break
+      endif
+    endif
+
+    let idx = idx + 1
+  endfor
+
   let n = len(listsyms)
 
-  return index(listsyms, 1) * 100/(n-1)
+  return found * 100/(n-1)
 endfunction
 
 

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -827,7 +827,10 @@ function! s:set_state_plus_children(item, new_rate, ...) abort
     if child_item.cb != vimwiki#vars#get_global('listsym_rejected')
       let all_children_are_rejected = 0
     endif
-    if child_item.cb != vimwiki#vars#get_wikilocal('listsyms_list')[-1]
+
+    let is_child_item_completed = type(completed_syms) == type([]) ? index(completed_syms, child_item.cb) >= 0 : child_item.cb == completed_syms
+
+    if !is_child_item_completed
       let all_children_are_done = 0
     endif
     if !all_children_are_done && !all_children_are_rejected

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -328,9 +328,16 @@ endfunction
 function! s:is_closed(item) abort
   " Returns: Whether or not the checkbox of a list item is [X] or [-]
   let state = a:item.cb
-  let completed_sym = flattennew([vimwiki#vars#get_wikilocal('listsyms_list')[-1]] + [vimwiki#vars#get_global('listsym_rejected')])
+  let completed_syms = vimwiki#vars#get_wikilocal('listsyms_list')[-1]
+  let closed_syms = []
 
-  return index(completed_sym, state) != -1
+  if type(completed_syms) == type([])
+    let closed_syms =  completed_syms + [vimwiki#vars#get_global('listsym_rejected')]
+  else
+    let closed_syms =  [completed_syms, vimwiki#vars#get_global('listsym_rejected')]
+  endif
+
+  return index(closed_syms, state) != -1
 endfunction
 
 " ---------------------------------------------------------
@@ -810,6 +817,7 @@ function! s:set_state_plus_children(item, new_rate, ...) abort
 
   let all_children_are_done = 1
   let all_children_are_rejected = 1
+  let completed_syms = vimwiki#vars#get_wikilocal('listsyms_list')[-1]
 
   let child_item = s:get_first_child(a:item)
   while 1

--- a/autoload/vimwiki/lst.vim
+++ b/autoload/vimwiki/lst.vim
@@ -328,8 +328,9 @@ endfunction
 function! s:is_closed(item) abort
   " Returns: Whether or not the checkbox of a list item is [X] or [-]
   let state = a:item.cb
-  return state ==# vimwiki#vars#get_wikilocal('listsyms_list')[-1]
-        \ || state ==# vimwiki#vars#get_global('listsym_rejected')
+  let completed_sym = flattennew([vimwiki#vars#get_wikilocal('listsyms_list')[-1]] + [vimwiki#vars#get_global('listsym_rejected')])
+
+  return index(completed_sym, state) != -1
 endfunction
 
 " ---------------------------------------------------------
@@ -772,8 +773,10 @@ function! s:get_rate(item) abort
   if state == vimwiki#vars#get_global('listsym_rejected')
     return -1
   endif
-  let n = len(vimwiki#vars#get_wikilocal('listsyms_list'))
-  return index(vimwiki#vars#get_wikilocal('listsyms_list'), state) * 100/(n-1)
+  let listsyms = map(deepcopy(vimwiki#vars#get_wikilocal('listsyms')), {_, val -> type(val) == type([]) ? index(val, state) > 0 : val == state })
+  let n = len(listsyms)
+
+  return index(listsyms, 1) * 100/(n-1)
 endfunction
 
 
@@ -865,6 +868,11 @@ function! s:rate_to_state(rate) abort
     let index = float2nr(ceil(a:rate/100.0*(n-2)))
     let state = listsyms_list[index]
   endif
+
+  if type(state) == type([])
+    let state = state[-1]
+  endif
+
   return state
 endfunction
 

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -167,7 +167,7 @@ function! s:get_default_global() abort
         \   }},
         \ 'links_header': {'type': type(''), 'default': 'Generated Links', 'min_length': 1},
         \ 'links_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 6},
-        \ 'listsyms': {'type': type(''), 'default': ' .oOX', 'min_length': 2},
+        \ 'listsyms': {'type': type([]), 'default': [' ', '.', 'o', 'X'], 'min_length': 2},
         \ 'listsym_rejected': {'type': type(''), 'default': '-', 'length': 1},
         \ 'map_prefix': {'type': type(''), 'default': '<Leader>w'},
         \ 'markdown_header_style': {'type': type(0), 'default': 1, 'min':0, 'max': 2},
@@ -514,7 +514,7 @@ function! s:get_default_wikilocal() abort
         \ 'list_ignore_newline': {'type': type(0), 'default': 1, 'min': 0, 'max': 1},
         \ 'list_margin': {'type': type(0), 'default': -1, 'min': -1},
         \ 'listsym_rejected': {'type': type(''), 'default': vimwiki#vars#get_global('listsym_rejected')},
-        \ 'listsyms': {'type': type(''), 'default': vimwiki#vars#get_global('listsyms')},
+        \ 'listsyms': {'type': type([]), 'default': vimwiki#vars#get_global('listsyms')},
         \ 'listsyms_propagate': {'type': type(0), 'default': 1},
         \ 'markdown_link_ext': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
         \ 'maxhi': {'type': type(0), 'default': 0, 'min': 0, 'max': 1},
@@ -1071,34 +1071,41 @@ function! s:populate_list_vars(wiki) abort
     let rxListBullet = '$^'
   endif
 
-  " the user can set the listsyms as string, but vimwiki needs a list
-  let a:wiki.listsyms_list = split(a:wiki.listsyms, '\zs')
+  let a:wiki.listsyms_list = a:wiki.listsyms
 
   " Guard: Check if listym_rejected is in listsyms
-  if match(a:wiki.listsyms, '[' . a:wiki.listsym_rejected . ']') != -1
+  if index(a:wiki.listsyms, a:wiki.listsym_rejected) != -1
     call vimwiki#u#warn('the value of listsym_rejected ('''
           \ . a:wiki.listsym_rejected . ''') must not be a part of listsyms ('''
-          \ . a:wiki.listsyms . ''')')
+          \ . join(a:wiki.listsyms, '') . ''')')
   endif
+
+  if type(a:wiki.listsyms_list[-1]) == type([])
+    let lastListSymReg = '\[' . join(a:wiki.listsyms_list[-1], '\|') . '\]'
+  else
+    let lastListSymReg = a:wiki.listsyms_list[-1]
+  endif
+
+  let flattenedListSyms = flattennew(a:wiki.listsyms)
 
   let a:wiki.rxListItemWithoutCB =
         \ '^\s*\%(\('.rxListBullet.'\)\|\('
         \ .rxListNumber.'\)\)\s'
   let a:wiki.rxListItem =
         \ a:wiki.rxListItemWithoutCB
-        \ . '\+\%(\[\(['.a:wiki.listsyms
+        \ . '\+\%(\[\(['.join(flattenedListSyms, '\|')
         \ . a:wiki.listsym_rejected.']\)\]\s\)\?'
   if recurring_bullets
     let a:wiki.rxListItemAndChildren =
           \ '^\('.rxListBullet.'\)\s\+\[['
-          \ . a:wiki.listsyms_list[-1]
+          \ . lastListSymReg
           \ . a:wiki.listsym_rejected . ']\]\s.*\%(\n\%(\1\%('
           \ .rxListBullet.'\).*\|^$\|\s.*\)\)*'
   else
     let a:wiki.rxListItemAndChildren =
           \ '^\(\s*\)\%('.rxListBullet.'\|'
           \ . rxListNumber.'\)\s\+\[['
-          \ . a:wiki.listsyms_list[-1]
+          \ . lastListSymReg
           \ . a:wiki.listsym_rejected . ']\]\s.*\%(\n\%(\1\s.*\|^$\)\)*'
   endif
 endfunction

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -167,7 +167,7 @@ function! s:get_default_global() abort
         \   }},
         \ 'links_header': {'type': type(''), 'default': 'Generated Links', 'min_length': 1},
         \ 'links_header_level': {'type': type(0), 'default': 1, 'min': 1, 'max': 6},
-        \ 'listsyms': {'type': type([]), 'default': [' ', '.', 'o', 'X'], 'min_length': 2},
+        \ 'listsyms': {'type': type([]), 'default': [' ', '.', 'o', 'O', 'X'], 'min_length': 2},
         \ 'listsym_rejected': {'type': type(''), 'default': '-', 'length': 1},
         \ 'map_prefix': {'type': type(''), 'default': '<Leader>w'},
         \ 'markdown_header_style': {'type': type(0), 'default': 1, 'min':0, 'max': 2},

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -1086,7 +1086,15 @@ function! s:populate_list_vars(wiki) abort
     let lastListSymReg = a:wiki.listsyms_list[-1]
   endif
 
-  let flattenedListSyms = flattennew(a:wiki.listsyms)
+  let flattenedListSyms = []
+
+  for sym in a:wiki.listsyms
+    if type(sym) == type([])
+      let flattenedListSyms = flattenedListSyms + sym
+    else
+      let flattenedListSyms = flattenedListSyms + [sym]
+    endif
+  endfor
 
   let a:wiki.rxListItemWithoutCB =
         \ '^\s*\%(\('.rxListBullet.'\)\|\('

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -144,7 +144,11 @@ for bullet in vimwiki#vars#get_syntaxlocal('bullet_types')
   " task list
   for point in vimwiki#vars#get_wikilocal('listsyms_list')
         \ + [vimwiki#vars#get_wikilocal('listsym_rejected')]
-    let comments .= ',fb:' . bullet . ' [' . point . ']'
+    if type(point) == type([])
+      let comments .= ',fb:' . bullet . ' [' . join(point, '') . ']'
+    else
+      let comments .= ',fb:' . bullet . ' [' . point . ']'
+    endif
   endfor
   " list
   let comments .= ',fb:' . bullet


### PR DESCRIPTION
This patch allows checkboxes to have multiple symbols that can denote a state

For example:

```
   let g:vimwiki_list = [{'path': '~/path/', 'listsyms': [' ', '.', 'o', 'O', ['x', 'X']] }]
```

This will allow the completed checkbox to be represented by both 'x' and 'X'


Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [ ] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
- [ ] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.