### PR TITLE
Update CONTRIBUTING.md for correct in-page link rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,11 @@ Issues can be filed at https://github.com/vimwiki/vimwiki/issues/
 
 As of v2022.12.02, VimWiki has adopted a rolling release model, along with
 [calendar versioning][calver].  A release should be
-[prepared][#preparing-a-release] for every change or set of changes which merge
+[prepared][prep] for every change or set of changes which merge
 to `dev`.
 
 [calver]: https://calver.org/
+[prep]: #preparing-a-release
 
 There are two permanent branches:
     1. `dev`: This is the default branch, and where changes are released. Tasks


### PR DESCRIPTION
Fix "preparing-new-release" link to render correctly

Steps for submitting a pull request:

- [ ] **ALL** pull requests should be made against the `dev` branch!
- [ ] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [ ] Reference any related issues.
- [ ] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [ ] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
