### PR TITLE
resolve_link(): check ext against version with dot (fixes #1256)

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -265,7 +265,8 @@ function! vimwiki#base#resolve_link(link_text, ...) abort
       " append extension iff one not already present or it's not the targeted
       " wiki extension - https://github.com/vimwiki/vimwiki/issues/950
       let ext = fnamemodify(link_text, ':e')
-      if ext ==? '' || ext !=? vimwiki#vars#get_wikilocal('ext', link_infos.index)
+      let ext_with_dot = '.' . ext
+      if ext ==? '' || ext_with_dot !=? vimwiki#vars#get_wikilocal('ext', link_infos.index)
         let link_infos.filename .= vimwiki#vars#get_wikilocal('ext', link_infos.index)
       endif
     endif


### PR DESCRIPTION
It turns out that the target extension here in `ext` has a dot prepended.

Under manual testing, this seems to fix the issue where a wiki with `markdown_link_ext` set and using `.md` (for example) in links will wind up taking people to pages with a repeated extension, like `foo.md.md`.

I feel like the repeated use of:

```
vimwiki#vars#get_wikilocal('ext', link_infos.index)
```

here should probably be replaced with a named variable like `target_ext`, but I wanted to touch the minimum lines of code possible for this fix.