### PR TITLE
fix wiki-style backlinks for markdown syntax

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -947,10 +947,10 @@ function! s:get_links(wikifile, idx) abort
   endif
 
   let syntax = vimwiki#vars#get_wikilocal('syntax', a:idx)
+  let rx_link = vimwiki#vars#get_syntaxlocal('wikilink', syntax)
+
   if syntax ==# 'markdown'
-    let rx_link = vimwiki#vars#get_syntaxlocal('rxWeblink1MatchUrl', syntax)
-  else
-    let rx_link = vimwiki#vars#get_syntaxlocal('wikilink', syntax)
+    let md_rx_link = vimwiki#vars#get_syntaxlocal('rxWeblink1MatchUrl', syntax)
   endif
 
   let links = []
@@ -963,9 +963,15 @@ function! s:get_links(wikifile, idx) abort
     while 1
       let col = match(line, rx_link, 0, link_count)+1
       let link_text = matchstr(line, rx_link, 0, link_count)
+
+      " if a link wasn't found, also try markdown syntax (if enabled)
+      if link_text ==? '' && syntax ==# 'markdown'
+        let link_text = matchstr(line, md_rx_link, 0, link_count)
+      endif
       if link_text ==? ''
         break
       endif
+
       let link_count += 1
       let target = vimwiki#base#resolve_link(link_text, a:wikifile)
       if target.filename !=? '' && target.scheme =~# '\mwiki\d\+\|diary\|file\|local'
@@ -1523,7 +1529,7 @@ function! vimwiki#base#update_listing_in_buffer(Generator, start_header,
     " them right back.
     let foldenable_save = &l:foldenable
     setlocal nofoldenable
-    
+
     " Clause: don't update file if there are no changes
     if (join(getline(start_lnum + 2, end_lnum - 1), '') == join(a_list, ''))
       return


### PR DESCRIPTION
Very small bugfix - addresses #1244 

Changes the way s:get_links finds/lists links within a file, so that both \[regular-links\](regular-links) and [[wiki-links]] are recognised when using markdown syntax. This should make VimwikiBacklinks line up with everything else.