### PR TITLE
fix issue #1007 ,  email style arrow quote conversion to html error

### DIFF
--- a/autoload/vimwiki/html.vim
+++ b/autoload/vimwiki/html.vim
@@ -987,27 +987,23 @@ function! s:process_tag_arrow_quote(line, arrow_quote) abort
     " Increase arrow_quote
     while line =~# '^' . repeat('\s*&gt;', arrow_quote + 1)
       call add(lines, '<blockquote>')
-      call add(lines, '<p>')
-      let arrow_quote .= 1
+      let arrow_quote += 1
     endwhile
-
-    " Treat & Add line
-    let stripped_line = substitute(a:line, '^\%(\s*&gt;\)\+', '', '')
-    if stripped_line =~# '^\s*$'
-      call add(lines, '</p>')
-      call add(lines, '<p>')
-    endif
-    call add(lines, stripped_line)
-    let processed = 1
-
   " Check if must decrease level
   elseif arrow_quote > 0
-    while line !~# '^' . repeat('\s*&gt;', arrow_quote - 1)
-      call add(lines, '</p>')
+    while line !~# '^' . repeat('\s*&gt;', arrow_quote)
       call add(lines, '</blockquote>')
       let arrow_quote -= 1
     endwhile
   endif
+
+  " Treat & Add line
+  let stripped_line = substitute(a:line, '^\%(\s*&gt;\)\+', '', '')
+  call add(lines, '<p>')
+  call add(lines, stripped_line)
+  call add(lines, '</p>')
+  let processed = 1
+
   return [processed, lines, arrow_quote]
 endfunction
 
@@ -1645,8 +1641,8 @@ function! s:parse_line(line, state) abort
     if processed && len(state.lists)
       call s:close_tag_list(state.lists, lines)
     endif
-    if processed && (state.quote || state.arrow_quote)
-      let state.quote = s:close_tag_precode(state.quote || state.arrow_quote, lines)
+    if processed && state.quote
+      let state.quote = s:close_tag_precode(state.quote, lines)
     endif
     if processed && state.arrow_quote
       let state.arrow_quote = s:close_tag_arrow_quote(state.arrow_quote, lines)


### PR DESCRIPTION
Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

Hi, I've solved #1007 , the email style arrow quote in vimwiki format conversion to html is working fine. Here's the my test.

Here's the code:
```
Test arrow quote:

> single arrow
> single arrow line2
> single arrow line3
>> double arrow line
original text
>> double arrow line2
>>>> quater arrow
>>> tripple arrow line
> Jump to single
>>> Jump back to tripple

>> empty line above
>
> empty line with single arrow above
```
Here's how github display
Test arrow quote:

> single arrow
> single arrow line2
> single arrow line3
>> double arrow line
original text
>> double arrow line2
>>>> quater arrow
>>> tripple arrow line
> Jump to single
>>> Jump back to tripple

>> empty line above
>
> empty line with single arrow above

Here's my test screen shot
![arrow_quote_test](https://github.com/user-attachments/assets/ed273226-90d0-4d1e-b316-5fc86ad700fd)


