### PR TITLE
File name prompt fixes

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1109,7 +1109,7 @@ function! vimwiki#base#edit_file(command, filename, anchor, ...) abort
   " :param: anchor
   " :param: (1) vimwiki_prev_link
   " :param: (2) vimwiki#u#ft_is_vw()
-  let fname = escape(a:filename, '% *|#`')
+  let fname = fnameescape(a:filename)
   let dir = fnamemodify(a:filename, ':p:h')
 
   let ok = vimwiki#path#mkdir(dir, 1)

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -495,6 +495,11 @@ function! vimwiki#base#goto(...) abort
   let key = a:0 > 0 && a:1 !=# '' ? a:1 : input('Enter name: ', '',
         \ 'customlist,vimwiki#base#complete_links_escaped')
 
+  if key ==# ''
+    " Input cancelled
+    return
+  endif
+
   let anchor = a:0 > 1 ? a:2 : ''
 
   " Save current file pos

--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -394,7 +394,7 @@ function! vimwiki#base#open_link(cmd, link, ...) abort
 endfunction
 
 
-function! vimwiki#base#get_globlinks_escaped(...) abort
+function! vimwiki#base#get_globlinks(...) abort
   " Escape global link
   " Called by command completion
   let s_arg_lead = a:0 > 0 ? a:1 : ''
@@ -414,8 +414,6 @@ function! vimwiki#base#get_globlinks_escaped(...) abort
   " " use smart case matching
   let r_arg = substitute(s_arg_lead, '\u', '[\0\l\0]', 'g')
   call filter(lst, '-1 != match(v:val, r_arg)')
-  " Apply fnameescape() to each item
-  call map(lst, 'fnameescape(v:val)')
   " Return list (for customlist completion)
   return lst
 endfunction
@@ -493,7 +491,7 @@ function! vimwiki#base#goto(...) abort
   " Jump: to other wikifile, specified on command mode
   " Called: by command VimwikiGoto (Exported)
   let key = a:0 > 0 && a:1 !=# '' ? a:1 : input('Enter name: ', '',
-        \ 'customlist,vimwiki#base#complete_links_escaped')
+        \ 'customlist,vimwiki#base#complete_links')
 
   if key ==# ''
     " Input cancelled
@@ -2844,9 +2842,9 @@ function! vimwiki#base#detect_nested_syntax() abort
 endfunction
 
 
-function! vimwiki#base#complete_links_escaped(ArgLead, CmdLine, CursorPos) abort
+function! vimwiki#base#complete_links(ArgLead, CmdLine, CursorPos) abort
   " Complete escaping globlinks
-  return vimwiki#base#get_globlinks_escaped(a:ArgLead)
+  return vimwiki#base#get_globlinks(a:ArgLead)
 endfunction
 
 

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -322,7 +322,7 @@ command! -buffer -nargs=0 VWB call vimwiki#base#backlinks()
 command! -buffer -nargs=* VimwikiSearch call vimwiki#base#search(<q-args>)
 command! -buffer -nargs=* VWS call vimwiki#base#search(<q-args>)
 
-command! -buffer -nargs=* -complete=customlist,vimwiki#base#complete_links_escaped
+command! -buffer -nargs=* -complete=customlist,vimwiki#base#complete_links
       \ VimwikiGoto call vimwiki#base#goto(<q-args>)
 
 command! -buffer -range VimwikiCheckLinks call vimwiki#base#check_links(<range>, <line1>, <line2>)
@@ -568,7 +568,7 @@ if str2nr(vimwiki#vars#get_global('key_mappings').lists)
       inoremap <expr><silent><buffer> <S-CR> pumvisible() ? '<CR>' : '<Esc>:VimwikiReturn 2 2<CR>'
     endif
   endif
- 
+
   " change symbol for bulleted lists
   for s:char in vimwiki#vars#get_syntaxlocal('bullet_types')
     if !hasmapto(':VimwikiChangeSymbolTo '.s:char.'<CR>')

--- a/test/file_goto.vader
+++ b/test/file_goto.vader
@@ -40,7 +40,7 @@ Do (,wn buzz_bo + Completion(input()) && Assert):
 Execute (:VimwikiGoto + Completion (API)):
   VimwikiIndex 2
   AssertEqual $HOME . '/testmarkdown/index.md', expand('%')
-  let s_complete=string(vimwiki#base#get_globlinks_escaped())
+  let s_complete=string(vimwiki#base#get_globlinks())
   Assert -1 != stridx(s_complete, 'buzz_bozz')
 
 Execute (Create dir1/dir2/test_goto_file.md):
@@ -55,23 +55,23 @@ Execute (:VimwikiGoto + Completion in directory):
   AssertEqual $HOME . '/testmarkdown/index.md', expand('%')
 
   " Complete without argment
-  let s_complete1=string(vimwiki#base#get_globlinks_escaped())
+  let s_complete1=string(vimwiki#base#get_globlinks())
   Assert -1 != stridx(s_complete1, 'test_goto_file')
 
   " Complete with file argument
-  let s_complete2=string(vimwiki#base#get_globlinks_escaped('test_goto_file'))
+  let s_complete2=string(vimwiki#base#get_globlinks('test_goto_file'))
   Assert -1 != stridx(s_complete2, 'test_goto_file')
 
   " Complete with start of file argument
-  let s_complete3=string(vimwiki#base#get_globlinks_escaped('test_got'))
+  let s_complete3=string(vimwiki#base#get_globlinks('test_got'))
   Assert -1 != stridx(s_complete3, 'test_goto_file')
 
   " Complete with (nested) dir2 argument
-  let s_complete4=string(vimwiki#base#get_globlinks_escaped('dir2'))
+  let s_complete4=string(vimwiki#base#get_globlinks('dir2'))
   Assert -1 != stridx(s_complete4, 'test_goto_file')
 
   " Complete with bad argument
-  let l_complete5=vimwiki#base#get_globlinks_escaped('this_string_is_nowhere')
+  let l_complete5=vimwiki#base#get_globlinks('this_string_is_nowhere')
   let s_complete5=string(l_complete5)
   Assert -1 == stridx(s_complete5, 'test_goto_file')
   AssertEqual 0, len(l_complete5)


### PR DESCRIPTION
Fixes two issues mentioned in #1229

In the `Enter name:` prompt opened by `<leader>wn`:
- `<esc>` now just takes you out of the prompt without creating an empty `.wiki` page
- special characters are no longer escaped, since they were being escaped twice (once in `vimwiki#base#get_globlinks_escaped()` and once in `vimwiki#base#edit_file()`)