### PR TITLE
Todo quickfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+ifdef VERBOSE
+override VERBOSE := -v
+endif
+
+verbose:
+	echo $(VERBOSE)
+
+test:
+	cd test; ./run_tests.sh $(VERBOSE) -t vader -n vim_7.3.429 || true
+	cd test; ./run_tests.sh $(VERBOSE) -t vader -n vim_8.1.0519 || true
+	# TODO add me when test works on Vim, 9.0
+	# -- Currently I experienced some surprised due to defaults
+	# -- tinmarino 2023-03-10
+	# cd test; run_tests.sh $(VERBOSE) -n v9.0.1396
+	
+	cd test; ./run_tests.sh $(VERBOSE) -t vader -n nvim_0.3.8 || true
+	
+	# Cannot quote as it is expanded from $OPT after quote removal
+	# So I decided to escape the *
+	cd test; ./run_tests.sh $(VERBOSE) -t vader -n vim_7.4.1099 -f '[a-k]*.vader' || true
+	cd test; ./run_tests.sh $(VERBOSE) -t vader -n vim_7.4.1546 -f 'l*.vader' || true
+	cd test; ./run_tests.sh $(VERBOSE) -t vader -n vim_8.0.0027 -f '[m-z]*.vader' || true
+
+.PHONY: test

--- a/autoload/vimwiki/todo.vim
+++ b/autoload/vimwiki/todo.vim
@@ -26,4 +26,17 @@ function! vimwiki#todo#list()
   setlocal nomodifiable
 
   " normal! gg
+  nnoremap <buffer> <C-Space> :call vimwiki#todo#toggle()<CR>
+endfunction
+
+function! vimwiki#todo#toggle()
+  execute ":normal \<C-W>\<CR>"
+  execute ":normal \<C-Space>"
+  execute ":normal y$"
+  wincmd q
+  wincmd p
+  setlocal modifiable
+  execute ":normal ^W\"_Dp"
+  setlocal nomodified
+  setlocal nomodifiable
 endfunction

--- a/autoload/vimwiki/todo.vim
+++ b/autoload/vimwiki/todo.vim
@@ -36,6 +36,7 @@ endfunction
 
 function! vimwiki#todo#toggle()
   execute ":normal \<C-W>\<CR>"
+  execute ":normal zR"
   execute ":normal \<C-Space>"
   execute ":normal y$"
   wincmd q

--- a/autoload/vimwiki/todo.vim
+++ b/autoload/vimwiki/todo.vim
@@ -1,5 +1,9 @@
 function! vimwiki#todo#list()
-  let files = vimwiki#vars#get_wikilocal('path') . vimwiki#vars#get_wikilocal('diary_rel_path') . '*.md'
+  let path = vimwiki#vars#get_wikilocal('path')
+  let rel_path = substitute(path, '^' . getcwd() . '/', '', '')
+  let diary_rel_path = vimwiki#vars#get_wikilocal('diary_rel_path')
+
+  let files = path . diary_rel_path . '*.md'
 
   call setqflist([])
 
@@ -15,7 +19,8 @@ function! vimwiki#todo#list()
 
   for i in range(1, line('$'))
     let line = getline(i)
-    let line = substitute(line, '^\([^\/]*\/\)*', '', '')
+    let line = substitute(line, '^' . rel_path, '', '')
+    let line = substitute(line, '^' . diary_rel_path, 'diary:', '')
     let line = substitute(line, '.md|', '|', '')
     let line = substitute(line, '|\([0-9]\+\) col [0-9-]*|', '|\1|', '')
     let line = substitute(line, '^|| ', '', '')

--- a/autoload/vimwiki/todo.vim
+++ b/autoload/vimwiki/todo.vim
@@ -1,32 +1,38 @@
-function! vimwiki#todo#grep()
-  "let l:path = vimwiki#vars#get_wikilocal('path')
-  let l:diary_files = vimwiki#diary#get_diary_files()
-  "let l:files = vimwiki#base#find_files(-1,0)
+function! vimwiki#todo#list()
+  "let files = vimwiki#base#find_files(-1,0)
+  let files = vimwiki#diary#get_diary_files()
 
   call setqflist([])
 
