### PR TITLE
fix(update_listing_in_buffer): don't update listing if there are no c…

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1521,6 +1521,12 @@ function! vimwiki#base#update_listing_in_buffer(Generator, start_header,
     " them right back.
     let foldenable_save = &l:foldenable
     setlocal nofoldenable
+    
+    " don't update file if there are no changes
+    if (join(getline(start_lnum + 2, end_lnum - 1), "") == join(a:Generator.f(), ""))
+      return
+    endif
+
     silent exe 'keepjumps ' . start_lnum.','.string(end_lnum - 1).'delete _'
     let &l:foldenable = foldenable_save
     let lines_diff = 0 - (end_lnum - start_lnum)


### PR DESCRIPTION
…hanges

Before updating a listing, check if the update differs from the existing state.
Only then update the buffer, otherwise return early.

Initial motivation: If `let g:vimwiki_auto_toc = 1` is set, saving a buffer would always update
the `contents`-section, even if there were no updates in this section. This lead to undesired
undo-behavior.

NOTE: this fix was only tested for the toc-listing.

Steps for submitting a pull request:

- [ ] **ALL** pull requests should be made against the `dev` branch!
- [ ] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
- [ ] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

PR. is a WIP, if keeping a clean undo-history qualifies as a problem, I will continue working on this.