### PR TITLE
Fix vimwiki#diary#calendar_sign when g:vimwiki_list is not set

### DIFF
--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -523,7 +523,7 @@ endfunction
 function! vimwiki#diary#calendar_sign(day, month, year) abort
   " Callback function for Calendar.vim
   " Clause: no wiki no sign #290
-  if len(g:vimwiki_list) <= 0
+  if exists('g:vimwiki_list') && len(g:vimwiki_list) <= 0
     return
   endif
   let day = s:prefix_zero(a:day)

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -4002,6 +4002,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Thomas Leyh (@leyhline)
     - nebulaeandstars (@nebulaeandstars)
     - dmitry kim (@jsn)
+    - Luke Atkinson (@LukeDAtkinson)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -4019,6 +4020,12 @@ master is retained as a legacy mirror of the dev branch.
 
 This is somewhat experimental, and will probably be refined over time.
 
+2023.04.04~
+
+Fixed:~
+    * Issue #1336: vimwiki#diary#calendar_sign throws an error
+      when g:vimwiki_list is not set
+ 
 2023.04.04~
 
 New:~

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -11,7 +11,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release:
-let g:vimwiki_version = '2023.04.04'
+let g:vimwiki_version = '2023.05.12'
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')

--- a/test/tag.vader
+++ b/test/tag.vader
@@ -257,7 +257,7 @@ Expect (Correctly formatted tags file):
   !_TAG_PROGRAM_AUTHOR	Vimwiki
   !_TAG_PROGRAM_NAME	Vimwiki Tags
   !_TAG_PROGRAM_URL	https://github.com/vimwiki/vimwiki
-  !_TAG_PROGRAM_VERSION	2023.04.04
+  !_TAG_PROGRAM_VERSION	2023.05.12
   second-tag	Test-Tag.md	13;"	vimwiki:Test-Tag\tTest-Tag#second-tag\tTest-Tag#second-tag
   test-tag	Test-Tag.md	5;"	vimwiki:Test-Tag\tTest-Tag#a-header\tA header
   top-tag	Test-Tag.md	1;"	vimwiki:Test-Tag\tTest-Tag\tTest-Tag


### PR DESCRIPTION
If a user is happy with the default vimwiki location, they may not set the g:vimwiki_list global variable. In this case, the len(g:vimwiki_list) vimwiki#diary#calendar_sign function throws an error every time it is called. This function is called for every day displayed in the calendar which is very noisy. Checking if the variable exists before doing the length check prevents the error and the rest of the function works fine if the variable is not set.

This fixes #1336 , removing the need for the workaround I identified in that issue's discussion

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
