### PR TITLE
in documentation, update link to tagbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,12 @@ let g:vimwiki_list = [{'path': '~/vimwiki/',
 [GitHub issues](https://github.com/vimwiki/vimwiki/issues) are the primary
 method for raising bug reports or feature requests.
 
-Additional resources include the IRC channel [#vimwiki](https://webchat.freenode.net/?channels=#vimwiki) on Freenode
-([webchat](https://webchat.freenode.net/?channels=#vimwiki), also synced to Matrix/Riot: `#freenode_#vimwiki:matrix.org` and [Telegram](https://t.me/joinchat/JqBaKBfWs04qNVrp5oWcMg))
-or post to the [mailing list](https://groups.google.com/forum/#!forum/vimwiki).
+Additional resources:
+
+  - The IRC channel [#vimwiki](ircs://irc.libera.chat:6697/vimwiki) on irc.libera.chat
+    - [Connect via webchat](https://web.libera.chat/?channels=#vimwiki)
+    - Connect via Matrix/Element: [#vimwiki:libera.chat](https://matrix.to/#/#vimwiki:libera.chat)
+  - Post to the [mailing list](https://groups.google.com/forum/#!forum/vimwiki).
 
 ## Helping VimWiki
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -1988,7 +1988,7 @@ If you want to keep the TOC up to date automatically, use the option
 Tagbar integration                                            *vimwiki-tagbar*
 
 As an alternative to the Table of Contents, you can use the Tagbar plugin
-(http://majutsushi.github.io/tagbar/) to show the headers of your wiki files
+(https://preservim.github.io/tagbar/) to show the headers of your wiki files
 in a side pane.
 Download the Python script from
 https://raw.githubusercontent.com/vimwiki/utils/master/vwtags.py and follow

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -10,7 +10,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release, otherwise -1 for dev-branch
-let s:plugin_vers = -1
+let s:plugin_vers = 2.5
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')


### PR DESCRIPTION
Old link is dead (and non-ssl http)

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
;)