### PR TITLE
Make auto_tags preserve existing tag section structure

### DIFF
--- a/test/tag_update_existing_heading.vader
+++ b/test/tag_update_existing_heading.vader
@@ -1,0 +1,63 @@
+# Test how vimwiki#tags#generate_tags behaves when updating existing tag link sections
+
+Before (Setup test wiki files):
+  call writefile([":usedtag:", ":othertag:"], expand("~/testmarkdown/Test-Tag-tagged.md"))
+  edit ~/testmarkdown/Test-Tag-links.md
+
+After (Cleanup files):
+  %delete
+  call system("rm $HOME/testmarkdown/.vimwiki_tags")
+  call system("rm $HOME/testmarkdown/Test-Tag-tagged.md")
+  call system("rm $HOME/testmarkdown/Test-Tag-links.md")
+
+
+Do (Create preexisting tag links with unused tag):
+  I
+  # Generated Tags\<CR>
+  \<CR>
+  ## unusedtag\<CR>
+  \<CR>
+  ## usedtag\<CR>
+  \<ESC>
+  :VimwikiRebuildTags!\<CR>
+  :call vimwiki#tags#generate_tags(0)\<CR>
+
+Expect (Keeps unused tag header):
+  # Generated Tags
+
+  ## unusedtag
+
+
+  ## usedtag
+
+  - [Test-Tag-tagged](Test-Tag-tagged)
+
+Do (Create preexisting tag subheadings out of alphabetical order):
+  I
+  # Generated Tags\<CR>
+  \<CR>
+  ## z\<CR>
+  \<CR>
+  ## usedtag\<CR>
+  \<CR>
+  ## a\<CR>
+  \<CR>
+  # Other Stuff
+  \<ESC>
+  :VimwikiRebuildTags!\<CR>
+  :call vimwiki#tags#generate_tags(0)\<CR>
+
+Expect (Existing tag subheading order is preserved):
+  # Generated Tags
+
+  ## z
+
+
+  ## usedtag
+
+  - [Test-Tag-tagged](Test-Tag-tagged)
+
+  ## a
+
+
+  # Other Stuff


### PR DESCRIPTION
Currently, auto_tags will delete sections from "Generated Tags" for tags that aren't used in any pages. This PR makes auto_tags preserve the subsections for unused tags, making auto_tags more usable for tags that are regularly removed (for example a "todo" tag).

Additionally, I made auto_tags preserve the existing order of subsections under "Generated Tags" instead of alphabetizing it.

Steps for submitting a pull request:

somewhat related issue: #724

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
