### PR TITLE
Fix tags generation when wiki extension has multiple dots

### DIFF
--- a/autoload/vimwiki/tags.vim
+++ b/autoload/vimwiki/tags.vim
@@ -31,7 +31,8 @@ function! vimwiki#tags#update_tags(full_rebuild, all_files) abort
   let all_files = a:all_files !=? ''
   if !a:full_rebuild
     " Updating for one page (current)
-    let page_name = vimwiki#vars#get_bufferlocal('subdir') . expand('%:t:r')
+    let page_name = vimwiki#vars#get_bufferlocal('subdir') . substitute(expand('%:t'), vimwiki#vars#get_wikilocal('ext', vimwiki#vars#get_bufferlocal('wiki_nr')) . '$' , '', '')
+
     " Collect tags in current file
     let tags = s:scan_tags(getline(1, '$'), page_name)
     " Load metadata file
@@ -50,7 +51,7 @@ function! vimwiki#tags#update_tags(full_rebuild, all_files) abort
     for file in files
       if all_files || getftime(file) >= tags_file_last_modification
         let subdir = vimwiki#base#subdir(wiki_base_dir, file)
-        let page_name = subdir . fnamemodify(file, ':t:r')
+        let page_name = subdir . substitute(file, vimwiki#vars#get_wikilocal('ext', vimwiki#vars#get_bufferlocal('wiki_nr')). '$' , '', '')
         let tags = s:scan_tags(readfile(file), page_name)
         let metadata = s:remove_page_from_tags(metadata, page_name)
         let metadata = s:merge_tags(metadata, page_name, tags)


### PR DESCRIPTION
When using extension containing multiple dots, for example `.wiki.txt`, generated tags would contains a faulty links that ends with piece of the extension, for example `.wiki`, then vimwiki would try to go to a file that ends with `.wiki.wiki.txt` instead.

This patch solves the issue by removing the exact suffix of the extension instead of using the root filename modifier.


Steps for submitting a pull request:

- [x] **ALL** pull requests should be made against the `dev` branch!
- [ ] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
- [ ] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
