### PR TITLE
#1291: Fix Markdown Header Level 1 as List

### DIFF
--- a/syntax/vimwiki_markdown_custom.vim
+++ b/syntax/vimwiki_markdown_custom.vim
@@ -122,6 +122,12 @@ let s:target = vimwiki#base#apply_template(
       \ vimwiki#vars#get_syntaxlocal('rxWikiLink1Descr'), '', '')
 call s:add_target_syntax_ON(s:wrap_wikilink1_rx(s:target), 'VimwikiWikiLink1')
 
+" Header levels, 1-6
+for s:i in range(1,6)
+  execute 'syntax match VimwikiHeader'.s:i.' /'.vimwiki#vars#get_syntaxlocal('rxH'.s:i).
+              \ '/ contains=VimwikiTodo,VimwikiHeaderChar,VimwikiNoExistsLink,VimwikiCode,'.
+              \ 'VimwikiLink,VimwikiWeblink1,VimwikiWikiLink1,@Spell'
+endfor
 
 " concealed chars
 if exists('+conceallevel')


### PR DESCRIPTION
Reverting header level deletion that happened in https://github.com/vimwiki/vimwiki/commit/990b25ce37bbeb8a8c8f9208c0f8f455202041db. This pull request resolves syntax highlighting bug that first level header getting rendered as a list when syntax is set to markdown.

This fixes: https://github.com/vimwiki/vimwiki/issues/1291