### PR TITLE
Fix: count ignored when looking up diary frequency

### DIFF
--- a/autoload/vimwiki/diary.vim
+++ b/autoload/vimwiki/diary.vim
@@ -37,8 +37,12 @@ endfunction
 
 function! vimwiki#diary#diary_date_link(...) abort
   " Return: <String> date
-
-  let wiki_nr = vimwiki#vars#get_bufferlocal('wiki_nr')
+  if a:0 > 2
+    " user supply wiki number as 1 indexed, not 0 indexed
+    let wiki_nr = a:3 - 1
+  else
+    let wiki_nr = vimwiki#vars#get_bufferlocal('wiki_nr')
+  endif
   if wiki_nr < 0  " this happens when called outside a wiki buffer
     let wiki_nr = 0
   endif

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -4005,6 +4005,7 @@ Contributors and their Github usernames in roughly chronological order:
     - Julian Prein (@druckdev)
     - Luke Atkinson (@LukeDAtkinson)
     - Joe Planisky (@jplanisky)
+    - Bence Ferdinandy (@ferdinandyb)
 
 
 ==============================================================================
@@ -4025,8 +4026,11 @@ This is somewhat experimental, and will probably be refined over time.
 
 New:~
     * Issue #1279: Fix/Improvement: When re-wrap a long line in a definition
-      by 'gq' it should insert ':: ' at the new line 
-    
+      by 'gq' it should insert ':: ' at the new line
+
+Fixed:~
+    * Issue #1365: Fix: count ignored when looking up diary frequency
+
 
 2023.04.04~
 
@@ -4036,7 +4040,7 @@ Fixed:~
     * PR #1324: Fix pressing escape in VimwikiGoto prompt (rddunphy)
     * Issue #1336: vimwiki#diary#calendar_sign throws an error
       when g:vimwiki_list is not set
- 
+
 2023.04.04~
 
 New:~

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -366,11 +366,11 @@ command! -count=0 VimwikiTabMakeDiaryNote
 
 command! -count=0 VimwikiMakeYesterdayDiaryNote
       \ call vimwiki#diary#make_note(<count>, 0,
-      \ vimwiki#diary#diary_date_link(localtime(), -1))
+      \ vimwiki#diary#diary_date_link(localtime(), -1, <count>))
 
 command! -count=0 VimwikiMakeTomorrowDiaryNote
       \ call vimwiki#diary#make_note(<count>, 0,
-      \ vimwiki#diary#diary_date_link(localtime(), 1))
+      \ vimwiki#diary#diary_date_link(localtime(), 1, <count>))
 
 command! VimwikiDiaryGenerateLinks
       \ call vimwiki#diary#generate_diary_section()
@@ -399,10 +399,10 @@ nnoremap <silent><script> <Plug>VimwikiTabMakeDiaryNote
     \ :<C-U>call vimwiki#diary#make_note(v:count, 1)<CR>
 nnoremap <silent><script> <Plug>VimwikiMakeYesterdayDiaryNote
     \ :<C-U>call vimwiki#diary#make_note(v:count, 0,
-    \ vimwiki#diary#diary_date_link(localtime(), -1))<CR>
+    \ vimwiki#diary#diary_date_link(localtime(), -1, v:count))<CR>
 nnoremap <silent><script> <Plug>VimwikiMakeTomorrowDiaryNote
     \ :<C-U>call vimwiki#diary#make_note(v:count, 0,
-    \ vimwiki#diary#diary_date_link(localtime(), 1))<CR>
+    \ vimwiki#diary#diary_date_link(localtime(), 1, v:count))<CR>
 
 
 " Set default global key mappings


### PR DESCRIPTION
When calling `VimwikiMakeYesterdayDiary` (or `Tomorrow`) the `wiki_nr` is looked up by `vimwiki#diary#diary_date_link` without access to the passed count, which would result in the creation of the file in the correct place, but with the `diary_frequency` of another wiki. Modify `vimwiki#diary#diary_date_link` to take a possible third argument as the `wiki_nr+1` and modify the commands to pass `<count>` as the third argument.

Fixes: #1365

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
