### PR TITLE
Reuse existing tabs with tab drop in following links and opening diary pages (closes #238)

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1664,8 +1664,17 @@ function! vimwiki#base#follow_link(split, ...) abort
       let cmd = ':badd '
     elseif a:split ==# 'tab'
       let cmd = ':tabnew '
+    elseif a:split ==# 'tabdrop'
+      " Use tab drop if we've already got the file open in an existing tab
+      let cmd = ':tab drop '
     else
+      " Same as above - doing this by default reduces incidence of multiple
+      " tabs with the same file.  We default to :e just in case :drop doesn't
+      " exist in the current build.
       let cmd = ':e '
+      if exists(':drop')
+        let cmd = ':drop '
+      endif
     endif
 
     " if we want to and can reuse a split window, jump to that window and open
@@ -1677,7 +1686,6 @@ function! vimwiki#base#follow_link(split, ...) abort
         let cmd = ':e'
       endif
     endif
-
 
     if vimwiki#vars#get_wikilocal('syntax') ==# 'markdown'
       let processed_by_markdown_reflink = vimwiki#markdown_base#open_reflink(lnk)

--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -307,6 +307,13 @@ function! vimwiki#diary#make_note(wnum, ...) abort
       let cmd = 'split'
     elseif a:1 == 3
       let cmd = 'vsplit'
+    elseif a:1 == 4
+      let cmd = 'tab drop'
+    elseif a:1 == 5
+      let cmd = 'drop'
+      if exists(':drop')
+        let cmd = 'drop'
+      endif
     endif
   endif
   if a:0>1

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -370,8 +370,10 @@ MAP                MODE
 <C-S-CR>, <D-CR>   n    Follow wiki link (create target wiki page if needed),
                         opening in a new tab.
                         May not work in some terminals. Remapping could help.
-                        Maps to |:VimwikiTabnewLink|.
-                        Remap command: `<Plug>VimwikiTabnewLink`
+                        Maps to |:VimwikiTabDropLink|.
+                        Remap command: `<Plug>VimwikiTabDropLink`
+                        See |:VimwikiTabnewLink| for old behavior which
+                        always opens a new tab.
 
                                                          *vimwiki_<Backspace>*
 <Backspace>        n    Go back to previously visited wiki page.
@@ -809,6 +811,11 @@ Vimwiki file.
 
 *:VimwikiTabnewLink*
     Follow wiki link in a new tab (create target wiki page if needed).
+
+*:VimwikiTabDropLink*
+    Follow wiki link with tab drop, reusing any existing tabs with the page.
+    Creates a new tab if the page isn't already open (create target wiki page
+    if needed).
 
 *:VimwikiNextLink*
     Find next link on the current page.
@@ -3984,6 +3991,7 @@ http://code.google.com/p/vimwiki/issues/list. They may be accessible from
 https://github.com/vimwiki-backup/vimwiki/issues.
 
 New:~
+    * Feature: #238: Reuse existing tabs with tab drop
     * Issue #621: Feature request: Highlight code listings in HTML
     * Issue #290: Calendar plugin, do not sign if no wiki
     * Issue #281: Permit `\|` in tables

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -312,6 +312,8 @@ command! -buffer -nargs=? VimwikiNormalizeLink call vimwiki#base#normalize_link(
 
 command! -buffer VimwikiTabnewLink call vimwiki#base#follow_link('tab', 0, 1)
 
+command! -buffer VimwikiTabDropLink call vimwiki#base#follow_link('tabdrop', 0, 1)
+
 command! -buffer -nargs=? VimwikiGenerateLinks call vimwiki#base#generate_links(1, <f-args>)
 
 command! -buffer -nargs=0 VimwikiBacklinks call vimwiki#base#backlinks()
@@ -418,6 +420,8 @@ vnoremap <silent><script><buffer> <Plug>VimwikiNormalizeLinkVisualCR
     \ :<C-U>VimwikiNormalizeLink 1<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiTabnewLink
     \ :VimwikiTabnewLink<CR>
+nnoremap <silent><script><buffer> <Plug>VimwikiTabDropLink
+    \ :VimwikiTabDropLink<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiGoBackLink
     \ :VimwikiGoBackLink<CR>
 nnoremap <silent><script><buffer> <Plug>VimwikiNextLink
@@ -448,8 +452,8 @@ if str2nr(vimwiki#vars#get_global('key_mappings').links)
   call vimwiki#u#map_key('n', '+', '<Plug>VimwikiNormalizeLink')
   call vimwiki#u#map_key('v', '+', '<Plug>VimwikiNormalizeLinkVisual')
   call vimwiki#u#map_key('v', '<CR>', '<Plug>VimwikiNormalizeLinkVisualCR')
-  call vimwiki#u#map_key('n', '<D-CR>', '<Plug>VimwikiTabnewLink')
-  call vimwiki#u#map_key('n', '<C-S-CR>', '<Plug>VimwikiTabnewLink', 1)
+  call vimwiki#u#map_key('n', '<D-CR>', '<Plug>VimwikiTabDropLink')
+  call vimwiki#u#map_key('n', '<C-S-CR>', '<Plug>VimwikiTabDropLink', 1)
   call vimwiki#u#map_key('n', '<BS>', '<Plug>VimwikiGoBackLink')
   call vimwiki#u#map_key('n', '<TAB>', '<Plug>VimwikiNextLink')
   call vimwiki#u#map_key('n', '<S-TAB>', '<Plug>VimwikiPrevLink')

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -362,7 +362,7 @@ command! -count=0 VimwikiDiaryIndex
       \ call vimwiki#diary#goto_diary_index(<count>)
 
 command! -count=0 VimwikiMakeDiaryNote
-      \ call vimwiki#diary#make_note(<count>)
+      \ call vimwiki#diary#make_note(<count>, 5)
 
 command! -count=0 VimwikiTabMakeDiaryNote
       \ call vimwiki#diary#make_note(<count>, 1)
@@ -397,7 +397,7 @@ nnoremap <silent><script> <Plug>VimwikiDiaryIndex
 nnoremap <silent><script> <Plug>VimwikiDiaryGenerateLinks
     \ :VimwikiDiaryGenerateLinks<CR>
 nnoremap <silent><script> <Plug>VimwikiMakeDiaryNote
-    \ :<C-U>call vimwiki#diary#make_note(v:count)<CR>
+    \ :<C-U>call vimwiki#diary#make_note(v:count, 5)<CR>
 nnoremap <silent><script> <Plug>VimwikiTabMakeDiaryNote
     \ :<C-U>call vimwiki#diary#make_note(v:count, 1)<CR>
 nnoremap <silent><script> <Plug>VimwikiMakeYesterdayDiaryNote


### PR DESCRIPTION
Replaces :e in `vimwiki#base#follow_link()` with `:drop`, making this the default behavior for pressing `<CR>` on a link.

Adds a new `:VimwikiTabDropLink` and makes this a default for the keybindings formerly occupied by `:VimwikiTabnewLink`; leaving `:VimwikiTabnewLink` available for backwards compatibility and anyone who still wants the old behavior.

Also defaults to using `:drop` for `:VimwikiMakeDiaryNote`, eliminating another common source of duplicate tabs / buffers.

Doesn't touch the split window reuse functionality, or the :VimwikiGoBackLink behavior, although I can see an argument for adding :drop to the latter.

I've wanted these changes for a while and happened to notice @davidlmontgomery's patch from 2016 in #238.  Code has moved around a little since, but I think this is correct.

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.