### PR TITLE
Fix: VimwikiRebuildTags doesn't always work #795

### DIFF
--- a/autoload/vimwiki/tags.vim
+++ b/autoload/vimwiki/tags.vim
@@ -47,6 +47,13 @@ function! vimwiki#tags#update_tags(full_rebuild, all_files) abort
     let wiki_base_dir = vimwiki#vars#get_wikilocal('path')
     let tags_file_last_modification = getftime(vimwiki#tags#metadata_file_path())
     let metadata = s:load_tags_metadata()
+    " Remove stale entries for files no longer on disk
+    let l:ext = vimwiki#vars#get_wikilocal('ext')
+    for pagename in keys(metadata)
+      if !filereadable(wiki_base_dir . pagename . l:ext)
+        call remove(metadata, pagename)
+      endif
+    endfor
     for file in files
       if all_files || getftime(file) >= tags_file_last_modification
         let subdir = vimwiki#base#subdir(wiki_base_dir, file)

--- a/doc/vimwiki.txt
+++ b/doc/vimwiki.txt
@@ -980,6 +980,7 @@ Vimwiki file.
 *:VimwikiRebuildTags*
     Rebuilds the tags metadata file for all wiki files newer than the metadata
     file.
+    Stale entries for files that have been deleted or moved are removed automatically.  
     Necessary for all tags related commands: |vimwiki-syntax-tags|.
 
     :VimwikiRebuildTags! does the same for all files.
@@ -4019,6 +4020,7 @@ Contributors and their Github usernames in roughly chronological order:
     - @jiamingc
     - Alex Claman (@claman)
     - @qadzek
+    - Nathan Giard (@giardn)
 
 
 ==============================================================================
@@ -4036,6 +4038,13 @@ are accepted, they will merge directly to dev, which is now the main branch.
 master is retained as a legacy mirror of the dev branch.
 
 This is somewhat experimental, and will probably be refined over time.
+
+
+2026.04.08~
+
+Fixed:~
+    * Issue #795: VimwikiRebuildTags now removes stale entries for files
+      that have been deleted or moved
 
 
 2024.01.24~


### PR DESCRIPTION
Fix: VimwikiRebuildTags doesn't always work #795

Steps for submitting a pull request:

- [X] **ALL** pull requests should be made against the `dev` branch!
- [X] Take a look at [CONTRIBUTING.MD](https://github.com/vimwiki/vimwiki/blob/dev/CONTRIBUTING.md)
- [X] Reference any related issues.
- [X] Provide a description of the proposed changes.
- [ ] PRs must pass Vint tests and add new Vader tests as applicable.
- [X] Make sure to update the documentation in `doc/vimwiki.txt` if applicable,
      including the Changelog and Contributors sections.
      

Proposed change:

Added the following after line 49:

" Remove stale entries for files no longer on disk
    let l:ext = vimwiki#vars#get_wikilocal('ext')
    for pagename in keys(metadata)
      if !filereadable(wiki_base_dir . pagename . l:ext)
        call remove(metadata, pagename)
      endif
    endfor
    
    
This removes entries only for files that no longer exist on disk. The  getftime optimization is kept — unchanged files are still skipped and their entries reused. Covers deleted files, moved files, and renamed files.

