### PR TITLE
README.md: point to libera.chat channel (#1167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,12 @@ let g:vimwiki_list = [{'path': '~/vimwiki/',
 [GitHub issues](https://github.com/vimwiki/vimwiki/issues) are the primary
 method for raising bug reports or feature requests.
 
-Additional resources include the IRC channel [#vimwiki](https://webchat.freenode.net/?channels=#vimwiki) on Freenode
-([webchat](https://webchat.freenode.net/?channels=#vimwiki), also synced to Matrix/Riot: `#freenode_#vimwiki:matrix.org` and [Telegram](https://t.me/joinchat/JqBaKBfWs04qNVrp5oWcMg))
-or post to the [mailing list](https://groups.google.com/forum/#!forum/vimwiki).
+Additional resources:
+
+  - The IRC channel [#vimwiki](ircs://irc.libera.chat:6697/vimwiki) on irc.libera.chat
+    - [Connect via webchat](https://web.libera.chat/?channels=#vimwiki)
+    - Connect via Matrix/Element: [#vimwiki:libera.chat](https://matrix.to/#/#vimwiki:libera.chat)
+  - Post to the [mailing list](https://groups.google.com/forum/#!forum/vimwiki).
 
 ## Helping VimWiki
 


### PR DESCRIPTION
README.md: point to libera.chat channel

Per discussion in #1131 and libera.chat `#vimwiki`.

Co-authored-by: KaiserBarbarossa <kaiser.barbarossa@yandex.com>
Co-authored-by: Brennen Bearnes <code@p1k3.com>
