### PR TITLE
All asymetric headers require space between the symbol and header text

### DIFF
--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -717,7 +717,7 @@ function! s:get_default_syntaxlocal() abort
 endfunction
 
 function! s:get_markdown_syntaxlocal() abort
-  let atx_header_search = '^\s*\(#\{1,6}\)\([^#].*\)$'
+  let atx_header_search = '^\s*\(#\{1,6}\)\s\+\([^#].*\)$'
   let atx_header_match  = '^\s*\(#\{1,6}\)#\@!\s*__Header__\s*$'
 
   let setex_header_search = '^\s\{0,3}\zs[^>].*\ze\n'
@@ -932,18 +932,18 @@ function! vimwiki#vars#populate_syntax_vars(syntax) abort
       let syntax_dic['rxH'.i.'_Template'] =
             \ repeat(header_symbol, i).' __Header__'
       let syntax_dic['rxH'.i] =
-            \ '^\s*'.header_symbol.'\{'.i.'}[^'.header_symbol.'].*$'
+            \ '^\s*'.header_symbol.'\{'.i.'}\s\+.*$'
       let syntax_dic['rxH'.i.'_Text'] =
-            \ '^\s*'.header_symbol.'\{'.i.'}\zs[^'.header_symbol.'].*\ze$'
+            \ '^\s*'.header_symbol.'\{'.i.'}\s\+\zs.*\ze$'
       let syntax_dic['rxH'.i.'_Start'] =
-            \ '^\s*'.header_symbol.'\{'.i.'}[^'.header_symbol.'].*$'
+            \ '^\s*'.header_symbol.'\{'.i.'}\s\+.*$'
       let syntax_dic['rxH'.i.'_End'] =
-            \ '^\s*'.header_symbol.'\{1,'.i.'}[^'.header_symbol.'].*$\|\%$'
+            \ '^\s*'.header_symbol.'\{1,'.i.'}\s\+.*$\|\%$'
     endfor
     " Define header regex
     " -- ATX heading := preceed by #*
     let atx_heading = '^\s*\%('.header_symbol.'\{1,6}\)'
-    let atx_heading .= '\zs[^'.header_symbol.'].*\ze$'
+    let atx_heading .= '\s\+\zs.*\ze$'
     let syntax_dic.rxHeader = atx_heading
   endif
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -4036,6 +4036,7 @@ New:~
       loading, if they weren't listed yet
 
 Changed:~
+    * PR #1221: Force markdown headers to have a space between the #'s and text
     * PR #1047: Allow to replace default mapping of VimwikiToggleListItem
     * VimwikiCheckLinks work on current wiki or on range
     * PR #1057: Change how resolve subdir work

--- a/test/fold.vader
+++ b/test/fold.vader
@@ -12,7 +12,8 @@ Given vimwiki (Markdown Headers):
   ### Header level 3  5
   # Header level 1    6
     Content           7
-  ## Just to end      8: Vader cannot match end-of-file
+  #notaheader         8
+  ## Just to end      9: Vader cannot match end-of-file
 
 Execute (Markdown and Fold Syntax):
   call SetSyntax('markdown')
@@ -27,6 +28,7 @@ Execute (Assert Markdown: Fold Syntax):
   AssertEqual 'line 5:2', 'line 5:' . foldlevel(5) 
   AssertEqual 'line 6:0', 'line 6:' . foldlevel(6) 
   AssertEqual 'line 7:0', 'line 7:' . foldlevel(7) 
+  AssertEqual 'line 8:0', 'line 8:' . foldlevel(8) 
 
 
 Given vimwiki (Wiki Headers):


### PR DESCRIPTION
Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues. (Raising PR immediately as the start of the conversation)
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

---

Updating the ATX headers details for the Markdown syntax to better match the specification at https://github.github.com/gfm/#atx-headings, particularly that:
> The opening sequence of # characters must be followed by a [space](https://github.github.com/gfm/#space)  

My desire is to have tags compatible with obsidian.md, which I have managed with the below tag format:
```viml
let g:vimwiki_tag_format = {
            \'pre_mark': '[''"]\?#\( \|#\)\@!',
            \'sep': '>><<',
            \'post_mark': '[''" ]\?\|$'
            \}
```
But tags were being recognized as headings, leading me to this change.