### PR TITLE
Fix: issue #1326 - VimwikiRebuildTags generates duplicate entries.

### DIFF
--- a/autoload/vimwiki/tags.vim
+++ b/autoload/vimwiki/tags.vim
@@ -123,38 +123,34 @@ function! s:scan_tags(lines, page_name) abort
 
     " Scan line for tags.  There can be many of them.
     let str = line
-    while 1
-      " Get all matches
-      let tag_groups = []
-      call substitute(str, tag_search_rx, '\=add(tag_groups, submatch(0))', 'g')
-      if tag_groups == []
-        break
-      endif
-      let tagend = matchend(str, tag_search_rx)
-      let str = str[(tagend):]
-      for tag_group in tag_groups
-        for tag in split(tag_group, tag_format.sep)
-          " Create metadata entry
-          let entry = {}
-          let entry.tagname  = tag
-          let entry.lineno   = line_nr
-          if line_nr <= PROXIMITY_LINES_NR && header_line_nr < 0
-            " Tag appeared at the top of the file
-            let entry.link   = a:page_name
-            let entry.description = entry.link
-          elseif line_nr <= (header_line_nr + PROXIMITY_LINES_NR)
-            " Tag appeared right below a header
-            let entry.link   = a:page_name . '#' . current_complete_anchor
-            let entry.description = current_header_description
-          else
-            " Tag stands on its own
-            let entry.link   = a:page_name . '#' . tag
-            let entry.description = entry.link
-          endif
-          call add(entries, entry)
-        endfor
+    " Get all matches
+    let tag_groups = []
+    call substitute(str, tag_search_rx, '\=add(tag_groups, submatch(0))', 'g')
+    if tag_groups == []
+      continue
+    endif
+    for tag_group in tag_groups
+      for tag in split(tag_group, tag_format.sep)
+        " Create metadata entry
+        let entry = {}
+        let entry.tagname  = tag
+        let entry.lineno   = line_nr
+        if line_nr <= PROXIMITY_LINES_NR && header_line_nr < 0
+          " Tag appeared at the top of the file
+          let entry.link   = a:page_name
+          let entry.description = entry.link
+        elseif line_nr <= (header_line_nr + PROXIMITY_LINES_NR)
+          " Tag appeared right below a header
+          let entry.link   = a:page_name . '#' . current_complete_anchor
+          let entry.description = current_header_description
+        else
+          " Tag stands on its own
+          let entry.link   = a:page_name . '#' . tag
+          let entry.description = entry.link
+        endif
+        call add(entries, entry)
       endfor
-    endwhile
+    endfor
 
   endfor " loop over lines
   return entries

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -4003,6 +4003,7 @@ Contributors and their Github usernames in roughly chronological order:
     - nebulaeandstars (@nebulaeandstars)
     - dmitry kim (@jsn)
     - Luke Atkinson (@LukeDAtkinson)
+    - Joe Planisky (@jplanisky)
 
 ==============================================================================
 16. Changelog                                              *vimwiki-changelog*

--- a/test/issue_1326_duplicate_tag_generation.vader
+++ b/test/issue_1326_duplicate_tag_generation.vader
@@ -1,0 +1,47 @@
+# Tests for issue: 1326
+# Multiple discrete tags on one line 
+# cause duplicate entries in .vimwiki_tags
+# For example, this line: 
+#     :tag1:tag2: 
+# gives correct results in .vimwiki_tags when VimwikiRebuildTags is called.
+# This line
+#     :tag3: :tag4:
+# gives duplicate entries for tag4.
+
+Execute (Start with no content or .vimwiki_tags files - Start issue 1326 test):
+  call system("rm $HOME/testwiki/.vimwiki_tags")
+  call system("rm $HOME/testwiki/Test-Tag-issue-1326.wiki")
+
+Do (Create file with tags and rebuild all tags):
+  :edit! $HOME/testwiki/Test-Tag-issue-1326.wiki\<CR>
+  I
+  :discrete1: :discrete2:\<CR>
+  :concat1:concat2:\<CR>
+  \<Esc>
+  :write\<CR>
+  :VimwikiRebuildTags!\<CR>
+
+Execute (Examine .vimwiki_tags file for generated tag entries.):
+  edit $HOME/testwiki/.vimwiki_tags
+  AssertEqual $HOME . '/testwiki/.vimwiki_tags', expand('%')
+  AssertEqual 'default', vimwiki#vars#get_wikilocal('syntax')
+  AssertEqual 0, vimwiki#vars#get_bufferlocal('wiki_nr')
+
+# For each tag, make sure it is found 
+# once and ONLY once in the .vimwiki_tags file.
+  AssertNotEqual 0, search('concat1', 'we'), 'Expected tag "concat1" was not found.'
+  AssertEqual search('concat1', 'we'), search('concat1', 'we'), 'More than 1 instance of tag "concat1" found'
+
+  AssertNotEqual 0, search('concat2', 'we'), 'Expected tag "concat2" was not found.'
+  AssertEqual search('concat2', 'we'), search('concat2', 'we'), 'More than 1 instance of tag "concat2" found'
+
+  AssertNotEqual 0, search('discrete1', 'we'), 'Expected tag "discrete1" was not found.'
+  AssertEqual search('discrete1', 'we'), search('discrete1', 'we'), 'More than 1 instance of tag "discrete1" found'
+
+  AssertNotEqual 0, search('discrete2', 'we'), 'Expected tag "discrete2" was not found.'
+  AssertEqual search('discrete2', 'we'), search('discrete2', 'we'), 'More than 1 instance of tag "discrete2" found'
+    
+Execute (Remove content and tags files - End issue 1326 test):
+  call system("rm $HOME/testmarkdown/.vimwiki_tags")
+  call system("rm $HOME/testmarkdown/Test-Tag-issue-1326.wiki")
+

