### PR TITLE
Fix #1412: Markdown Link creation when cursor is on word 2024.01.24 (…

### DIFF
--- a/autoload/vimwiki/markdown_base.vim
+++ b/autoload/vimwiki/markdown_base.vim
@@ -100,7 +100,8 @@ function! s:normalize_link_syntax_n() abort
       let sub = vimwiki#base#normalize_link_in_diary(lnk)
     else
       let sub = vimwiki#base#normalize_link_helper(lnk,
-            \ vimwiki#vars#get_global('rxWord'), '',
+            \ vimwiki#vars#get_global('rxWord'),
+            \ vimwiki#vars#get_global('rxWord'),
             \ vimwiki#vars#get_syntaxlocal('Link1'))
     endif
     call vimwiki#base#replacestr_at_cursor('\V'.lnk, sub)


### PR DESCRIPTION
Issue was: Can't create diary links in Markdown #1412.

It seems good, I'll merge it immediately, I just could push directly to the vimwiki repo not sure why.
