### PR TITLE
Fix: check for utilization of legacy regexpengine

### DIFF
--- a/autoload/vimwiki/u.vim
+++ b/autoload/vimwiki/u.vim
@@ -283,7 +283,7 @@ function! vimwiki#u#get_punctuation_regex() abort
   " From: https://gist.github.com/asabaylus/3071099#gistcomment-2563127
   " Faster
   " Unused now
-  if v:version <= 703
+  if v:version <= 703 || &regexpengine == 1
     " Retrocompatibility: Get invalid range for vim 7.03
     return '[^0-9a-zA-Z_ \-]'
   else

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -4019,6 +4019,7 @@ Contributors and their Github usernames in roughly chronological order:
     - @jiamingc
     - Alex Claman (@claman)
     - @qadzek
+    - Ben Winston (@winsbe01)
 
 
 ==============================================================================
@@ -4037,6 +4038,11 @@ master is retained as a legacy mirror of the dev branch.
 
 This is somewhat experimental, and will probably be refined over time.
 
+2025.10.26
+
+New:
+    * PR #1479: Fix: check for and handle legacy regexpengine (Issues #1002
+      and #1386)
 
 2024.01.24~
 

--- a/plugin/vimwiki.vim
+++ b/plugin/vimwiki.vim
@@ -11,7 +11,7 @@ endif
 let g:loaded_vimwiki = 1
 
 " Set to version number for release:
-let g:vimwiki_version = '2024.01.24'
+let g:vimwiki_version = '2025.10.26'
 
 " Get the directory the script is installed in
 let s:plugin_dir = expand('<sfile>:p:h:h')

--- a/test/tag.vader
+++ b/test/tag.vader
@@ -257,7 +257,7 @@ Expect (Correctly formatted tags file):
   !_TAG_PROGRAM_AUTHOR	Vimwiki
   !_TAG_PROGRAM_NAME	Vimwiki Tags
   !_TAG_PROGRAM_URL	https://github.com/vimwiki/vimwiki
-  !_TAG_PROGRAM_VERSION	2024.01.24
+  !_TAG_PROGRAM_VERSION	2025.10.26
   second-tag	Test-Tag.md	13;"	vimwiki:Test-Tag\tTest-Tag#second-tag\tTest-Tag#second-tag
   test-tag	Test-Tag.md	5;"	vimwiki:Test-Tag\tTest-Tag#a-header\tA header
   top-tag	Test-Tag.md	1;"	vimwiki:Test-Tag\tTest-Tag\tTest-Tag


### PR DESCRIPTION
Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [x] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.

This fixes a bug where vimwiki was throwing an `E945: Range too large in character class` when trying to follow a link to a header anchor in Markdown (or, theoretically, anywhere that tries to normalize an anchor). The root of the problem seems to be the `get_punctuation_regex()`, which for newer versions of vim (>7.03) includes the CJK Unified Ideographs unicode block (u4300-u9fff). Starting with vim 7.04, a new regular expression engine is available in vim, which allows for wider ranges of characters than the original one (only 256). The check in this function assumes that the user either has the new engine enabled ( `set regexpengine=2`), or has the "pick for me at runtime based on my regex" option enabled (`set regexpengine=0`). This error arises specifically when the version of vim is 7.04+ and the option is `set regexpengine=1`.

FWIW, I discovered this problem on a Mac running vim 9.x (can't remember the minor at the moment), and it seems like `set regexpengine=1` may be the default on the version of vim that is shipped with the Mac. I say this because I have never manually set this option (I didn't even know it was a thing until digging in here), my vimrc is smallish (40 lines with spaces and comments) and I share it between Mac and Linux (I don't have this problem on Linux unless I manually change the `regexpengine`), and I have no other vim plugins installed besides vimwiki.

This may be the root cause behind issues #1002 and/or #1386.