--- a/test/issue_1326_duplicate_tag_generation.vader
+++ b/test/issue_1326_duplicate_tag_generation.vader
@@ -42,6 +42,6 @@ Execute (Examine .vimwiki_tags file for generated tag entries.):
   AssertEqual search('discrete2', 'we'), search('discrete2', 'we'), 'More than 1 instance of tag "discrete2" found'
     
 Execute (Remove content and tags files - End issue 1326 test):
-  call system("rm $HOME/testmarkdown/.vimwiki_tags")
-  call system("rm $HOME/testmarkdown/Test-Tag-issue-1326.wiki")
+  call system("rm $HOME/testwiki/.vimwiki_tags")
+  call system("rm $HOME/testwiki/Test-Tag-issue-1326.wiki")
 

--- a/test/issue_1326_duplicate_tag_generation.vader
+++ b/test/issue_1326_duplicate_tag_generation.vader
@@ -17,6 +17,7 @@ Do (Create file with tags and rebuild all tags):
   I
   :discrete1: :discrete2:\<CR>
   :concat1:concat2:\<CR>
+  :mixed1:mixed2: :mixed3: :mixed4:\<CR>
   \<Esc>
   :write\<CR>
   :VimwikiRebuildTags!\<CR>
@@ -27,8 +28,13 @@ Execute (Examine .vimwiki_tags file for generated tag entries.):
   AssertEqual 'default', vimwiki#vars#get_wikilocal('syntax')
   AssertEqual 0, vimwiki#vars#get_bufferlocal('wiki_nr')
 
-# For each tag, make sure it is found 
-# once and ONLY once in the .vimwiki_tags file.
+# For each tag, make sure it is found # once and ONLY once in 
+#     the .vimwiki_tags file.
+# The "AssertNotEqual" tests that the tag is present at least once.
+# The "AssertEqual" searches for the tag 2 times and checks that the
+#     line number where it was found is the same both times. 
+#     The 'w' flag tells search to wrap around at the end of the file. 
+#     The 'e' flag makes search position the cursor at the end of the match.
   AssertNotEqual 0, search('concat1', 'we'), 'Expected tag "concat1" was not found.'
   AssertEqual search('concat1', 'we'), search('concat1', 'we'), 'More than 1 instance of tag "concat1" found'
 
@@ -41,6 +47,18 @@ Execute (Examine .vimwiki_tags file for generated tag entries.):
   AssertNotEqual 0, search('discrete2', 'we'), 'Expected tag "discrete2" was not found.'
   AssertEqual search('discrete2', 'we'), search('discrete2', 'we'), 'More than 1 instance of tag "discrete2" found'
     
+  AssertNotEqual 0, search('mixed1', 'we'), 'Expected tag "mixed1" was not found.'
+  AssertEqual search('mixed1', 'we'), search('mixed1', 'we'), 'More than 1 instance of tag "mixed1" found'
+
+  AssertNotEqual 0, search('mixed2', 'we'), 'Expected tag "mixed2" was not found.'
+  AssertEqual search('mixed2', 'we'), search('mixed2', 'we'), 'More than 1 instance of tag "mixed2" found'
+
+  AssertNotEqual 0, search('mixed3', 'we'), 'Expected tag "mixed3" was not found.'
+  AssertEqual search('mixed3', 'we'), search('mixed3', 'we'), 'More than 1 instance of tag "mixed3" found'
+
+  AssertNotEqual 0, search('mixed4', 'we'), 'Expected tag "mixed4" was not found.'
+  AssertEqual search('mixed4', 'we'), search('mixed4', 'we'), 'More than 1 instance of tag "mixed4" found'
+
 Execute (Remove content and tags files - End issue 1326 test):
   call system("rm $HOME/testwiki/.vimwiki_tags")
   call system("rm $HOME/testwiki/Test-Tag-issue-1326.wiki")


### PR DESCRIPTION
Fixes issue #1326 

`VimwikiRebuildTags` was creating duplicate entries in the .vimwiki_tags file if there were multiple discrete tags on a line (e.g. :tag1:  :tag2:).  When multiple tags separated by one or more non-tag-delimiters were present (i.e. multiple `tag_groups`), the `scan_tags` function was unnecessarily processing the groups after the first one multiple times.  This change removes the unneeded `while` loop so each `tag_group` is only processed once. 

Note: when comparing the changes to the `tag.vim` file, it's helpful to ignore whitespace as the code that was in a `while` loop has now been unindented, making it look like the changes were much more extensive than they actually were. 

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
