### PR TITLE
Restore the previous quickfix list after markdown reflink scan

### DIFF
--- a/autoload/vimwiki/markdown_base.vim
+++ b/autoload/vimwiki/markdown_base.vim
@@ -12,6 +12,9 @@ endfunction
 
 
 function! vimwiki#markdown_base#scan_reflinks() abort
+  " get id of the current quickfix list (we are about to override it with vimgrep)
+  let qfixlist_id = getqflist({"id": 0}).id
+
   let mkd_refs = {}
   " construct list of references using vimgrep
   try
@@ -30,6 +33,12 @@ function! vimwiki#markdown_base#scan_reflinks() abort
     endif
   endfor
   call vimwiki#vars#set_bufferlocal('markdown_refs', mkd_refs)
+
+  " if there was a previous quickfix list, restore it
+  if qfixlist_id
+    silent colder
+  endif
+
   return mkd_refs
 endfunction
 

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -4019,6 +4019,7 @@ Contributors and their Github usernames in roughly chronological order:
     - @jiamingc
     - Alex Claman (@claman)
     - @qadzek
+    - Filip Úradník (@furadnik)
 
 
 ==============================================================================
@@ -4036,6 +4037,12 @@ are accepted, they will merge directly to dev, which is now the main branch.
 master is retained as a legacy mirror of the dev branch.
 
 This is somewhat experimental, and will probably be refined over time.
+
+
+2025.09.17
+
+Fixed:~
+    * Issue #1475: Restore the previous quickfix list after markdown reflink scan
 
 
 2024.01.24~

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -11,7 +11,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release:
-let g:vimwiki_version = '2024.01.24'
+let g:vimwiki_version = '2025.09.17'
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')

--- a/test/tag.vader
+++ b/test/tag.vader
@@ -257,7 +257,7 @@ Expect (Correctly formatted tags file):
   !_TAG_PROGRAM_AUTHOR	Vimwiki
   !_TAG_PROGRAM_NAME	Vimwiki Tags
   !_TAG_PROGRAM_URL	https://github.com/vimwiki/vimwiki
-  !_TAG_PROGRAM_VERSION	2024.01.24
+  !_TAG_PROGRAM_VERSION	2025.09.17
   second-tag	Test-Tag.md	13;"	vimwiki:Test-Tag\tTest-Tag#second-tag\tTest-Tag#second-tag
   test-tag	Test-Tag.md	5;"	vimwiki:Test-Tag\tTest-Tag#a-header\tA header
   top-tag	Test-Tag.md	1;"	vimwiki:Test-Tag\tTest-Tag\tTest-Tag


### PR DESCRIPTION
Fixes issue https://github.com/vimwiki/vimwiki/issues/1475.

Currently, with Markdown syntax enabled, the first time a link is entered in a buffer, `vimwiki#markdown_base#scan_reflinks` is called, which uses `vimgrep` to find Markdown reflinks.
This overwrites the current quickfixlist.

I added functionality to restore the previous quickfixlist (if any) after it's done.

Steps for submitting a pull request:

- [x] ALL pull requests should be made against the dev branch!
- [x] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [x] Reference any related issues.
- [x] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in doc/vimwiki.txt if applicable, including the Changelog and Contributors sections.
