### PR TITLE
Feature: VimwikiPasteLink to get absolute wiki link to the current file

### DIFF
--- a/autoload/vimwiki/path.vim
+++ b/autoload/vimwiki/path.vim
@@ -221,6 +221,17 @@ function! vimwiki#path#is_absolute(path) abort
 endfunction
 
 
+
+function! s:get_wikifile_link(wikifile) abort
+  return vimwiki#base#subdir(vimwiki#vars#get_wikilocal('path'), a:wikifile).
+    \ fnamemodify(a:wikifile, ':t:r')
+endfunction
+
+function! vimwiki#path#PasteLink(wikifile) abort
+  execute 'r !echo "[[/'.s:get_wikifile_link(a:wikifile).']]"'
+endfunction
+
+
 if vimwiki#u#is_windows()
   " Combine: a directory and a file into one path, doesn't generate duplicate
   " path separator in case the directory is also having an ending / or \. This

--- a/autoload/vimwiki/path.vim
+++ b/autoload/vimwiki/path.vim
@@ -228,7 +228,7 @@ function! s:get_wikifile_link(wikifile) abort
 endfunction
 
 function! vimwiki#path#PasteLink(wikifile) abort
-  execute 'r !echo "[[/'.s:get_wikifile_link(a:wikifile).']]"'
+  call append(line('.'), '[[/'.s:get_wikifile_link(a:wikifile).']]')
 endfunction
 
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -974,6 +974,14 @@ Vimwiki file.
     colors are configured by |vimwiki-option-color_dic| and the format of the
     surrounding color tags by |vimwiki-option-color_tag_template|
 
+*:VimwikiPasteLink*
+    Pastes an absolute wiki link (relative to the wiki root) to the current
+    wiki file into the current buffer
+
+*:VimwikiPasteUrl*
+    Pastes the url to the html file corresponding to the current wiki file
+    into the current buffer
+
 
 ==============================================================================
 5. Wiki syntax                                                *vimwiki-syntax*
@@ -3914,6 +3922,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Brennen Bearnes
     - Stefan Schuhbäck (@stefanSchuhbaeck)
     - Vinny Furia (@vinnyfuria)
+    - paperbenni (@paperbenni)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3970,6 +3979,8 @@ New:~
     * PR #934: RSS feed generation for diary with :VimwikiRss.
     * Feature: Add option |vimwiki-option-template_date_format| to configure
       alternative date string format
+    * Feature: Add |VimwikiPasteLink| to paste an absolute wiki link to the
+      current file
 
 Changed:~
     * PR #1047: Allow to replace default mapping of VimwikiToggleListItem

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -369,6 +369,7 @@ command! -buffer -nargs=* -complete=custom,vimwiki#tags#complete_tags
       \ call vimwiki#tags#generate_tags(1, <f-args>)
 
 command! -buffer VimwikiPasteUrl call vimwiki#html#PasteUrl(expand('%:p'))
+command! -buffer VimwikiPasteLink call vimwiki#path#PasteLink(expand('%:p'))
 command! -buffer VimwikiCatUrl call vimwiki#html#CatUrl(expand('%:p'))
 command! -buffer -nargs=* -range -complete=custom,vimwiki#base#complete_colorize
       \ VimwikiColorize <line1>,<line2>call vimwiki#base#colorize(<f-args>)


### PR DESCRIPTION
This is useful for quickly pages that multiple other pages link to. Until now the only two options were to create relative links that are different for different pages and require manual work or to manually type out the absolute path. 