### PR TITLE
docs: describe undocumented key mappings

### DIFF
--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -479,13 +479,13 @@ glp                     Decrease the "done" status.
 gll               n     Increase the level of a list item.
                         Remap command: `<Plug>VimwikiIncreaseLvlSingleItem`
 gLl                     Increase the level of a list item and all child items.
-                        Remap command: `<Plug>VimwikiIncreaseLvlWholeItem`
+ or gLL                 Remap command: `<Plug>VimwikiIncreaseLvlWholeItem`
 
                                                   *vimwiki_glh* *vimwiki_gLh*
 glh               n     Decrease the level of a list item.
                         Remap command: `<Plug>VimwikiDecreaseLvlSingleItem`
 gLh                     Decrease the level of a list item and all child items.
-                        Remap command: `<Plug>VimwikiDecreaseLvlWholeItem`
+ or gLH                 Remap command: `<Plug>VimwikiDecreaseLvlWholeItem`
 
                                                   *vimwiki_glr* *vimwiki_gLr*
 glr               n     Renumber list items if the cursor is on a numbered
@@ -515,6 +515,13 @@ gl-               n     Make a list item out of a normal line or change the
                         Remap command:  `:VimwikiChangeSymbolTo -<CR>`
 gL-                     Change the symbol of the current list to -.
                         Remap command: `:VimwikiChangeSymbolInListTo -<CR>`
+
+                                                  *vimwiki_gl+* *vimwiki_gL+*
+gl+               n     Make a list item out of a normal line or change the
+                        symbol of the current item to +.
+                        Remap command:  `:VimwikiChangeSymbolTo +<CR>`
+gL+                     Change the symbol of the current list to +.
+                        Remap command: `:VimwikiChangeSymbolInListTo +<CR>`
 
                                                   *vimwiki_gl1* *vimwiki_gL1*
 gl1               n     Make a list item out of a normal line or change the


### PR DESCRIPTION
I noticed that the documentation does not include these key mappings.

Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [x] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
