### PR TITLE
Fix: Handle multibyte chars properly in get_cells

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -3982,6 +3982,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Thomas Leyh (@leyhline)
     - nebulaeandstars (@nebulaeandstars)
     - dmitry kim (@jsn)
+    - Julian Prein (@druckdev)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*


### PR DESCRIPTION
Previously `vimwiki#tbl#get_cells()` would act on `line` as a normal string (i.e. using `[idx]` and `strpart()`). This breaks when the column separator (`s:s_rep()` or `rxTableSep`) is a multibyte character like the vertical box drawing character `│`. In that case the separator is never found and only one empty cell is returned. This also affects `vimwiki#tbl#format()` which in turn clears the whole table each time the insert mode is left.

Fix this issue by initially splitting the line into a list of the characters. Getting the elements with `[idx]` now returns each character instead of a byte. In addition `len()` is used in place of `strlen()` as well as slicing together with join() instead of `strpart()`.

Fixes: #1297 ("Table formatting breaks on multibyte separator")

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
