### PR TITLE
Improve generation of tag links

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1968,7 +1968,7 @@ endfunction
 
 function! vimwiki#base#TO_header(inner, including_subheaders, count) abort
   " Jump to next header (Exported for text object)
-  let headers = s:collect_headers()
+  let headers = vimwiki#base#collect_headers()
   if empty(headers)
     return
   endif
@@ -2275,7 +2275,7 @@ function! vimwiki#base#RemoveHeaderLevel(...) abort
 endfunction
 
 
-function! s:collect_headers() abort
+function! vimwiki#base#collect_headers() abort
   " Returns: all the headers in the current buffer as a list of the form
   " [[line_number, header_level, header_text], [...], [...], ...]
   " Init loop variables
@@ -2392,7 +2392,7 @@ endfunction
 
 function! vimwiki#base#goto_parent_header() abort
   " Jump to parent header
-  let headers = s:collect_headers()
+  let headers = vimwiki#base#collect_headers()
   let current_header_index = s:current_header(headers, line('.'))
   let parent_header = s:get_another_header(headers, current_header_index, -1, '<')
   if parent_header >= 0
@@ -2405,7 +2405,7 @@ endfunction
 
 function! vimwiki#base#goto_next_header() abort
   " Jump to next header
-  let headers = s:collect_headers()
+  let headers = vimwiki#base#collect_headers()
   let current_header_index = s:current_header(headers, line('.'))
   if current_header_index >= 0 && current_header_index < len(headers) - 1
     call cursor(headers[current_header_index + 1][0], 1)
@@ -2419,7 +2419,7 @@ endfunction
 
 function! vimwiki#base#goto_prev_header() abort
   " Jump to previous header
-  let headers = s:collect_headers()
+  let headers = vimwiki#base#collect_headers()
   let current_header_index = s:current_header(headers, line('.'))
   " if the cursor already was on a header, jump to the previous one
   if current_header_index >= 1 && headers[current_header_index][0] == line('.')
@@ -2435,7 +2435,7 @@ endfunction
 
 function! vimwiki#base#goto_sibling(direction) abort
   " Jump to sibling header, next or previous (with same level)
-  let headers = s:collect_headers()
+  let headers = vimwiki#base#collect_headers()
   let current_header_index = s:current_header(headers, line('.'))
   let next_potential_sibling =
         \ s:get_another_header(headers, current_header_index, a:direction, '<=')
@@ -2453,7 +2453,7 @@ function! vimwiki#base#table_of_contents(create) abort
   " a:create == 1: creates or updates TOC in current file
   " a:create == 0: update if TOC exists
   " Gather heading
-  let headers = s:collect_headers()
+  let headers = vimwiki#base#collect_headers()
   let toc_header_text = vimwiki#vars#get_wikilocal('toc_header')
 
   if !a:create

