### PR TITLE
Conf: Add syntax variable open_link_add_ext to decide if visiting a link must add .md or .wiki extension

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -262,11 +262,20 @@ function! vimwiki#base#resolve_link(link_text, ...) abort
               \ vimwiki#vars#get_wikilocal('ext', link_infos.index)
       endif
     else
-      " append extension iff one not already present or it's not the targeted
+      " append extension if one not already present or it's not the targeted
       " wiki extension - https://github.com/vimwiki/vimwiki/issues/950
       let ext = fnamemodify(link_text, ':e')
       let ext_with_dot = '.' . ext
-      if ext ==? '' || ext_with_dot !=? vimwiki#vars#get_wikilocal('ext', link_infos.index)
+
+      " Check if a .md must be added
+      " See #1271 to modify files with a "."
+      let do_add_ext = ext ==? ''
+      if vimwiki#vars#get_syntaxlocal('open_link_add_ext')
+        let do_add_ext = do_add_ext || ext_with_dot !=? vimwiki#vars#get_wikilocal('ext', link_infos.index)
+      endif
+
+      " Add the dot
+      if do_add_ext
         let link_infos.filename .= vimwiki#vars#get_wikilocal('ext', link_infos.index)
       endif
     endif

--- a/autoload/vimwiki/vars.vim
+++ b/autoload/vimwiki/vars.vim
@@ -851,6 +851,10 @@ function! s:get_common_syntaxlocal() abort
   " HTML comment
   let res.comment_regex = {'type': type(''), 'default': '\%(^\s*%%.*$\|<!--\%([^>]\|\n\)*-->\)'}
 
+  " Opening link with dot in the ref, see #1271 and ref and Brennen comment:
+  " -- https://github.com/vimwiki/vimwiki/issues/1271#issuecomment-1482207680
+  let res.open_link_add_ext = {'type': type(1), 'default': 1}
+
   return res
 endfunction
 


### PR DESCRIPTION
Please see discussion at #1271.

Configure the feature adding extension .md to files at link opening. The new feature (2023) was implemented by Brennen and fixing many other tickets but also openend #1271. So let's just add a configuration variable! https://github.com/vimwiki/vimwiki/commit/d7ec12645a0460a7d200279c52915e6e080e9869

