### PR TITLE
Revert breaking changes to customwiki2html.sh

### DIFF
--- a/autoload/vimwiki/customwiki2html.sh
+++ b/autoload/vimwiki/customwiki2html.sh
@@ -40,7 +40,7 @@ CSSFILE="$6"
 
 [[ "$SYNTAX" == "markdown" ]] || { echo "Error: Unsupported syntax"; exit 2; };
 
-OUTPUT="$OUTPUTDIR/$(basename "$INPUT" . "$EXTENSION").html"
+OUTPUT="$OUTPUTDIR/$(basename "$INPUT" ."$EXTENSION").html"
 
 # # Method 1:
 # FORCEFLAG=


### PR DESCRIPTION
There is an extra space when calling the `basename` command, which causes the following error:
```
Vimwiki: 'basename: extra operand ‘md’
Try ''basename --help'' for more information.
```

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
