### PR TITLE
Support angle bracket escaped markdown urls

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -1181,7 +1181,7 @@ function! s:populate_extra_markdown_vars() abort
   let mkd_syntax.rxWeblinkMatchDescr0 = mkd_syntax.rxWeblinkMatchDescr
 
   let mkd_syntax.rxWeblink1Prefix = '['
-  let mkd_syntax.rxWeblink1Suffix = '>\=)'
+  let mkd_syntax.rxWeblink1Suffix = ')'
   let mkd_syntax.rxWeblink1EscapeCharsSuffix = '\(\\\)\@<!\(>\=)\)'
   let mkd_syntax.rxWeblink1Separator = ']('
 

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -1181,8 +1181,8 @@ function! s:populate_extra_markdown_vars() abort
   let mkd_syntax.rxWeblinkMatchDescr0 = mkd_syntax.rxWeblinkMatchDescr
 
   let mkd_syntax.rxWeblink1Prefix = '['
-  let mkd_syntax.rxWeblink1Suffix = ')'
-  let mkd_syntax.rxWeblink1EscapeCharsSuffix = '\(\\\)\@<!\()\)'
+  let mkd_syntax.rxWeblink1Suffix = '>\=)'
+  let mkd_syntax.rxWeblink1EscapeCharsSuffix = '\(\\\)\@<!\(>\=)\)'
   let mkd_syntax.rxWeblink1Separator = ']('
 
   let rxWeblink1Ext = ''
@@ -1207,7 +1207,7 @@ function! s:populate_extra_markdown_vars() abort
   let valid_chars_url = '[^[:cntrl:]]'
 
   let mkd_syntax.rxWeblink1Prefix = vimwiki#u#escape(mkd_syntax.rxWeblink1Prefix)
-  let mkd_syntax.rxWeblink1Separator = vimwiki#u#escape(mkd_syntax.rxWeblink1Separator)
+  let mkd_syntax.rxWeblink1Separator = '\](<\='
   let mkd_syntax.rxWeblink1Url = valid_chars_url.'\{-}'
   let mkd_syntax.rxWeblink1Descr = valid_chars.'\{-}'
   let mkd_syntax.WikiLinkMatchUrlTemplate =

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3973,6 +3973,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Jean-Luc Bastarache (@jlbas)
     - Youssof Taha (@ysftaha)
     - Thomas Leyh (@leyhline)
+    - Charles Schimmelpfennig (@charlesschimmel)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -4034,6 +4035,7 @@ New:~
       current file
     * Feature: Add |VimwikiBaddLink| to add links to the buffer list, without
       loading, if they weren't listed yet
+    * PR #XXX: Enable parsing Markdown links escaped with angle brackets
 
 Changed:~
     * PR #1047: Allow to replace default mapping of VimwikiToggleListItem


### PR DESCRIPTION
Very small change to support Markdown links with angle bracket escaped URIs, like `[link title](<path/to/some file>)` to enable link-following of angle bracket escaped markdown links. This syntax is [part of the the Commonmark spec](https://spec.commonmark.org/0.30/#example-487):

> The [link] destination can only contain spaces if it is enclosed in pointy brackets

 This is also helpful is people use Obsidian alongside their Vimwiki as Obsidian strongly conforms to markdown standards and will not parse links with enescaped spaces. I believe this is all needed to support link following and concealment/preview.

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

Edited to specifically highlight link-following of angle bracket escaped markdown links and add related commonmark spec