--- a/test/tag.vader
+++ b/test/tag.vader
@@ -276,6 +276,30 @@ Expect (Tag links relative to current file):
   - [standalone-tag-1](../../Test-Tag-1#standalone-tag-1)
   - [standalone-tag-1](../Test-Tag-2#standalone-tag-1)
 
+Do (Delete some existing links to test updating generated tag links):
+  :edit $HOME/testmarkdown/subdir1/subdir11/Test-Tag-Links.md\<Cr>
+  7G
+  dd
+  12G
+  6dd
+  :write\<Cr>
+  :call vimwiki#tags#generate_tags(0)\<Cr>
+
+Expect (Only update generated tag links for tags already existing in the file):
+  
+
+  # Generated Tags
+
+  ## header-tag-1
+  
+  - [A Header](../../Test-Tag-1#a-header)
+  - [A Header](../Test-Tag-2#a-header)
+
+  ## header-tag-2
+
+  - [Another Header](../../Test-Tag-1#another-header)
+  - [Another Header](../Test-Tag-2#another-header)
+
 Execute (Clean relative tag setup):
   call system("rm -rf $HOME/testmarkdown/subdir1")
   call system("rm $HOME/testmarkdown/Test-Tag-1.md")

--- a/test/tag.vader
+++ b/test/tag.vader
@@ -59,11 +59,11 @@ Expect (Correctly generated tags section {{{3):
 
   ## tag-bar-2
 
-  - [a-header](Test-Tag#a-header)
+  - [A header](Test-Tag#a-header)
 
   ## tag-bar-3
 
-  - [a-header](Test-Tag#a-header)
+  - [A header](Test-Tag#a-header)
 
 
 Do (Write a quick tag for a quick jump):
@@ -160,9 +160,9 @@ Expect (Correctly formatted tags file):
   !_TAG_PROGRAM_NAME	Vimwiki Tags
   !_TAG_PROGRAM_URL	https://github.com/vimwiki/vimwiki
   !_TAG_PROGRAM_VERSION	2.5
-  second-tag	Test-Tag.md	13;"	vimwiki:Test-Tag\tTest-Tag#second-tag
-  test-tag	Test-Tag.md	5;"	vimwiki:Test-Tag\tTest-Tag#a-header
-  top-tag	Test-Tag.md	1;"	vimwiki:Test-Tag\tTest-Tag
+  second-tag	Test-Tag.md	13;"	vimwiki:Test-Tag\tTest-Tag#second-tag\tTest-Tag#second-tag
+  test-tag	Test-Tag.md	5;"	vimwiki:Test-Tag\tTest-Tag#a-header\tA header
+  top-tag	Test-Tag.md	1;"	vimwiki:Test-Tag\tTest-Tag\tTest-Tag
 
 Execute (Generate tags):
   edit $HOME/testmarkdown/Test-Tag.md
@@ -192,7 +192,7 @@ Expect (Correctly generated tags section):
 
   ## test-tag
 
-  - [a-header](Test-Tag#a-header)
+  - [A header](Test-Tag#a-header)
 
   ## top-tag
 
@@ -263,13 +263,13 @@ Expect (Tag links relative to current file):
 
   ## header-tag-1
   
-  - [a-header](../../Test-Tag-1#a-header)
-  - [a-header](../Test-Tag-2#a-header)
+  - [A Header](../../Test-Tag-1#a-header)
+  - [A Header](../Test-Tag-2#a-header)
 
   ## header-tag-2
 
-  - [another-header](../../Test-Tag-1#another-header)
-  - [another-header](../Test-Tag-2#another-header)
+  - [Another Header](../../Test-Tag-1#another-header)
+  - [Another Header](../Test-Tag-2#another-header)
 
   ## standalone-tag-1
 


### PR DESCRIPTION
This PR introduces the following changes to the tag system:

# Collect a link description when building the tag metadata file

Before, the link caption of a generated tag link was set as the anchor of the link, which resulted in ugly looking lists. E.g. the 
following:
```
# This is a header
:this-is-a-tag:
```
Resulted in the generated tag links:
```
# Generated Tags

## this-is-a-tag
- [this-is-a-header](#this-is-a-header)
```
The link caption would look even more strange when the header had a higher level, which results in all parent headers being included in the link.

This was updated to show the real header text before it was formatted as an anchor (a53d605) which results in:

```
# Generated Tags

## this-is-a-tag
- [This is a header](#this-is-a-header)
```

**Attention**: This changes the creation of the meta-data file and thus marks old meta data file versions as corrupted. This can however easily be fixed by deleting the `.vimwiki-tags` metadata file and rebuilding it with `:VimwikiRebuildTags`.

To allow the vader tests to pass, some of the tests in `tag.vader` had to be adjusted for the new header captions and the changed metadata file format. (402ff6f)

# Look for already existing tag links

When setting `vimwiki-option-auto_generate_tags` to `1` and writing a file where `VimwikiGenerateTagLinks` was invoked with only a single tag e.g.. The function `vimwiki#tags#generate_tags` would overwrite the auto generated links for this single tag with the links to all tags available in the current wiki. This does not seem to be the intent of the `auto_generate_tags` option.

The function was changed so that when having the option enabled the buffer will now be searched for the `vimwiki#vars#get_global('tags_header')` (`Generated Tags` by default) and all tags that were used to build the auto generated links will be used to update these instead of overwriting it with all available tags in the wiki. (64c606b)

For this to work I made the function `s:collect_headers` a plugin wide function (so I changed it to `vimwiki#base#collect_headers`) as it was defined in `base.vim`. This way one can use it in `tags.vim` to retrieve all headers in the file and iterate over them. (b1deba9) Obviously I also changed all occurences of `collect_headers()` in `base.vim` to `vimwiki#base#collect_headers()`.

Additionally I added another vader test case to cover the updating of the auto generated link section. (b079a47)

All vader and vint tests are passing for me.

----

Adresses #724
Might be related to #966 but I could be wrong as the information there is very limited.

I have not yet updated the changelog as I am not sure if that is fixing #724.

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
