### PR TITLE
Fix error when opening links using system handler on Windows

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -313,7 +313,7 @@ function! vimwiki#base#system_open_link(url) abort
       else
         let url = shellescape(a:url, 1)
       endif
-      execute 'silent ! start "Title" /B ' . url
+      execute 'silent ! start /B ' . url
 
     else
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -4003,6 +4003,7 @@ Contributors and their Github usernames in roughly chronological order:
     - nebulaeandstars (@nebulaeandstars)
     - dmitry kim (@jsn)
     - Luke Atkinson (@LukeDAtkinson)
+    - Kincaid Savoie (@Caid11)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*
@@ -4019,6 +4020,12 @@ are accepted, they will merge directly to dev, which is now the main branch.
 master is retained as a legacy mirror of the dev branch.
 
 This is somewhat experimental, and will probably be refined over time.
+
+2023.05.13~
+
+Fixed:~
+    * Opening links using the system handler fails with "command not found"
+      error on Windows under Vim 9
 
 2023.04.04~
 

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -11,7 +11,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release:
-let g:vimwiki_version = '2023.05.12'
+let g:vimwiki_version = '2023.05.13'
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')

--- a/test/tag.vader
+++ b/test/tag.vader
@@ -257,7 +257,7 @@ Expect (Correctly formatted tags file):
   !_TAG_PROGRAM_AUTHOR	Vimwiki
   !_TAG_PROGRAM_NAME	Vimwiki Tags
   !_TAG_PROGRAM_URL	https://github.com/vimwiki/vimwiki
-  !_TAG_PROGRAM_VERSION	2023.05.12
+  !_TAG_PROGRAM_VERSION	2023.05.13
   second-tag	Test-Tag.md	13;"	vimwiki:Test-Tag\tTest-Tag#second-tag\tTest-Tag#second-tag
   test-tag	Test-Tag.md	5;"	vimwiki:Test-Tag\tTest-Tag#a-header\tA header
   top-tag	Test-Tag.md	1;"	vimwiki:Test-Tag\tTest-Tag\tTest-Tag


### PR DESCRIPTION
Under Windows and Vim 9, opening a link that triggers the system handler fails with a "command not found" error message. It looks like the title argument to `start` is treated as the executable path.

According to the help page for `start`, the title argument is optional, and /B instructs start not to open a CMD window, so the title is never used and can be removed with no loss in functionality.

This change removes the redundant title argument, fixing the "command not found" error.

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
