### PR TITLE
Fix wildcard expansion in `find_autoload_file`

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -87,8 +87,9 @@ endfunction
 function! s:find_autoload_file(name) abort
   for path in split(&runtimepath, ',')
     let fname = path.'/autoload/vimwiki/'.a:name
-    if glob(fname) !=? ''
-      return fname
+    let match = glob(fname)
+    if match !=? ''
+      return match
     endif
   endfor
   return ''

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3924,6 +3924,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Vinny Furia (@vinnyfuria)
     - paperbenni (@paperbenni)
     - Lily Foster (@lilyinstarlight)
+    - Thomas Leyh (@leyhline)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -3994,6 +3995,7 @@ Changed:~
 Removed:~
 
 Fixed:~
+    * Issue #1193: Fix wildcard expansion in |find_autoload_file|
     * PR #1108: Fix resolution of leading-slash page links, add link tests
     * Allow title values with quotes
     * Enable strikethrough for Neovim


### PR DESCRIPTION
When using vim's native mechanism for `packages`, wildcards (*) are used
in the `runtimepath` since package folders can have arbitrary names.
They were not expanded, thus a path to e.g. `default.tpl` could not be
resolved when calling Vimwiki2HTML.

Resolves vimwiki/vimwiki#1193

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