-  for f in l:diary_files
+  silent call setqflist([{'text': '# In progress'}], 'a')
+  for f in files
+    let d = split(split(f, '/')[-1], '\.')[0]
+    silent call setqflist([{'text': '# ' . d, 'filename': f}], 'a')
+    silent execute 'vimgrepadd /\- \[\.\]/' . f
+  endfor
 
-    silent call setqflist([{'text': '# ' . split(split(f, '/')[-1], '\.')[0], 'filename': f}], 'a')
+  silent call setqflist([{'text': '# To Do'}], 'a')
+  for f in files
+    let d = split(split(f, '/')[-1], '\.')[0]
 
-    silent execute 'vimgrepadd /\- \[ \]/' . f
+    silent call setqflist([{'text': '## ' . d, '\.')[0], 'filename': f}], 'a')
+    silent execute 'vimgrepadd /\- \[\.\]/' . f
   endfor
 
   copen
 
-  set modifiable
+  setlocal modifiable
 
   for i in range(1, line('$'))
     let l:line = getline(i)
     let l:line = substitute(l:line, '^[^|]*', '', '')
     let l:line = substitute(l:line, '^|| ', '', '')
     let l:line = substitute(l:line, '^|[^|]*|', '', '')
-
     call setline(i, l:line)
   endfor
 
-  set nomodified
-  set nomodifiable
+  setlocal nomodified
+  setlocal nomodifiable
 
   normal! gg
 endfunction

--- a/autoload/vimwiki/todo.vim
+++ b/autoload/vimwiki/todo.vim
@@ -1,0 +1,32 @@
+function! vimwiki#todo#grep()
+  "let l:path = vimwiki#vars#get_wikilocal('path')
+  let l:diary_files = vimwiki#diary#get_diary_files()
+  "let l:files = vimwiki#base#find_files(-1,0)
+
+  call setqflist([])
+
+  for f in l:diary_files
+
+    silent call setqflist([{'text': '# ' . split(split(f, '/')[-1], '\.')[0], 'filename': f}], 'a')
+
+    silent execute 'vimgrepadd /\- \[ \]/' . f
+  endfor
+
+  copen
+
+  set modifiable
+
+  for i in range(1, line('$'))
+    let l:line = getline(i)
+    let l:line = substitute(l:line, '^[^|]*', '', '')
+    let l:line = substitute(l:line, '^|| ', '', '')
+    let l:line = substitute(l:line, '^|[^|]*|', '', '')
+
+    call setline(i, l:line)
+  endfor
+
+  set nomodified
+  set nomodifiable
+
+  normal! gg
+endfunction

--- a/autoload/vimwiki/todo.vim
+++ b/autoload/vimwiki/todo.vim
@@ -1,38 +1,29 @@
 function! vimwiki#todo#list()
-  "let files = vimwiki#base#find_files(-1,0)
-  let files = vimwiki#diary#get_diary_files()
+  let files = vimwiki#vars#get_wikilocal('path') . vimwiki#vars#get_wikilocal('diary_rel_path') . '*.md'
 
   call setqflist([])
 
   silent call setqflist([{'text': '# In progress'}], 'a')
-  for f in files
-    let d = split(split(f, '/')[-1], '\.')[0]
-    silent call setqflist([{'text': '# ' . d, 'filename': f}], 'a')
-    silent execute 'vimgrepadd /\- \[\.\]/' . f
-  endfor
+  silent execute 'vimgrepadd /\- \[\.\]/ ' . files
 
   silent call setqflist([{'text': '# To Do'}], 'a')
-  for f in files
-    let d = split(split(f, '/')[-1], '\.')[0]
-
-    silent call setqflist([{'text': '## ' . d, '\.')[0], 'filename': f}], 'a')
-    silent execute 'vimgrepadd /\- \[\.\]/' . f
-  endfor
+  silent execute 'vimgrepadd /\- \[ \]/' . files
 
   copen
 
   setlocal modifiable
 
   for i in range(1, line('$'))
-    let l:line = getline(i)
-    let l:line = substitute(l:line, '^[^|]*', '', '')
-    let l:line = substitute(l:line, '^|| ', '', '')
-    let l:line = substitute(l:line, '^|[^|]*|', '', '')
-    call setline(i, l:line)
+    let line = getline(i)
+    let line = substitute(line, '^\([^\/]*\/\)*', '', '')
+    let line = substitute(line, '.md|', '|', '')
+    let line = substitute(line, '|\([0-9]\+\) col [0-9-]*|', '|\1|', '')
+    let line = substitute(line, '^|| ', '', '')
+    call setline(i, line)
   endfor
 
   setlocal nomodified
   setlocal nomodifiable
 
