### PR TITLE
WIP: update tested versions of vim

### DIFF
--- a/.github/workflows/test-vader-action.yml
+++ b/.github/workflows/test-vader-action.yml
@@ -64,20 +64,24 @@ jobs:
         opt: [
           # "vint",
 
-          "-n vim_7.3.429",
-          "-n vim_8.1.0519",
+          "-n vim_7.4.2367",
+          "-n vim_8.2.5172",
+          "-n vim_9.0.2190",
+          "-n vim_9.1.0786",
+
           # TODO add me when test works on Vim, 9.0
           # -- Currently I experienced some surprised due to defaults
           # -- tinmarino 2023-03-10
           # "-n v9.0.1396",
 
-          "-n nvim_0.3.8",
+          # This build isn't currently working with vim-testbed:
+          # "-n nvim_0.10.2",
 
           # Cannot quote as it is expanded from $OPT after quote removal
           # So I decided to escape the *
-          "-n vim_7.4.1099 -f '[a-k]*.vader'",
-          "-n vim_7.4.1546 -f 'l*.vader'",
-          "-n vim_8.0.0027 -f '[m-z]*.vader'",
+          # "-n vim_7.4.1099 -f '[a-k]*.vader'",
+          # "-n vim_7.4.1546 -f 'l*.vader'",
+          # "-n vim_8.0.0027 -f '[m-z]*.vader'",
         ]
     steps:
       # This action is required to fetch the code to test

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ RUN git checkout de8a976f1eae2c2b680604205c3e8b5c8882493c
 # Build vim and neovim versions we want to test
 WORKDIR /
 
-RUN install_vim -tag v7.3.429 -name vim_7.3.429 -build
-RUN install_vim -tag v7.4.1099 -name vim_7.4.1099 -build
-RUN install_vim -tag v7.4.1546 -name vim_7.4.1546 -build
-RUN install_vim -tag v8.0.0027 -name vim_8.0.0027 -build
-RUN install_vim -tag v8.1.0519 -name vim_8.1.0519 -build
-RUN install_vim -tag v9.0.1396 -name v9.0.1396 -build
-RUN install_vim -tag neovim:v0.3.8 -name nvim_0.3.8 -build
+RUN install_vim -tag v7.4.2367 -name vim_7.4.2367 -build
+RUN install_vim -tag v8.2.5172 -name vim_8.2.5172 -build
+RUN install_vim -tag v9.0.2190 -name v9.0.2190 -build
+RUN install_vim -tag v9.1.0786 -name v9.1.0786 -build
+
+# TODO: This one doesn't build - vim-testbed seems way out of date:
+# TODO: tag neovim:v0.10.2, name nvim_0.10.2
+# (Format as install_vim instances above.)


### PR DESCRIPTION
Adjusting the list per discussion on #1445:

    nvim 0.10.2
    vim 7.4.2367
    vim 8.2.5172
    vim 9.0.2190
    vim 9.1.0786

Currently nvim 0.10.2 fails to build.  Seems like vim-testbed is fairly out-of-date.  I filed this re: project status:

https://github.com/Vimjas/vim-testbed/issues/91