### PR TITLE
Feature: Add wiki page to buffer list using `badd`

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1652,6 +1652,8 @@ function! vimwiki#base#follow_link(split, ...) abort
       let cmd = ':split '
     elseif a:split ==# 'vsplit'
       let cmd = ':vsplit '
+    elseif a:split ==# 'badd'
+      let cmd = ':badd '
     elseif a:split ==# 'tab'
       let cmd = ':tabnew '
     else

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -359,6 +359,13 @@ MAP                MODE
                         Maps to |:VimwikiVSplitLink|.
                         Remap command: `<Plug>VimwikiVSplitLink`
 
+                                                              *vimwiki_<M-CR>*
+<M-CR>             n    Add to the buffer list, without loading, if it wasn't
+                        listed yet (create target wiki page if needed). May
+                        not work in some terminals. Remapping could help.
+                        Maps to |:VimwikiBaddLink|.
+                        Remap command: `<Plug>VimwikiBaddLink`
+
                                         *vimwiki_<C-S-CR>*    *vimwiki_<D-CR>*
 <C-S-CR>, <D-CR>   n    Follow wiki link (create target wiki page if needed),
                         opening in a new tab.
@@ -795,6 +802,10 @@ Vimwiki file.
 
     If 'move_cursor' is given and nonzero, the cursor moves to the window with
     the opened link, otherwise, it stays in the window with the link.
+
+*:VimwikiBaddLink*
+    Add to the buffer list, without loading, if it wasn't listed yet (create
+    target wiki page if needed).
 
 *:VimwikiTabnewLink*
     Follow wiki link in a new tab (create target wiki page if needed).
@@ -3924,6 +3935,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Vinny Furia (@vinnyfuria)
     - paperbenni (@paperbenni)
     - Lily Foster (@lilyinstarlight)
+    - Jean-Luc Bastarache (@jlbas)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3982,6 +3994,8 @@ New:~
       alternative date string format
     * Feature: Add |VimwikiPasteLink| to paste an absolute wiki link to the
       current file
+    * Feature: Add |VimwikiBaddLink| to add links to the buffer list, without
+      loading, if they weren't listed yet
 
 Changed:~
     * PR #1047: Allow to replace default mapping of VimwikiToggleListItem

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -306,6 +306,7 @@ command! -buffer VimwikiFollowLink call vimwiki#base#follow_link('nosplit', 0, 1
 command! -buffer VimwikiGoBackLink call vimwiki#base#go_back_link()
 command! -buffer -nargs=* VimwikiSplitLink call vimwiki#base#follow_link('hsplit', <f-args>)
 command! -buffer -nargs=* VimwikiVSplitLink call vimwiki#base#follow_link('vsplit', <f-args>)
+command! -buffer VimwikiBaddLink call vimwiki#base#follow_link('badd', 0, 1)
 
 command! -buffer -nargs=? VimwikiNormalizeLink call vimwiki#base#normalize_link(<f-args>)
 
@@ -386,6 +387,7 @@ if str2nr(vimwiki#vars#get_global('key_mappings').mouse)
         \ :call vimwiki#base#follow_link('nosplit', 0, 1, "\<lt>2-LeftMouse>")<CR>
   nnoremap <silent><buffer> <S-2-LeftMouse> <LeftMouse>:VimwikiSplitLink<CR>
   nnoremap <silent><buffer> <C-2-LeftMouse> <LeftMouse>:VimwikiVSplitLink<CR>
+  nnoremap <silent><buffer> <MiddleMouse> <LeftMouse>:VimwikiBaddLink<CR>
   nnoremap <silent><buffer> <RightMouse><LeftMouse> :VimwikiGoBackLink<CR>
 endif
 
@@ -406,6 +408,8 @@ nnoremap <silent><script><buffer> <Plug>VimwikiSplitLink
     \ :VimwikiSplitLink<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiVSplitLink
     \ :VimwikiVSplitLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiBaddLink
+    \ :VimwikiBaddLink<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiNormalizeLink
     \ :VimwikiNormalizeLink 0<CR>
 vnoremap <silent><script><buffer> <Plug>VimwikiNormalizeLinkVisual
@@ -440,6 +444,7 @@ if str2nr(vimwiki#vars#get_global('key_mappings').links)
   call vimwiki#u#map_key('n', '<CR>', '<Plug>VimwikiFollowLink')
   call vimwiki#u#map_key('n', '<S-CR>', '<Plug>VimwikiSplitLink')
   call vimwiki#u#map_key('n', '<C-CR>', '<Plug>VimwikiVSplitLink')
+  call vimwiki#u#map_key('n', '<M-CR>', '<Plug>VimwikiBaddLink')
   call vimwiki#u#map_key('n', '+', '<Plug>VimwikiNormalizeLink')
   call vimwiki#u#map_key('v', '+', '<Plug>VimwikiNormalizeLinkVisual')
   call vimwiki#u#map_key('v', '<CR>', '<Plug>VimwikiNormalizeLinkVisualCR')


### PR DESCRIPTION
This PR adds the `VimwikiBaddLink` command, which adds wiki pages to the buffer list, if they weren't already listed. The main reason for wanting this feature is to facilitate the process of opening multiple links. For example, using this command, one can open multiple wiki pages into hidden buffers, and then cycle or navigate through them however they like. When opening links, this avoids having to go back and forth or worrying about window layouts.

There has previously been interest for a feature that avoids such back and forth behavior when opening multiple links #1141. However, this PR only partially addresses that issue, since the user wanted a way of opening/listing all the links in the current page (something for a future PR if this fits into the overall design of Vimwiki).
