### PR TITLE
Fix: use relative path when opening wiki files

### DIFF
--- a/autoload/vimwiki/base.vim
+++ b/autoload/vimwiki/base.vim
@@ -1159,7 +1159,7 @@ function! vimwiki#base#edit_file(command, filename, anchor, ...) abort
   " getpos() directly after this command. Strange.
   if !(a:command =~# ':\?[ed].*' && vimwiki#path#is_equal(a:filename, expand('%:p')))
     try
-      execute a:command fname
+      execute a:command fnameescape(fnamemodify(a:filename, ':.'))
     catch /E37:/
       call vimwiki#u#warn('Can''t leave the current buffer, because it is modified. Hint: Take a look at'
             \ . ''':h g:vimwiki_autowriteall'' to see how to save automatically.')

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -4019,6 +4019,7 @@ Contributors and their Github usernames in roughly chronological order:
     - @jiamingc
     - Alex Claman (@claman)
     - @qadzek
+    - @jpmor
 
 
 ==============================================================================
@@ -4036,6 +4037,12 @@ are accepted, they will merge directly to dev, which is now the main branch.
 master is retained as a legacy mirror of the dev branch.
 
 This is somewhat experimental, and will probably be refined over time.
+
+
+2026.03.11~
+
+Fix:~
+    * PR #1450: Use relative filename modifier when opening wiki files
 
 
 2024.01.24~

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -11,7 +11,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release:
-let g:vimwiki_version = '2024.01.24'
+let g:vimwiki_version = '2026.03.11'
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')

--- a/test/tag.vader
+++ b/test/tag.vader
@@ -257,7 +257,7 @@ Expect (Correctly formatted tags file):
   !_TAG_PROGRAM_AUTHOR	Vimwiki
   !_TAG_PROGRAM_NAME	Vimwiki Tags
   !_TAG_PROGRAM_URL	https://github.com/vimwiki/vimwiki
-  !_TAG_PROGRAM_VERSION	2024.01.24
+  !_TAG_PROGRAM_VERSION	2026.03.11
   second-tag	Test-Tag.md	13;"	vimwiki:Test-Tag\tTest-Tag#second-tag\tTest-Tag#second-tag
   test-tag	Test-Tag.md	5;"	vimwiki:Test-Tag\tTest-Tag#a-header\tA header
   top-tag	Test-Tag.md	1;"	vimwiki:Test-Tag\tTest-Tag\tTest-Tag


### PR DESCRIPTION
vimwiki constructs absolute paths internally (by concatenating `path + key + ext`
from `get_wikilocal`), so `edit_file` always receives an absolute path. This means
vimwiki buffers always display their full path in the statusline, even when working
inside the wiki directory — unlike standard Vim behavior when opening files directly.

This fix uses the `:.` filename modifier to reduce the path to be relative to the
current directory when possible, falling back to the absolute path otherwise.

The key ordering: `fnamemodify` is applied to the raw `a:filename` before
`fnameescape`, since `fnamemodify` expects a literal path. Applying it to the
already-escaped `fname` would silently fail for filenames with spaces or special
characters.

---

- [x] **ALL** pull requests should be made against the `dev` branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable, including the Changelog and Contributors sections.