-  normal! gg
+  " normal! gg
 endfunction

--- a/autoload/vimwiki/todo.vim
+++ b/autoload/vimwiki/todo.vim
@@ -5,13 +5,13 @@ function! vimwiki#todo#list()
 
   let files = path . diary_rel_path . '*.md'
 
-  call setqflist([])
+  :call setqflist([])
 
-  silent call setqflist([{'text': '# In progress'}], 'a')
-  silent execute 'vimgrepadd /\- \[\.\]/ ' . files
+  ;silent call setqflist([{'text': '# In progress'}], 'a')
+  silent execute 'lvimgrep /\- \[\.\]/ ' . files
 
-  silent call setqflist([{'text': '# To Do'}], 'a')
-  silent execute 'vimgrepadd /\- \[ \]/' . files
+  :silent call setqflist([{'text': '# To Do'}], 'a')
+  silent execute 'lvimgrepadd /\- \[ \]/' . files
 
   copen
 

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -380,6 +380,8 @@ command! VimwikiShowVersion call s:get_version()
 command! -nargs=* -complete=customlist,vimwiki#vars#complete
       \ VimwikiVar call vimwiki#vars#cmd(<q-args>)
 
+command! VimwikiTodoGrep
+      \ call vimwiki#todo#grep()
 
 " Declare global maps
 " <Plug> global definitions

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -380,8 +380,8 @@ command! VimwikiShowVersion call s:get_version()
 command! -nargs=* -complete=customlist,vimwiki#vars#complete
       \ VimwikiVar call vimwiki#vars#cmd(<q-args>)
 
-command! VimwikiTodoGrep
-      \ call vimwiki#todo#grep()
+command! VimwikiTodoList
+      \ call vimwiki#todo#list()
 
 " Declare global maps
 " <Plug> global definitions
@@ -405,6 +405,8 @@ nnoremap <silent><script> <Plug>VimwikiMakeYesterdayDiaryNote
 nnoremap <silent><script> <Plug>VimwikiMakeTomorrowDiaryNote
     \ :<C-U>call vimwiki#diary#make_note(v:count, 0,
     \ vimwiki#diary#diary_date_link(localtime(), 1, v:count))<CR>
+nnoremap <silent><script> <Plug>VimwikiTodoGrep
+    \ :<C-U>call vimwiki#todo#grep()<CR>
 
 
 " Set default global key mappings


### PR DESCRIPTION
Steps for submitting a pull request:

- [X]  **ALL** pull requests should be made against the `dev` branch!
- [ ] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
    - This is intended to address the issue of collecting **todo items**, described in #515 (amongst [tips in the wiki](https://vimwiki.github.io/vimwikiwiki/Tips%20and%20Snips.html#Tips%20and%20Snips-Task%20Management-Find%20Incomplete%20Tasks) and discussions here on GitHub and elsewhere online)
- [X] Provide a description of the proposed changes.
    - This will collect all **todo items** from the **diary** and present them in a quickfix buffer, sorted from oldest to newest; allowing the user to toggle the items from the list with `<C-Space>` directly from the list. 
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

Pending/planned before merging:

- [ ] Use **location list** instead of the **quickfix list**
- [ ] Cross check with the [relevant section of the wiki](https://vimwiki.github.io/vimwikiwiki/Tips%20and%20Snips.html#Tips%20and%20Snips-Task%20Management-Find%20Incomplete%20Tasks)
- [ ] Provide mapping (also based on [wiki](https://vimwiki.github.io/vimwikiwiki/Tips%20and%20Snips.html#Tips%20and%20Snips-Task%20Management-Find%20Incomplete%20Tasks))
- [ ] Map `gln` and `glp` in the list - similar to `<C-Space>`
- [ ] Extend logic to tasks from **all pages** (but keep **diary** as default)
- [ ] Handle file name extension and dynamically
- [ ] Handle syntax dynamically for headings
- [ ] Map `[[` and `]]` to jump between _in-progress_ and _not-yet-started_ tasks (also allow jumping between dates?)
- [ ] Handle all list symbols besides `-`
