### PR TITLE
Fix links generated from VimwikiGenerateTagLinks

### DIFF
--- a/autoload/vimwiki/tags.vim
+++ b/autoload/vimwiki/tags.vim
@@ -345,6 +345,7 @@ function! vimwiki#tags#generate_tags(create, ...) abort
 
     let lines = []
     let bullet = repeat(' ', vimwiki#lst#get_list_margin()).vimwiki#lst#default_symbol().' '
+    let current_dir = vimwiki#base#current_subdir()
     for tagname in sort(keys(tags_entries))
       if need_all_tags || index(self.specific_tags, tagname) != -1
         if len(lines) > 0
@@ -361,6 +362,7 @@ function! vimwiki#tags#generate_tags(create, ...) abort
         endif
 
         for taglink in sort(tags_entries[tagname])
+          let taglink = vimwiki#path#relpath(current_dir, taglink)
           if vimwiki#vars#get_wikilocal('syntax') ==# 'markdown'
             let link_tpl = vimwiki#vars#get_syntaxlocal('Weblink3Template')
             let link_infos = vimwiki#base#resolve_link(taglink)

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3923,6 +3923,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Stefan Schuhbäck (@stefanSchuhbaeck)
     - Vinny Furia (@vinnyfuria)
     - paperbenni (@paperbenni)
+    - Philipp Oberdiek (@RonMcKay)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -4024,6 +4025,7 @@ Fixed:~
     * PR #1030: Allow overwriting insert mode mappings
     * PR #1057: Fix renaming, updating link, and exporting HTML subdir wrong
       Fix resolve subdir return wrong path in Windows
+    * Issue #794: Fix: Generated tag links are build wrong
 
 
 2.5 (2020-05-26)~

--- a/test/tag.vader
+++ b/test/tag.vader
@@ -205,3 +205,77 @@ Execute (Clean Test-Tag and .vimwiki_tags -1 ):
   call DeleteHiddenBuffers()
 
 # vim: sw=2:foldlevel=30:foldmethod=marker:
+
+######################################################################
+Execute (Check first tags file):
+  call system("mkdir -p $HOME/testmarkdown/subdir1/subdir11")
+  edit $HOME/testmarkdown/Test-Tag-1.md
+  AssertEqual $HOME . '/testmarkdown/Test-Tag-1.md', expand('%')
+  AssertEqual 'markdown', vimwiki#vars#get_wikilocal('syntax')
+  AssertEqual 1, vimwiki#vars#get_bufferlocal('wiki_nr')
+
+Do (Build first tags file):
+  :edit $HOME/testmarkdown/Test-Tag-1.md\<Cr>
+  ggI
+  # A Header\<Cr>
+  :header-tag-1:\<Cr>
+  \<Cr>
+  # Another Header\<Cr>
+  :header-tag-2:\<Cr>
+  \<Cr>
+  :standalone-tag-1:
+  \<Esc>
+  :write\<Cr>
+  :VimwikiRebuildTags!\<CR>
+
+Execute (Check second tags file):
+  edit $HOME/testmarkdown/subdir1/Test-Tag-2.md
+  AssertEqual $HOME . '/testmarkdown/subdir1/Test-Tag-2.md', expand('%')
+  AssertEqual 'markdown', vimwiki#vars#get_wikilocal('syntax')
+  AssertEqual 1, vimwiki#vars#get_bufferlocal('wiki_nr')
+
+Do (Build second tags file):
+  :edit $HOME/testmarkdown/subdir1/Test-Tag-2.md\<Cr>
+  ggI
+  # A Header\<Cr>
+  :header-tag-1:\<Cr>
+  \<Cr>
+  # Another Header\<Cr>
+  :header-tag-2:\<Cr>
+  \<Cr>
+  :standalone-tag-1:
+  \<Esc>
+  :write\<Cr>
+  :VimwikiRebuildTags!\<CR>
+
+Execute (Build tag links in third file):
+  edit $HOME/testmarkdown/subdir1/subdir11/Test-Tag-Links.md
+  AssertEqual $HOME . '/testmarkdown/subdir1/subdir11/Test-Tag-Links.md', expand('%')
+  AssertEqual 'markdown', vimwiki#vars#get_wikilocal('syntax')
+  AssertEqual 1, vimwiki#vars#get_bufferlocal('wiki_nr')
+  VimwikiGenerateTagLinks
+  write
+
+Expect (Tag links relative to current file):
+  
+
+  # Generated Tags
+
+  ## header-tag-1
+  
+  - [a-header](../../Test-Tag-1#a-header)
+  - [a-header](../Test-Tag-2#a-header)
+
+  ## header-tag-2
+
+  - [another-header](../../Test-Tag-1#another-header)
+  - [another-header](../Test-Tag-2#another-header)
+
+  ## standalone-tag-1
+
+  - [standalone-tag-1](../../Test-Tag-1#standalone-tag-1)
+  - [standalone-tag-1](../Test-Tag-2#standalone-tag-1)
+
+Execute (Clean relative tag setup):
+  call system("rm -rf $HOME/testmarkdown/subdir1")
+  call system("rm $HOME/testmarkdown/Test-Tag-1.md")


### PR DESCRIPTION
As described in issue #794 links that are generated from tags are build wrong and are resulting in non functioning links for which vimwiki tries to create new wiki files if followed.

This pull request changes the generated links in `vimwiki#tag#generate_tags` such that they are relative to the file in which the `VimwikiGenerateTagLinks` command is issued.

I am not certain if the tag link should be made relative when iterating over the available tag links (like in the proposed solution) or  earlier in the function when the `tag_entries` dictionary is build. I would be happy if someone who is more knowledgeable would have a look at this.

All vint tests are passing but I do not really know how to write an additional test for this change.
EDIT: I just added a vader test case which tests for tag links relative to the current directory.

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
