### PR TITLE
Provide link of LICENSE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,22 +265,6 @@ Also, take a look at [CONTRIBUTING.md](https://github.com/vimwiki/vimwiki/blob/m
 MIT License
 
 Copyright (c) 2008-2010 Maxim Kim
-              2013-2017 Daniel Schemala
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+              2013-2017 Daniel Schemala.
+              
+For more details refer to [LICENSE](LICENSE.md) File.


### PR DESCRIPTION
Providing the Link of License file will be better than copy pasting the whole License. 