### PR TITLE
Fix: Links opening in qutebrowser multiple times #763

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -331,7 +331,7 @@ function! vimwiki#base#system_open_link(url) abort
     call system('open ' . shellescape(a:url).' &')
   endfunction
   function! s:linux_handler(url) abort
-    call system('xdg-open ' . shellescape(a:url).' &')
+    call system('xdg-open ' . shellescape(a:url).' >/dev/null 2>&1 &')
   endfunction
   try
     if vimwiki#u#is_windows()

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3923,6 +3923,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Stefan Schuhbäck (@stefanSchuhbaeck)
     - Vinny Furia (@vinnyfuria)
     - paperbenni (@paperbenni)
+    - Lily Foster (@lilyinstarlight)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -4024,6 +4025,7 @@ Fixed:~
     * PR #1030: Allow overwriting insert mode mappings
     * PR #1057: Fix renaming, updating link, and exporting HTML subdir wrong
       Fix resolve subdir return wrong path in Windows
+    * Issue #763: Links opening in qutebrowser multiple times on Linux
 
 
 2.5 (2020-05-26)~


### PR DESCRIPTION
When attempting to open external URLs with qutebrowser as the default browser on Linux from VimWiki, three total tabs will be opened instead of the expected one. This is caused by several things:
* Qutebrowser will open new URLs in an existing instance if possible, and prints "INFO: Opening in existing instance" to stderr when it does.
* VimWiki uses the `system()` function with `&` but no redirection, causing the stdio pipes to be broken near immediately.
* Python interpreter errors from the SIGPIPE signal during exit (when trying to send the printed message to stderr) and returns code 120
* xdg-open takes the return code to mean opening qutebrowser failed (despite the tab being successfully opened)
* xdg-open attempts to do so again using a different method two more times, causing three total tabs to be opened (since none of the attempts actually failed).

This patch specifically redirects stderr and stdout to `/dev/null` when opening external links in VimWiki with xdg-open to prevent a broken pipe and bad exit code, allowing xdg-open to do the right thing and only open one tab.

Fixes #763

I've tested this locally and it works for me now with qutebrowser. This should not cause any regressions, but I would welcome anyone to test this change with their own default browser to ensure nothing spooky happens for other browsers (e.g. Firefox or Chromium).

I wasn't sure how a regression test could easily be added for this, without adding qutebrowser (or similarly affected browsers) to the test container and probing whether the command fails with tabs still being spawned, so no tests were added.

Let me know if you have feedback or otherwise need me to do something else for this!


Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.