### PR TITLE
is_diary_file(): use filereadable() to check a single file

### DIFF
--- a/test/api_base_is_diary_file.vader
+++ b/test/api_base_is_diary_file.vader
@@ -1,0 +1,25 @@
+# Test vimwiki#base#is_diary_file() for various inputs.
+
+Execute (Check known good diary file):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('diary:2020-07-22')
+  Assert vimwiki#base#is_diary_file(link_infos.filename)
+
+Execute (Check known good diary file using is_diary_file, with list of all diary files - legacy interface):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('diary:2020-07-22')
+  let diary_file_paths = vimwiki#diary#get_diary_files()
+  Assert vimwiki#base#is_diary_file(link_infos.filename, diary_file_paths)
+
+Execute (Check known good diary file use is_among_diary_files, with list of all diary files):
+  VimwikiIndex 1
+  let link_infos = vimwiki#base#resolve_link('diary:2020-07-22')
+  let diary_file_paths = vimwiki#diary#get_diary_files()
+  Assert vimwiki#base#is_among_diary_files(link_infos.filename, diary_file_paths)
+
+Execute (Check for nonexistent diary file):
+  VimwikiIndex 1
+  Assert !vimwiki#base#is_diary_file('not-a-diary-file')
+
+Execute (Clean):
+  call ReloadVimwiki()


### PR DESCRIPTION
Intended to address #1267 - "get_diary_files() takes very long to execute on Windows - this leads to very slow link-creation using the Enter key".

In theory, this should be a performance improvement for link creation on systems with very slow filesystem access (this came up under Windows, but ought to be a general optimization).  It does nothing for generating the entire list of diary files, which by nature has to get the whole list anyway.

  - Uses a single `filereadable()` call against a path instead of checking the results of `get_diary_files()` for most calls.

  - Introduces `is_among_diary_files()` for the case where you want to check against a `get_diary_files()` list.

  - `is_diary_file()` will pass through to is_among_diary_files() if it gets invoked with a second parameter, to retain backwards compatibility on the off chance anyone has scripted against this behavior.  I'm not sure this is necessary, but trying to be cautious with the implicit API here.

 - Includes a `test/api_base_is_diary_file.vader`

My original version of this change assumed that input would be in the form of "2023-01-01", instead of a fully-qualifed filename.  As it is, it expects a full path to the file, in keeping with the list returned by `vimwiki#diary#get_diary_files()`.